### PR TITLE
Fix travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,25 @@ os:
 - osx
 install:
 - rustup target add wasm32-unknown-unknown
+- | # download cargo web
+    cargo_web_release=$(curl -L -s -H 'Accept: application/json' \
+        https://github.com/koute/cargo-web/releases/latest)
+    cargo_web_version=$(echo $cargo_web_release \
+        | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+    if [ "$(uname -s)" == "Darwin" ]; then
+      cargo_web_host_triple="x86_64-apple-darwin"
+    else
+      cargo_web_host_triple="x86_64-unknown-linux-gnu"
+    fi
+    cargo_web_url_prefix="https://github.com/koute/cargo-web/releases/download"
+    cargo_web_url="$cargo_web_url_prefix/$cargo_web_version/cargo-web-$cargo_web_host_triple.gz"
+
+    echo "Downloading cargo-web from: $cargo_web_url"
+    curl -L "$cargo_web_url" | gzip -d > cargo-web
+    chmod +x cargo-web
+
+    mkdir -p ~/.cargo/bin
+    mv cargo-web ~/.cargo/bin
 script:
 - (cd cargo-screeps && cargo build --verbose)
 - (cd cargo-screeps && cargo test --verbose)


### PR DESCRIPTION
This reverts the part of #183 which removed downloading cargo-web from the travis configuration. While we don't need it for cargo-screeps anymore, it's definitely useful to easily download the binary for use in screeps-game-api testing.