### PR TITLE
Move 'pub mod x;' outside of game_map_access! macro

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -17,34 +17,49 @@ pub mod map;
 pub mod market;
 pub mod shards;
 
-game_map_access! {
-    /// See [http://docs.screeps.com/api/#Game.constructionSites]
-    ///
-    /// [http://docs.screeps.com/api/#Game.constructionSites]: http://docs.screeps.com/api/#Game.constructionSites
-    (construction_sites, objects::ConstructionSite, Game.constructionSites),
-    /// See [http://docs.screeps.com/api/#Game.creeps]
-    ///
-    /// [http://docs.screeps.com/api/#Game.creeps]: http://docs.screeps.com/api/#Game.creeps
-    (creeps, objects::Creep, Game.creeps),
-    /// See [http://docs.screeps.com/api/#Game.flags]
-    ///
-    /// [http://docs.screeps.com/api/#Game.flags]: http://docs.screeps.com/api/#Game.flags
-    (flags, objects::Flag, Game.flags),
-    // TODO: See [http://docs.screeps.com/api/#Game.resources]
-    ///
-    /// [http://docs.screeps.com/api/#Game.resources]: http://docs.screeps.com/api/#Game.resources
-    /// See [http://docs.screeps.com/api/#Game.rooms]
-    ///
-    /// [http://docs.screeps.com/api/#Game.rooms]: http://docs.screeps.com/api/#Game.rooms
-    (rooms, objects::Room, Game.rooms),
-    /// See [http://docs.screeps.com/api/#Game.spawns]
-    ///
-    /// [http://docs.screeps.com/api/#Game.spawns]: http://docs.screeps.com/api/#Game.spawns
-    (spawns, objects::StructureSpawn, Game.spawns),
-    /// See [http://docs.screeps.com/api/#Game.structures]
-    ///
-    /// [http://docs.screeps.com/api/#Game.structures]: http://docs.screeps.com/api/#Game.structures
-    (structures, objects::Structure, Game.structures)
+/// See [http://docs.screeps.com/api/#Game.constructionSites]
+///
+/// [http://docs.screeps.com/api/#Game.constructionSites]: http://docs.screeps.com/api/#Game.constructionSites
+pub mod construction_sites {
+    game_map_access!(objects::ConstructionSite, Game.constructionSites);
+}
+
+/// See [http://docs.screeps.com/api/#Game.creeps]
+///
+/// [http://docs.screeps.com/api/#Game.creeps]: http://docs.screeps.com/api/#Game.creeps
+pub mod creeps {
+    game_map_access!(objects::Creep, Game.creeps);
+}
+
+/// See [http://docs.screeps.com/api/#Game.flags]
+///
+/// [http://docs.screeps.com/api/#Game.flags]: http://docs.screeps.com/api/#Game.flags
+pub mod flags {
+    game_map_access!(objects::Flag, Game.flags);
+}
+
+// TODO: See [http://docs.screeps.com/api/#Game.resources]
+///
+/// [http://docs.screeps.com/api/#Game.resources]: http://docs.screeps.com/api/#Game.resources
+/// See [http://docs.screeps.com/api/#Game.rooms]
+///
+/// [http://docs.screeps.com/api/#Game.rooms]: http://docs.screeps.com/api/#Game.rooms
+pub mod rooms {
+    game_map_access!(objects::Room, Game.rooms);
+}
+
+/// See [http://docs.screeps.com/api/#Game.spawns]
+///
+/// [http://docs.screeps.com/api/#Game.spawns]: http://docs.screeps.com/api/#Game.spawns
+pub mod spawns {
+    game_map_access!(objects::StructureSpawn, Game.spawns);
+}
+
+/// See [http://docs.screeps.com/api/#Game.structures]
+///
+/// [http://docs.screeps.com/api/#Game.structures]: http://docs.screeps.com/api/#Game.structures
+pub mod structures {
+    game_map_access!(objects::Structure, Game.structures);
 }
 
 /// See [http://docs.screeps.com/api/#Game.time]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -434,50 +434,36 @@ macro_rules! typesafe_look_constants {
 /// collection, the `values` as `rust_object_accessedX` and a single object
 /// via the `get` function.
 macro_rules! game_map_access {
-    (
-        $(
-            $(
-                    #[$attr:meta]
-            )*
-            ($mod_name:ident, $type:path, $js_inner:expr) $(,)*
-        ),* $(,)*
-    ) => {
-        $(
-            $(
-                    #[$attr]
-            )*
-            pub mod $mod_name {
-                use std::{collections::HashMap};
+    ($type:path, $js_inner:expr $(,)?) => {
+        use std::{collections::HashMap};
 
-                use crate::objects;
-                use crate::macros::*;
+        use crate::objects;
+        use crate::macros::*;
 
-                calculated_doc! {
-                    #[doc = concat!("Retrieve the full `HashMap<String, ",
-                                    stringify!($type),
-                                    ">`.")
-                    ]
-                    pub fn hashmap() -> HashMap<String, $type> {
-                        js_unwrap!($js_inner)
-                    }
-                }
-
-                /// Retrieve the string keys of this object.
-                pub fn keys() -> Vec<String> {
-                    js_unwrap!(Object.keys($js_inner))
-                }
-
-                /// Retrieve all values in this object.
-                pub fn values() -> Vec<$type> {
-                    js_unwrap_ref!(Object.values($js_inner))
-                }
-
-                /// Retrieve a specific value by key.
-                pub fn get(name: &str) -> Option<$type> {
-                    js_unwrap_ref!($js_inner[@{name}])
-                }
+        calculated_doc! {
+            #[doc = concat!("Retrieve the full `HashMap<String, ",
+                            stringify!($type),
+                            ">`.")
+            ]
+            pub fn hashmap() -> HashMap<String, $type> {
+                js_unwrap!($js_inner)
             }
-        )*
+        }
+
+        /// Retrieve the string keys of this object.
+        pub fn keys() -> Vec<String> {
+            js_unwrap!(Object.keys($js_inner))
+        }
+
+        /// Retrieve all values in this object.
+        pub fn values() -> Vec<$type> {
+            js_unwrap_ref!(Object.values($js_inner))
+        }
+
+        /// Retrieve a specific value by key.
+        pub fn get(name: &str) -> Option<$type> {
+            js_unwrap_ref!($js_inner[@{name}])
+        }
     };
 }
 


### PR DESCRIPTION
This moves the documentation and `pub mod x;` outside of  `game_map_access!`, so it only generates function names.

My main reason for doing this would be to work around https://github.com/intellij-rust/intellij-rust/issues/3710, where IntelliJ-Rust doesn't / can't figure out macros which create `pub mod` statements. I don't personally use IntelliJ, but it is an annoyance for some people who do. It doesn't seem like they'll be fixing that bug anytime soon, and it's a fairly simple workaround.

I don't think this should be a large change - and it shouldn't be _too_ more more code to maintain.