### PR TITLE
Make Step fields publicly accessible

### DIFF
--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -481,11 +481,11 @@ where
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Step {
-    x: u32,
-    y: u32,
-    dx: i32,
-    dy: i32,
-    direction: Direction,
+    pub x: u32,
+    pub y: u32,
+    pub dx: i32,
+    pub dy: i32,
+    pub direction: Direction,
 }
 
 js_deserializable! {Step}


### PR DESCRIPTION
I don't believe there's currently a way to read the `x/y/dx/dy` values, which might be useful.