### PR TITLE
Add new APIs from 2018-12-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Unreleased
   repository
 - Misc. documentation improvements.
 - Add `game::cpu::halt` binding for [`Game.cpu.halt`](https://docs.screeps.com/api/#Game.halt)
-- Add `Creep::pull` binding for [`Creep.pull`](https://docs.screeps.com/api/#Creep.pull)
+  (#210)
+- Add `Creep::pull` binding for [`Creep.pull`](https://docs.screeps.com/api/#Creep.pull) (#210)
 
 [pos-doc]: https://docs.rs/screeps-game-api/0.6.0/screeps/local/struct.Position.html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Unreleased
   repository
 - Misc. documentation improvements.
 - Add `game::cpu::halt` binding for [`Game.cpu.halt`](https://docs.screeps.com/api/#Game.halt)
+- Add `Creep::pull` binding for [`Creep.pull`](https://docs.screeps.com/api/#Creep.pull)
 
 [pos-doc]: https://docs.rs/screeps-game-api/0.6.0/screeps/local/struct.Position.html
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Unreleased
 - Split [cargo-screeps](https://github.com/rustyscreeps/cargo-screeps/) out into a separate
   repository
 - Misc. documentation improvements.
+- Add `game::cpu::halt` binding for [`Game.cpu.halt`](https://docs.screeps.com/api/#Game.halt)
 
 [pos-doc]: https://docs.rs/screeps-game-api/0.6.0/screeps/local/struct.Position.html
 

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -85,3 +85,12 @@ pub fn get_used() -> f64 {
 pub fn set_shard_limits(limits: collections::HashMap<String, f64>) -> ReturnCode {
     js_unwrap!(Game.cpu.setShardLimits(@{limits}))
 }
+
+/// Reset your runtime environment and wipe all data in heap memory.
+///
+/// See [Game.cpu.halt()](https://docs.screeps.com/api/#Game.halt).
+pub fn halt() {
+    js! {
+        Game.cpu.halt();
+    }
+}

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -307,6 +307,7 @@ creep_simple_concrete_action! {
     (harvest(Source) -> harvest),
     (heal(Creep) -> heal),
     (pickup(Resource) -> pickup),
+    (pull(Creep) -> pull),
     (ranged_heal(Creep) -> rangedHeal),
     (reserve_controller(StructureController) -> reserveController),
     (upgrade_controller(StructureController) -> upgradeController),


### PR DESCRIPTION
I don't _think_ there's anything we need to do in the APIs to represent boosting spawning creeps being disallowed, so I think this should close #127.

Just adds `game::cpu::halt` and `Creep::pull`.