### PR TITLE
Fix up OrderType & use it in other struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Unreleased
   - An alias `type RoomPosition = Position;` has been added to reflect the JS API
 - Make `StructureSpawn::spawning` an `Option<Spawning>` to reflect reality
 - Fix prices returned from `game::market` APIs being integers rather than floats (breaking) (#179)
+- Use `OrderType` rather than `String` for `order_type` fields of `TransactionOrder`, `Order` and
+  `MyOrder`. (breaking) (#213)
 - Work around bug where IntelliJ-Rust didn't understand `screeps::game::*` modules created by a
   macro, even with experimental engine enabled (#197)
 - `OwnedStructureProperties`'s `my` method now correctly handles the value being undefined.
@@ -24,6 +26,8 @@ Unreleased
 - Collections provided by `Game` now implement the `hashmap` function to retrieve both keys
   and values at once. (#194)
 - Implement `Clone` for `Structure`
+- Update `screeps::game::market::OrderType` derives to match other constants changed in the
+  constants overhaul last update (#213)
 - Split [cargo-screeps](https://github.com/rustyscreeps/cargo-screeps/) out into a separate
   repository
 - Misc. documentation improvements.

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -67,8 +67,8 @@ js_deserializable!(Player);
 #[derive(Deserialize, Debug)]
 pub struct TransactionOrder {
     id: String,
-    #[serde(rename = "type")]
-    order_type: String,
+    #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
+    order_type: OrderType,
     price: f64,
 }
 js_deserializable!(TransactionOrder);
@@ -94,8 +94,8 @@ js_deserializable!(Transaction);
 pub struct Order {
     id: String,
     created: u32,
-    #[serde(rename = "type")]
-    order_type: String,
+    #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
+    order_type: OrderType,
     resource_type: String,
     room_name: String,
     amount: u32,
@@ -110,8 +110,8 @@ pub struct MyOrder {
     id: String,
     created: u32,
     active: bool,
-    #[serde(rename = "type")]
-    order_type: String,
+    #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
+    order_type: OrderType,
     resource_type: String,
     room_name: String,
     amount: u32,


### PR DESCRIPTION
Fixes #52.

This also applies the changes from the constants overhaul to `OrderType` - the utility method added to all the integer-based string constants helps a lot with using `OrderType`-typed fields.

This will still transfer a string as part of the deserialization, but that shouldn't be _too bad_.