### PR TITLE
Make Bodypart fields public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Unreleased
 - `StructurePortal` no longer implements `OwnedStructure` and `Attackable`. (#190)
 - Collections provided by `Game` now implement the `hashmap` function to retrieve both keys
   and values at once. (#194)
+- Allow accessing fields of the `Bodypart` struct. (#215)
 - Implement `Clone` for `Structure`
 - Split [cargo-screeps](https://github.com/rustyscreeps/cargo-screeps/) out into a separate
   repository

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -37,7 +37,12 @@ impl Creep {
             let part: Part = js_unwrap!(__part_str_to_num(@{self.as_ref()}.body[@{i}].type));
             let hits: u32 = js_unwrap!(@{self.as_ref()}.body[@{i}].hits);
 
-            body_parts.push(Bodypart { boost, part, hits });
+            body_parts.push(Bodypart {
+                boost,
+                part,
+                hits,
+                _non_exhaustive: (),
+            });
         }
         body_parts
     }
@@ -276,9 +281,10 @@ impl Creep {
 
 #[derive(Clone, Debug)]
 pub struct Bodypart {
-    boost: Option<ResourceType>,
-    part: Part,
-    hits: u32,
+    pub boost: Option<ResourceType>,
+    pub part: Part,
+    pub hits: u32,
+    _non_exhaustive: (),
 }
 
 simple_accessors! {


### PR DESCRIPTION
Fixes #214.

I'm not 100% sure if there was a reason we had them private to begin with? If there was, then maybe this could be addressed with accessor methods instead.

I've added a `_non_exhaustive` field to make it a non-breaking change to add new properties (not that that matters _that much_).