### PR TITLE
Last `LocalRoomName` changes: use in all APIs, rename to RoomName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Unreleased
     `Position`, and will only have to upload a single `u32` to JavaScript to call it.
   - `Position` methods dealing with math between positions are now implemented in pure-Rust code
   - An alias `type RoomPosition = Position;` has been added to reflect the JS API
+- Rename `LocalRoomName` to `RoomName`, use in APIs, and optimize representation:
+  - It is now a 16-bit sized structure, one very efficient to get from a `Position` (#209)
+  - It's now used in all API bindings referencing room names (#217)
 - Make `StructureSpawn::spawning` an `Option<Spawning>` to reflect reality
 - Fix prices returned from `game::market` APIs being integers rather than floats (breaking) (#179)
 - Work around bug where IntelliJ-Rust didn't understand `screeps::game::*` modules created by a

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -125,7 +125,7 @@ js_deserializable!(ReturnCode);
 /// ```no_run
 /// use screeps::{find, game, Room};
 ///
-/// let room: Room = game::rooms::get("E23S55").unwrap();
+/// let room: Room = game::rooms::get("E23S55".parse().unwrap()).unwrap();
 ///
 /// let creeps = room.find(find::CREEPS);
 /// # let _ = creeps;

--- a/src/game.rs
+++ b/src/game.rs
@@ -45,7 +45,29 @@ pub mod flags {
 ///
 /// [http://docs.screeps.com/api/#Game.rooms]: http://docs.screeps.com/api/#Game.rooms
 pub mod rooms {
-    game_map_access!(objects::Room, Game.rooms);
+    use std::collections::HashMap;
+
+    use crate::{local::LocalRoomName, macros::*, objects::Room};
+
+    /// Retrieve the full `HashMap<LocalRoomName, Room>`.
+    pub fn hashmap() -> HashMap<String, Room> {
+        js_unwrap!($js_inner)
+    }
+
+    /// Retrieve the string keys of this object.
+    pub fn keys() -> Vec<String> {
+        js_unwrap!(Object.keys(Game.rooms))
+    }
+
+    /// Retrieve all values in this object.
+    pub fn values() -> Vec<Room> {
+        js_unwrap_ref!(Object.values(Game.rooms))
+    }
+
+    /// Retrieve a specific value by key.
+    pub fn get(name: LocalRoomName) -> Option<Room> {
+        js_unwrap_ref!(Game.rooms[@{name}])
+    }
 }
 
 /// See [http://docs.screeps.com/api/#Game.spawns]

--- a/src/game.rs
+++ b/src/game.rs
@@ -50,8 +50,20 @@ pub mod rooms {
     use crate::{local::RoomName, macros::*, objects::Room};
 
     /// Retrieve the full `HashMap<RoomName, Room>`.
-    pub fn hashmap() -> HashMap<String, Room> {
-        js_unwrap!($js_inner)
+    pub fn hashmap() -> HashMap<RoomName, Room> {
+        // `TryFrom<Value>` is only implemented for `HashMap<String, V>`.
+        //
+        // See https://github.com/koute/stdweb/issues/359.
+        let map: HashMap<String, Room> = js_unwrap!(Game.rooms);
+        map.into_iter()
+            .map(|(key, val)| {
+                (
+                    key.parse()
+                        .expect("expected room name in Game.rooms to be valid"),
+                    val,
+                )
+            })
+            .collect()
     }
 
     /// Retrieve the string keys of this object.

--- a/src/game.rs
+++ b/src/game.rs
@@ -47,9 +47,9 @@ pub mod flags {
 pub mod rooms {
     use std::collections::HashMap;
 
-    use crate::{local::LocalRoomName, macros::*, objects::Room};
+    use crate::{local::RoomName, macros::*, objects::Room};
 
-    /// Retrieve the full `HashMap<LocalRoomName, Room>`.
+    /// Retrieve the full `HashMap<RoomName, Room>`.
     pub fn hashmap() -> HashMap<String, Room> {
         js_unwrap!($js_inner)
     }
@@ -65,7 +65,7 @@ pub mod rooms {
     }
 
     /// Retrieve a specific value by key.
-    pub fn get(name: LocalRoomName) -> Option<Room> {
+    pub fn get(name: RoomName) -> Option<Room> {
         js_unwrap_ref!(Game.rooms[@{name}])
     }
 }

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -10,7 +10,7 @@ use stdweb::Value;
 
 use crate::{
     constants::{Direction, ExitDirection, ReturnCode},
-    local::LocalRoomName,
+    local::RoomName,
     macros::*,
     objects::RoomTerrain,
     traits::{TryFrom, TryInto},
@@ -19,7 +19,7 @@ use crate::{
 /// See [http://docs.screeps.com/api/#Game.map.describeExits]
 ///
 /// [http://docs.screeps.com/api/#Game.map.describeExits]: http://docs.screeps.com/api/#Game.map.describeExits
-pub fn describe_exits(room_name: LocalRoomName) -> collections::HashMap<Direction, String> {
+pub fn describe_exits(room_name: RoomName) -> collections::HashMap<Direction, String> {
     let orig: collections::HashMap<String, String> =
         js_unwrap!(Game.map.describeExits(@{room_name}));
 
@@ -41,15 +41,11 @@ pub fn describe_exits(room_name: LocalRoomName) -> collections::HashMap<Directio
 /// See [http://docs.screeps.com/api/#Game.map.getRoomLinearDistance]
 ///
 /// [http://docs.screeps.com/api/#Game.map.getRoomLinearDistance]: http://docs.screeps.com/api/#Game.map.getRoomLinearDistance
-pub fn get_room_linear_distance(
-    room1: LocalRoomName,
-    room2: LocalRoomName,
-    continuous: bool,
-) -> u32 {
+pub fn get_room_linear_distance(room1: RoomName, room2: RoomName, continuous: bool) -> u32 {
     js_unwrap!(Game.map.getRoomLinearDistance(@{room1}, @{room2}, @{continuous}))
 }
 
-pub fn get_room_terrain(room_name: LocalRoomName) -> RoomTerrain {
+pub fn get_room_terrain(room_name: RoomName) -> RoomTerrain {
     js_unwrap!(Game.map.getRoomTerrain(@{room_name}))
 }
 
@@ -63,24 +59,21 @@ pub fn get_world_size() -> u32 {
 /// See [http://docs.screeps.com/api/#Game.map.isRoomAvailable]
 ///
 /// [http://docs.screeps.com/api/#Game.map.isRoomAvailable]: http://docs.screeps.com/api/#Game.map.isRoomAvailable
-pub fn is_room_available(room_name: LocalRoomName) -> bool {
+pub fn is_room_available(room_name: RoomName) -> bool {
     js_unwrap!(Game.map.isRoomAvailable(@{room_name}))
 }
 
 /// Implements `Game.map.findExit`.
-pub fn find_exit(
-    from_room: LocalRoomName,
-    to_room: LocalRoomName,
-) -> Result<ExitDirection, ReturnCode> {
+pub fn find_exit(from_room: RoomName, to_room: RoomName) -> Result<ExitDirection, ReturnCode> {
     let code: i32 = js_unwrap! {Game.map.findExit(@{from_room}, @{to_room})};
     ExitDirection::from_i32(code)
         .ok_or_else(|| ReturnCode::from_i32(code).expect("find_exit: Error code not recognized."))
 }
 
 pub fn find_exit_with_callback(
-    from_room: LocalRoomName,
-    to_room: LocalRoomName,
-    route_callback: impl Fn(LocalRoomName, LocalRoomName) -> f64,
+    from_room: RoomName,
+    to_room: RoomName,
+    route_callback: impl Fn(RoomName, RoomName) -> f64,
 ) -> Result<ExitDirection, ReturnCode> {
     // Actual callback
     fn callback(room_name: String, from_room_name: String) -> f64 {
@@ -98,10 +91,9 @@ pub fn find_exit_with_callback(
         })
     }
 
-    let callback_type_erased: Box<dyn Fn(LocalRoomName, LocalRoomName) -> f64> =
-        Box::new(route_callback);
+    let callback_type_erased: Box<dyn Fn(RoomName, RoomName) -> f64> = Box::new(route_callback);
 
-    let callback_lifetime_erased: Box<dyn Fn(LocalRoomName, LocalRoomName) -> f64 + 'static> =
+    let callback_lifetime_erased: Box<dyn Fn(RoomName, RoomName) -> f64 + 'static> =
         unsafe { mem::transmute(callback_type_erased) };
 
     FR_CALLBACK.set(&callback_lifetime_erased, || {
@@ -123,12 +115,12 @@ pub fn find_route(from_room: &str, to_room: &str) -> Result<Vec<RoomRouteStep>, 
     parse_find_route_returned_value(v)
 }
 
-scoped_thread_local!(static FR_CALLBACK: Box<(dyn Fn(LocalRoomName, LocalRoomName) -> f64)>);
+scoped_thread_local!(static FR_CALLBACK: Box<(dyn Fn(RoomName, RoomName) -> f64)>);
 
 pub fn find_route_with_callback(
-    from_room: LocalRoomName,
-    to_room: LocalRoomName,
-    route_callback: impl Fn(LocalRoomName, LocalRoomName) -> f64,
+    from_room: RoomName,
+    to_room: RoomName,
+    route_callback: impl Fn(RoomName, RoomName) -> f64,
 ) -> Result<Vec<RoomRouteStep>, ReturnCode> {
     // Actual callback
     fn callback(room_name: String, from_room_name: String) -> f64 {
@@ -146,10 +138,9 @@ pub fn find_route_with_callback(
         })
     }
 
-    let callback_type_erased: Box<dyn Fn(LocalRoomName, LocalRoomName) -> f64> =
-        Box::new(route_callback);
+    let callback_type_erased: Box<dyn Fn(RoomName, RoomName) -> f64> = Box::new(route_callback);
 
-    let callback_lifetime_erased: Box<dyn Fn(LocalRoomName, LocalRoomName) -> f64 + 'static> =
+    let callback_lifetime_erased: Box<dyn Fn(RoomName, RoomName) -> f64 + 'static> =
         unsafe { mem::transmute(callback_type_erased) };
 
     FR_CALLBACK.set(&callback_lifetime_erased, || {

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 
 use crate::{
     constants::{ResourceType, ReturnCode},
+    local::LocalRoomName,
     macros::*,
     traits::TryInto,
     Room,
@@ -67,7 +68,7 @@ pub struct Order {
     #[serde(rename = "type")]
     order_type: String,
     resource_type: String,
-    room_name: String,
+    room_name: LocalRoomName,
     amount: u32,
     remaining_amount: u32,
     price: f64,
@@ -83,7 +84,7 @@ pub struct MyOrder {
     #[serde(rename = "type")]
     order_type: String,
     resource_type: String,
-    room_name: String,
+    room_name: LocalRoomName,
     amount: u32,
     remaining_amount: u32,
     total_amount: u32,

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::{
     constants::{ResourceType, ReturnCode},
-    local::LocalRoomName,
+    local::RoomName,
     macros::*,
     traits::TryInto,
     Room,
@@ -68,7 +68,7 @@ pub struct Order {
     #[serde(rename = "type")]
     order_type: String,
     resource_type: String,
-    room_name: LocalRoomName,
+    room_name: RoomName,
     amount: u32,
     remaining_amount: u32,
     price: f64,
@@ -84,7 +84,7 @@ pub struct MyOrder {
     #[serde(rename = "type")]
     order_type: String,
     resource_type: String,
-    room_name: LocalRoomName,
+    room_name: RoomName,
     amount: u32,
     remaining_amount: u32,
     total_amount: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use stdweb::private::ConversionError;
 pub use crate::{
     constants::*,
     js_collections::JsVec,
-    local::{LocalRoomName, LocalRoomNameParseError, Position},
+    local::{Position, RoomName, RoomNameParseError},
     objects::*,
     traits::{FromExpectedType, IntoExpectedType},
 };

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -11,7 +11,7 @@ use super::{HALF_WORLD_SIZE, VALID_ROOM_NAME_COORDINATES};
 
 /// A structure representing a room name.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
-pub struct LocalRoomName {
+pub struct RoomName {
     /// A bit-packed integer, containing, from highest-order to lowest:
     ///
     /// - 1 byte: (room_x) + 128
@@ -26,13 +26,13 @@ pub struct LocalRoomName {
     packed: u16,
 }
 
-impl fmt::Display for LocalRoomName {
+impl fmt::Display for RoomName {
     /// Formats this room name into the format the game expects.
     ///
     /// Resulting string will be `(E|W)[0-9]+(N|S)[0-9]+`, and will result
-    /// in the same LocalRoomName if passed into [`LocalRoomName::new`].
+    /// in the same RoomName if passed into [`RoomName::new`].
     ///
-    /// [`LocalRoomName::new`]: struct.LocalRoomName.html#method.new
+    /// [`RoomName::new`]: struct.RoomName.html#method.new
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let x_coord = self.x_coord();
 
@@ -54,7 +54,7 @@ impl fmt::Display for LocalRoomName {
     }
 }
 
-impl LocalRoomName {
+impl RoomName {
     /// Parses a room name from a string.
     ///
     /// This will parse the input string, returning an error if it is in an
@@ -63,7 +63,7 @@ impl LocalRoomName {
     /// The expected format can be represented by the regex
     /// `[ewEW][0-9]+[nsNS][0-9]+`.
     #[inline]
-    pub fn new<T>(x: &T) -> Result<Self, LocalRoomNameParseError>
+    pub fn new<T>(x: &T) -> Result<Self, RoomNameParseError>
     where
         T: AsRef<str> + ?Sized,
     {
@@ -72,7 +72,7 @@ impl LocalRoomName {
 
     #[inline]
     pub(crate) fn from_packed(packed: u16) -> Self {
-        LocalRoomName { packed }
+        RoomName { packed }
     }
 
     /// Creates a new room name from room coords with direction implicit in
@@ -86,11 +86,11 @@ impl LocalRoomName {
     ///
     /// Returns an error if the coordinates are outside of the valid room name
     /// bounds.
-    pub(super) fn from_coords(x_coord: i32, y_coord: i32) -> Result<Self, LocalRoomNameParseError> {
+    pub(super) fn from_coords(x_coord: i32, y_coord: i32) -> Result<Self, RoomNameParseError> {
         if !VALID_ROOM_NAME_COORDINATES.contains(&x_coord)
             || !VALID_ROOM_NAME_COORDINATES.contains(&y_coord)
         {
-            return Err(LocalRoomNameParseError::PositionOutOfBounds { x_coord, y_coord });
+            return Err(RoomNameParseError::PositionOutOfBounds { x_coord, y_coord });
         }
 
         let room_x = (x_coord + HALF_WORLD_SIZE) as u16;
@@ -120,7 +120,7 @@ impl LocalRoomName {
         self.packed
     }
 
-    /// Converts this LocalRoomName into an efficient, stack-based string.
+    /// Converts this RoomName into an efficient, stack-based string.
     ///
     /// This is equivalent to [`ToString::to_string`], but involves no
     /// allocation.
@@ -131,7 +131,7 @@ impl LocalRoomName {
     }
 }
 
-impl ops::Add<(i32, i32)> for LocalRoomName {
+impl ops::Add<(i32, i32)> for RoomName {
     type Output = Self;
 
     /// Offsets this room name by a given horizontal and vertical (x, y) pair.
@@ -142,15 +142,15 @@ impl ops::Add<(i32, i32)> for LocalRoomName {
     ///
     /// # Panics
     ///
-    /// Will panic if the addition overflows the boundaries of LocalRoomName.
+    /// Will panic if the addition overflows the boundaries of RoomName.
     #[inline]
     fn add(self, (x, y): (i32, i32)) -> Self {
-        LocalRoomName::from_coords(self.x_coord() + x, self.y_coord() + y)
-            .expect("expected addition to keep LocalRoomName in-bounds")
+        RoomName::from_coords(self.x_coord() + x, self.y_coord() + y)
+            .expect("expected addition to keep RoomName in-bounds")
     }
 }
 
-impl ops::Sub<(i32, i32)> for LocalRoomName {
+impl ops::Sub<(i32, i32)> for RoomName {
     type Output = Self;
 
     /// Offsets this room name in the opposite direction from the coordinates.
@@ -159,15 +159,15 @@ impl ops::Sub<(i32, i32)> for LocalRoomName {
     ///
     /// # Panics
     ///
-    /// Will panic if the subtraction overflows the boundaries of LocalRoomName.
+    /// Will panic if the subtraction overflows the boundaries of RoomName.
     #[inline]
     fn sub(self, (x, y): (i32, i32)) -> Self {
-        LocalRoomName::from_coords(self.x_coord() - x, self.y_coord() - y)
-            .expect("expected addition to keep LocalRoomName in-bounds")
+        RoomName::from_coords(self.x_coord() - x, self.y_coord() - y)
+            .expect("expected addition to keep RoomName in-bounds")
     }
 }
 
-impl ops::Sub<LocalRoomName> for LocalRoomName {
+impl ops::Sub<RoomName> for RoomName {
     type Output = (i32, i32);
 
     /// Subtracts one room name from the other, extracting the difference.
@@ -179,9 +179,9 @@ impl ops::Sub<LocalRoomName> for LocalRoomName {
     /// being positive and 'more north' being negative.
     ///
     /// This coordinate system agrees with the implementations `Add<(i32, i32)>
-    /// for LocalRoomName` and `Sub<(i32, i32)> for LocalRoomName`.
+    /// for RoomName` and `Sub<(i32, i32)> for RoomName`.
     #[inline]
-    fn sub(self, other: LocalRoomName) -> (i32, i32) {
+    fn sub(self, other: RoomName) -> (i32, i32) {
         (
             self.x_coord() - other.x_coord(),
             self.y_coord() - other.y_coord(),
@@ -189,13 +189,13 @@ impl ops::Sub<LocalRoomName> for LocalRoomName {
     }
 }
 
-impl FromStr for LocalRoomName {
-    type Err = LocalRoomNameParseError;
+impl FromStr for RoomName {
+    type Err = RoomNameParseError;
 
-    fn from_str(s: &str) -> Result<Self, LocalRoomNameParseError> {
+    fn from_str(s: &str) -> Result<Self, RoomNameParseError> {
         parse_to_coords(s)
-            .map_err(|()| LocalRoomNameParseError::new(s))
-            .and_then(|(x, y)| LocalRoomName::from_coords(x, y))
+            .map_err(|()| RoomNameParseError::new(s))
+            .and_then(|(x, y)| RoomName::from_coords(x, y))
     }
 }
 
@@ -252,45 +252,45 @@ fn parse_to_coords(s: &str) -> Result<(i32, i32), ()> {
 }
 
 /// An error representing when a string can't be parsed into a
-/// [`LocalRoomName`].
+/// [`RoomName`].
 ///
-/// [`LocalRoomName`]: struct.LocalRoomName.html
+/// [`RoomName`]: struct.RoomName.html
 #[derive(Clone, Debug)]
-pub enum LocalRoomNameParseError {
+pub enum RoomNameParseError {
     TooLarge { length: usize },
     InvalidString { string: ArrayString<[u8; 8]> },
     PositionOutOfBounds { x_coord: i32, y_coord: i32 },
 }
 
-impl LocalRoomNameParseError {
-    /// Private method to construct a `LocalRoomNameParseError`.
+impl RoomNameParseError {
+    /// Private method to construct a `RoomNameParseError`.
     fn new(failed_room_name: &str) -> Self {
         match ArrayString::from(failed_room_name) {
-            Ok(string) => LocalRoomNameParseError::InvalidString { string },
-            Err(_) => LocalRoomNameParseError::TooLarge {
+            Ok(string) => RoomNameParseError::InvalidString { string },
+            Err(_) => RoomNameParseError::TooLarge {
                 length: failed_room_name.len(),
             },
         }
     }
 }
 
-impl error::Error for LocalRoomNameParseError {}
+impl error::Error for RoomNameParseError {}
 
-impl fmt::Display for LocalRoomNameParseError {
+impl fmt::Display for RoomNameParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LocalRoomNameParseError::TooLarge { length } => write!(
+            RoomNameParseError::TooLarge { length } => write!(
                 f,
                 "got invalid room name, too large to stick in error. \
                  expected length 8 or less, got length {}",
                 length
             ),
-            LocalRoomNameParseError::InvalidString { string } => write!(
+            RoomNameParseError::InvalidString { string } => write!(
                 f,
                 "expected room name formatted `[ewEW][0-9]+[nsNS][0-9]+`, found `{}`",
                 string
             ),
-            LocalRoomNameParseError::PositionOutOfBounds { x_coord, y_coord } => write!(
+            RoomNameParseError::PositionOutOfBounds { x_coord, y_coord } => write!(
                 f,
                 "expected room name with coords within -128..+128, found {}, {}",
                 x_coord, y_coord,
@@ -299,15 +299,15 @@ impl fmt::Display for LocalRoomNameParseError {
     }
 }
 
-impl PartialEq<str> for LocalRoomName {
+impl PartialEq<str> for RoomName {
     fn eq(&self, other: &str) -> bool {
         let s = self.to_array_string();
         s.eq_ignore_ascii_case(other)
     }
 }
-impl PartialEq<LocalRoomName> for str {
+impl PartialEq<RoomName> for str {
     #[inline]
-    fn eq(&self, other: &LocalRoomName) -> bool {
+    fn eq(&self, other: &RoomName) -> bool {
         // Explicitly call the impl for `PartialEq<str>` so that we don't end up
         // accidentally calling one of the other implementations and ending up in an
         // infinite loop.
@@ -315,49 +315,49 @@ impl PartialEq<LocalRoomName> for str {
         // This one in particular would probably be OK, but I've written it this way to
         // be consistent with the others, and to ensure that if this code changes in
         // this future it'll stay working.
-        <LocalRoomName as PartialEq<str>>::eq(other, self)
+        <RoomName as PartialEq<str>>::eq(other, self)
     }
 }
 
-impl PartialEq<&str> for LocalRoomName {
+impl PartialEq<&str> for RoomName {
     #[inline]
     fn eq(&self, other: &&str) -> bool {
-        <LocalRoomName as PartialEq<str>>::eq(self, other)
+        <RoomName as PartialEq<str>>::eq(self, other)
     }
 }
 
-impl PartialEq<LocalRoomName> for &str {
+impl PartialEq<RoomName> for &str {
     #[inline]
-    fn eq(&self, other: &LocalRoomName) -> bool {
-        <LocalRoomName as PartialEq<str>>::eq(other, self)
+    fn eq(&self, other: &RoomName) -> bool {
+        <RoomName as PartialEq<str>>::eq(other, self)
     }
 }
 
-impl PartialEq<String> for LocalRoomName {
+impl PartialEq<String> for RoomName {
     #[inline]
     fn eq(&self, other: &String) -> bool {
-        <LocalRoomName as PartialEq<str>>::eq(self, &other)
+        <RoomName as PartialEq<str>>::eq(self, &other)
     }
 }
 
-impl PartialEq<LocalRoomName> for String {
+impl PartialEq<RoomName> for String {
     #[inline]
-    fn eq(&self, other: &LocalRoomName) -> bool {
-        <LocalRoomName as PartialEq<str>>::eq(other, self)
+    fn eq(&self, other: &RoomName) -> bool {
+        <RoomName as PartialEq<str>>::eq(other, self)
     }
 }
 
-impl PartialEq<&String> for LocalRoomName {
+impl PartialEq<&String> for RoomName {
     #[inline]
     fn eq(&self, other: &&String) -> bool {
-        <LocalRoomName as PartialEq<str>>::eq(self, other)
+        <RoomName as PartialEq<str>>::eq(self, other)
     }
 }
 
-impl PartialEq<LocalRoomName> for &String {
+impl PartialEq<RoomName> for &String {
     #[inline]
-    fn eq(&self, other: &LocalRoomName) -> bool {
-        <LocalRoomName as PartialEq<str>>::eq(other, self)
+    fn eq(&self, other: &RoomName) -> bool {
+        <RoomName as PartialEq<str>>::eq(other, self)
     }
 }
 
@@ -369,10 +369,10 @@ mod serde {
         Deserialize, Deserializer, Serialize, Serializer,
     };
 
-    use super::LocalRoomName;
+    use super::RoomName;
     use crate::macros::*;
 
-    impl Serialize for LocalRoomName {
+    impl Serialize for RoomName {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -381,10 +381,10 @@ mod serde {
         }
     }
 
-    struct LocalRoomNameVisitor;
+    struct RoomNameVisitor;
 
-    impl<'de> Visitor<'de> for LocalRoomNameVisitor {
-        type Value = LocalRoomName;
+    impl<'de> Visitor<'de> for RoomNameVisitor {
+        type Value = RoomName;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str(
@@ -401,36 +401,30 @@ mod serde {
         }
     }
 
-    impl<'de> Deserialize<'de> for LocalRoomName {
+    impl<'de> Deserialize<'de> for RoomName {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            deserializer.deserialize_str(LocalRoomNameVisitor)
+            deserializer.deserialize_str(RoomNameVisitor)
         }
     }
 
-    js_deserializable!(LocalRoomName);
-    js_serializable!(LocalRoomName);
+    js_deserializable!(RoomName);
+    js_serializable!(RoomName);
 }
 
 #[cfg(test)]
 mod test {
     #[test]
     fn test_string_equality() {
-        use super::LocalRoomName;
+        use super::RoomName;
         let room_names = vec!["E21N4", "w6S42", "W17s5", "e2n5"];
         for room_name in room_names {
-            assert_eq!(room_name, LocalRoomName::new(room_name).unwrap());
-            assert_eq!(LocalRoomName::new(room_name).unwrap(), room_name);
-            assert_eq!(
-                LocalRoomName::new(room_name).unwrap(),
-                &room_name.to_string()
-            );
-            assert_eq!(
-                &room_name.to_string(),
-                LocalRoomName::new(room_name).unwrap()
-            );
+            assert_eq!(room_name, RoomName::new(room_name).unwrap());
+            assert_eq!(RoomName::new(room_name).unwrap(), room_name);
+            assert_eq!(RoomName::new(room_name).unwrap(), &room_name.to_string());
+            assert_eq!(&room_name.to_string(), RoomName::new(room_name).unwrap());
         }
     }
 }

--- a/src/local/room_position.rs
+++ b/src/local/room_position.rs
@@ -5,7 +5,7 @@
 //! file stay within Rust.
 use std::fmt;
 
-use super::{LocalRoomName, HALF_WORLD_SIZE};
+use super::{RoomName, HALF_WORLD_SIZE};
 
 mod extra_math;
 mod game_math;
@@ -129,7 +129,7 @@ impl Position {
     /// Will panic if either `x` or `y` is larger than 49, or if `room_name` is
     /// outside of the range `E127N127 - W127S127`.
     #[inline]
-    pub fn new(x: u32, y: u32, room_name: LocalRoomName) -> Self {
+    pub fn new(x: u32, y: u32, room_name: RoomName) -> Self {
         assert!(x < 50, "out of bounds x: {}", x);
         assert!(y < 50, "out of bounds y: {}", y);
 
@@ -195,8 +195,8 @@ impl Position {
     }
 
     #[inline]
-    pub fn room_name(self) -> LocalRoomName {
-        LocalRoomName::from_packed(((self.packed >> 16) & 0xFFFF) as u16)
+    pub fn room_name(self) -> RoomName {
+        RoomName::from_packed(((self.packed >> 16) & 0xFFFF) as u16)
     }
 
     #[inline]
@@ -212,7 +212,7 @@ impl Position {
     }
 
     #[inline]
-    pub fn set_room_name(&mut self, room_name: LocalRoomName) {
+    pub fn set_room_name(&mut self, room_name: RoomName) {
         let room_repr_packed = room_name.packed_repr() as u32;
         self.packed = (self.packed & 0xFFFF) | (room_repr_packed << 16);
     }
@@ -230,7 +230,7 @@ impl Position {
     }
 
     #[inline]
-    pub fn with_room_name(mut self, room_name: LocalRoomName) -> Self {
+    pub fn with_room_name(mut self, room_name: RoomName) -> Self {
         self.set_room_name(room_name);
         self
     }
@@ -289,12 +289,12 @@ mod stdweb {
 mod serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    use super::{LocalRoomName, Position};
+    use super::{Position, RoomName};
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct ReadableFormat {
-        room_name: LocalRoomName,
+        room_name: RoomName,
         x: u32,
         y: u32,
     }

--- a/src/local/room_position/game_methods.rs
+++ b/src/local/room_position/game_methods.rs
@@ -2,6 +2,7 @@
 use crate::{
     constants::{Color, FindConstant, LookConstant, ReturnCode, StructureType},
     game,
+    local::LocalRoomName,
     macros::*,
     objects::{FindOptions, Flag, HasPosition, LookResult, Path},
     pathfinder::CostMatrix,
@@ -66,16 +67,16 @@ impl Position {
 
     pub fn find_path_to<'a, F, T>(self, target: &T, opts: FindOptions<'a, F>) -> Path
     where
-        F: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
         T: ?Sized + HasPosition,
     {
-        let self_room = game::rooms::get(&self.room_name().to_array_string()).unwrap();
+        let self_room = game::rooms::get(self.room_name()).unwrap();
         self_room.find_path(&self, target, opts)
     }
 
     pub fn find_path_to_xy<'a, F>(self, x: u32, y: u32, opts: FindOptions<'a, F>) -> Path
     where
-        F: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
     {
         let target = Position::new(x, y, self.room_name());
         self.find_path_to(&target, opts)

--- a/src/local/room_position/game_methods.rs
+++ b/src/local/room_position/game_methods.rs
@@ -2,7 +2,7 @@
 use crate::{
     constants::{Color, FindConstant, LookConstant, ReturnCode, StructureType},
     game,
-    local::LocalRoomName,
+    local::RoomName,
     macros::*,
     objects::{FindOptions, Flag, HasPosition, LookResult, Path},
     pathfinder::CostMatrix,
@@ -67,7 +67,7 @@ impl Position {
 
     pub fn find_path_to<'a, F, T>(self, target: &T, opts: FindOptions<'a, F>) -> Path
     where
-        F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
         T: ?Sized + HasPosition,
     {
         let self_room = game::rooms::get(self.room_name()).unwrap();
@@ -76,7 +76,7 @@ impl Position {
 
     pub fn find_path_to_xy<'a, F>(self, x: u32, y: u32, opts: FindOptions<'a, F>) -> Path
     where
-        F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
     {
         let target = Position::new(x, y, self.room_name());
         self.find_path_to(&target, opts)

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -6,7 +6,7 @@ use stdweb::{Reference, Value};
 use super::room::Step;
 use crate::{
     constants::{Direction, Part, ResourceType, ReturnCode},
-    local::Position,
+    local::{LocalRoomName, Position},
     macros::*,
     memory::MemoryReference,
     objects::{
@@ -17,7 +17,7 @@ use crate::{
     traits::TryFrom,
 };
 
-scoped_thread_local!(static COST_CALLBACK: Box<dyn Fn(String, Reference) -> Option<Reference>>);
+scoped_thread_local!(static COST_CALLBACK: Box<dyn Fn(LocalRoomName, Reference) -> Option<Reference>>);
 
 impl Creep {
     pub fn body(&self) -> Vec<Bodypart> {
@@ -88,7 +88,7 @@ impl Creep {
         move_options: MoveToOptions<'a, F>,
     ) -> ReturnCode
     where
-        F: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
     {
         let pos = Position::new(x, y, self.pos().room_name());
         self.move_to_with_options(&pos, move_options)
@@ -106,7 +106,7 @@ impl Creep {
     ) -> ReturnCode
     where
         T: ?Sized + HasPosition,
-        F: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
     {
         let MoveToOptions {
             reuse_path,
@@ -130,6 +130,10 @@ impl Creep {
 
         // This callback is the one actually passed to JavaScript.
         fn callback(room_name: String, cost_matrix: Reference) -> Option<Reference> {
+            let room_name = room_name.parse().expect(
+                "expected room name passed into Creep.moveTo \
+                 callback to be a valid room name",
+            );
             COST_CALLBACK.with(|callback| callback(room_name, cost_matrix))
         }
 
@@ -147,7 +151,7 @@ impl Creep {
 
         // Type erased and boxed callback: no longer a type specific to the closure
         // passed in, now unified as Box<Fn>
-        let callback_type_erased: Box<dyn Fn(String, Reference) -> Option<Reference> + 'a> =
+        let callback_type_erased: Box<dyn Fn(LocalRoomName, Reference) -> Option<Reference> + 'a> =
             Box::new(callback_boxed);
 
         // Overwrite lifetime of box inside closure so it can be stuck in
@@ -158,7 +162,7 @@ impl Creep {
         // scope but otherwise unknown" is not a valid lifetime to have
         // PF_CALLBACK have.
         let callback_lifetime_erased: Box<
-            dyn Fn(String, Reference) -> Option<Reference> + 'static,
+            dyn Fn(LocalRoomName, Reference) -> Option<Reference> + 'static,
         > = unsafe { mem::transmute(callback_type_erased) };
 
         // Store callback_lifetime_erased in COST_CALLBACK for the duration of the
@@ -315,7 +319,7 @@ creep_simple_concrete_action! {
 
 pub struct MoveToOptions<'a, F>
 where
-    F: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
 {
     pub(crate) reuse_path: u32,
     pub(crate) serialize_memory: bool,
@@ -324,7 +328,9 @@ where
     pub(crate) find_options: FindOptions<'a, F>,
 }
 
-impl Default for MoveToOptions<'static, fn(String, CostMatrix<'_>) -> Option<CostMatrix<'static>>> {
+impl Default
+    for MoveToOptions<'static, fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>>
+{
     fn default() -> Self {
         // TODO: should we fall back onto the game's default values, or is
         // it alright to copy them here?
@@ -338,7 +344,7 @@ impl Default for MoveToOptions<'static, fn(String, CostMatrix<'_>) -> Option<Cos
     }
 }
 
-impl MoveToOptions<'static, fn(String, CostMatrix<'_>) -> Option<CostMatrix<'static>>> {
+impl MoveToOptions<'static, fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>> {
     /// Creates default SearchOptions
     pub fn new() -> Self {
         Self::default()
@@ -347,7 +353,7 @@ impl MoveToOptions<'static, fn(String, CostMatrix<'_>) -> Option<CostMatrix<'sta
 
 impl<'a, F> MoveToOptions<'a, F>
 where
-    F: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
 {
     /// Enables caching of the calculated path. Default: 5 ticks
     pub fn reuse_path(mut self, n_ticks: u32) -> Self {
@@ -389,7 +395,7 @@ where
     /// Sets cost callback - default `|_, _| {}`.
     pub fn cost_callback<'b, F2>(self, cost_callback: F2) -> MoveToOptions<'b, F2>
     where
-        F2: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
+        F2: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
     {
         MoveToOptions {
             reuse_path: self.reuse_path,
@@ -444,7 +450,7 @@ where
     /// Sets options related to FindOptions. Defaults to FindOptions default.
     pub fn find_options<'b, F2>(self, find_options: FindOptions<'b, F2>) -> MoveToOptions<'b, F2>
     where
-        F2: Fn(String, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
+        F2: Fn(LocalRoomName, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
     {
         MoveToOptions {
             reuse_path: self.reuse_path,

--- a/src/objects/impls/nuke.rs
+++ b/src/objects/impls/nuke.rs
@@ -1,8 +1,8 @@
-use crate::{local::LocalRoomName, macros::*, objects::Nuke};
+use crate::{local::RoomName, macros::*, objects::Nuke};
 
 simple_accessors! {
     Nuke;
     // id from HasID
-    (lauch_room_name -> lauchRoomName -> LocalRoomName),
+    (lauch_room_name -> lauchRoomName -> RoomName),
     (time_to_land -> timeToLand -> u32),
 }

--- a/src/objects/impls/nuke.rs
+++ b/src/objects/impls/nuke.rs
@@ -1,8 +1,8 @@
-use crate::{macros::*, objects::Nuke};
+use crate::{local::LocalRoomName, macros::*, objects::Nuke};
 
 simple_accessors! {
     Nuke;
     // id from HasID
-    (lauch_room_name -> lauchRoomName -> String),
+    (lauch_room_name -> lauchRoomName -> LocalRoomName),
     (time_to_land -> timeToLand -> u32),
 }

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -2,14 +2,14 @@ use stdweb::UnsafeTypedArray;
 
 use crate::{
     constants::{ReturnCode, Terrain},
-    local::LocalRoomName,
+    local::RoomName,
     macros::*,
     objects::RoomTerrain,
     traits::TryInto,
 };
 
 impl RoomTerrain {
-    pub fn constructor(room_name: LocalRoomName) -> Self {
+    pub fn constructor(room_name: RoomName) -> Self {
         js_unwrap!(new Room.Terrain(@{room_name}))
     }
 

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -2,13 +2,14 @@ use stdweb::UnsafeTypedArray;
 
 use crate::{
     constants::{ReturnCode, Terrain},
+    local::LocalRoomName,
     macros::*,
     objects::RoomTerrain,
     traits::TryInto,
 };
 
 impl RoomTerrain {
-    pub fn constructor(room_name: &str) -> Self {
+    pub fn constructor(room_name: LocalRoomName) -> Self {
         js_unwrap!(new Room.Terrain(@{room_name}))
     }
 

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -1,7 +1,7 @@
-use crate::{constants::ReturnCode, local::LocalRoomName, macros::*, objects::StructureObserver};
+use crate::{constants::ReturnCode, local::RoomName, macros::*, objects::StructureObserver};
 
 impl StructureObserver {
-    pub fn observe_room(&self, room_name: LocalRoomName) -> ReturnCode {
+    pub fn observe_room(&self, room_name: RoomName) -> ReturnCode {
         js_unwrap! {@{self.as_ref()}.observeRoom(@{room_name})}
     }
 }

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -1,7 +1,7 @@
-use crate::{constants::ReturnCode, macros::*, objects::StructureObserver};
+use crate::{constants::ReturnCode, local::LocalRoomName, macros::*, objects::StructureObserver};
 
 impl StructureObserver {
-    pub fn observe_room(&self, room_name: &str) -> ReturnCode {
+    pub fn observe_room(&self, room_name: LocalRoomName) -> ReturnCode {
         js_unwrap! {@{self.as_ref()}.observeRoom(@{room_name})}
     }
 }

--- a/src/objects/impls/structure_portal.rs
+++ b/src/objects/impls/structure_portal.rs
@@ -1,12 +1,17 @@
 use serde::Deserialize;
 use stdweb::Value;
 
-use crate::{local::Position, macros::*, objects::StructurePortal, traits::TryInto};
+use crate::{
+    local::{LocalRoomName, Position},
+    macros::*,
+    objects::StructurePortal,
+    traits::TryInto,
+};
 
 #[derive(Deserialize, Debug)]
 pub struct InterShardPortalDestination {
     shard: String,
-    room: String,
+    room: LocalRoomName,
 }
 js_deserializable!(InterShardPortalDestination);
 

--- a/src/objects/impls/structure_portal.rs
+++ b/src/objects/impls/structure_portal.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use stdweb::Value;
 
 use crate::{
-    local::{LocalRoomName, Position},
+    local::{Position, RoomName},
     macros::*,
     objects::StructurePortal,
     traits::TryInto,
@@ -11,7 +11,7 @@ use crate::{
 #[derive(Deserialize, Debug)]
 pub struct InterShardPortalDestination {
     shard: String,
-    room: LocalRoomName,
+    room: RoomName,
 }
 js_deserializable!(InterShardPortalDestination);
 


### PR DESCRIPTION
This makes all public functions which refer to room names use our in-rust `RoomName` representation. They still translate the room names to strings before transferring to the API (`RoomName` implements `JsSerialize` using its `Serialize` impl, which allocates a stack-based string and serializes that), but that could change in the future?

This also renames `LocalRoomName` to `RoomName`, since it's no longer an optional "local" version of something but the canonical structure to use for room names. I do still like the name `RoomName` most, because even if it isn't the most technically accurate, it matches the wording the screeps documentation uses, and fields like `RoomPosition.roomName` in JS. Even if it represents a room coordinate, there's value in being consistent with JS naming conventions. I'm thinking of the resources in slack and people who know to use "room name" to refer to this bit of info.

Resolves #198.