### PR TITLE
Add travis CI badges

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ description = "WASM bindings to the in-game Screeps API"
 [lib]
 name = "screeps"
 
+[badges]
+travis-ci = { repository = "rustyscreeps/screeps-game-api" }
+
 [dependencies]
 arrayvec = "0.4"
 enum-iterator = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 screeps-game-api
 ================
 
+[![Linux Build Status][travis-image]][travis-builds]
 [![crates.io version badge][cratesio-badge]][crate]
 [![docs.rs version badge][docsrs-badge]][docs]
 
@@ -59,6 +60,8 @@ cargo screeps --help
 
 [screeps]: https://screeps.com/
 [`stdweb`]: https://github.com/koute/stdweb
+[travis-image]: https://travis-ci.org/rustyscreeps/screeps-game-api.svg?branch=master
+[travis-builds]: https://travis-ci.org/rustyscreeps/screeps-game-api
 [docsrs-badge]: https://docs.rs/screeps-game-api/badge.svg
 [cratesio-badge]: http://meritbadge.herokuapp.com/screeps-game-api
 [docs]: https://docs.rs/screeps-game-api/


### PR DESCRIPTION
Adds CI badges to the crate page on crates.io, and to the README.