### PR TITLE
Work around undefined hits and hitsMax

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -391,10 +391,22 @@ pub unsafe trait Withdrawable: RoomObjectProperties {}
 /// The reference returned from `AsRef<Reference>::as_ref` must be a valid
 /// target for `Creep.attack`.
 pub unsafe trait Attackable: RoomObjectProperties {
+    /// Retrieve this hits of this structure, or `0` if this structure doesn't
+    /// have a hit count.
+    ///
+    /// For instance, this retrieves the hitpoints of a `Creep`. Or for a
+    /// `StructureWall` that's part of a novice area border, this will return
+    /// `0`.
     fn hits(&self) -> u32 {
         js_unwrap! { @{self.as_ref()}.hits || 0 }
     }
 
+    /// Retrieve the maximum hits of this structure, or `0` if this structure
+    /// doesn't have a hit count.
+    ///
+    /// For instance, this retrieves the maximum full health of a `Creep`. Or
+    /// for a `StructureWall` that's part of a novice area border, this will
+    /// return `0`.
     fn hits_max(&self) -> u32 {
         js_unwrap! { @{self.as_ref()}.hitsMax || 0 }
     }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -392,11 +392,11 @@ pub unsafe trait Withdrawable: RoomObjectProperties {}
 /// target for `Creep.attack`.
 pub unsafe trait Attackable: RoomObjectProperties {
     fn hits(&self) -> u32 {
-        js_unwrap! { @{self.as_ref()}.hits }
+        js_unwrap! { @{self.as_ref()}.hits || 0 }
     }
 
     fn hits_max(&self) -> u32 {
-        js_unwrap! { @{self.as_ref()}.hitsMax }
+        js_unwrap! { @{self.as_ref()}.hitsMax || 0 }
     }
 }
 


### PR DESCRIPTION
Fixes #139.

This is a pretty minimal solution, not necessarily the most elegant one.

The main alternative I can think of would be to just do this for `StructureWall`, so that we properly handle indestructible novice / respawn area walls. We could just ignore the apparent problems in simulation mode.

However, I think node.js should be able to optimize this down so that it doesn't have that much of a practical effect.