### PR TITLE
Fix extra fixes / cleanups for object IDs

### DIFF
--- a/src/local/object_id.rs
+++ b/src/local/object_id.rs
@@ -12,6 +12,7 @@ use stdweb::{Reference, UnsafeTypedArray};
 
 use crate::{
     objects::{HasId, SizedRoomObject},
+    traits::{TryFrom, TryInto},
     ConversionError,
 };
 
@@ -85,7 +86,7 @@ impl<T> FromStr for ObjectId<T> {
 }
 
 impl<T> TryFrom<u128> for ObjectId<T> {
-    type Err = RawObjectIdParseError;
+    type Error = RawObjectIdParseError;
 
     fn try_from(val: u128) -> Result<Self, RawObjectIdParseError> {
         let raw: RawObjectId = val.try_into()?;

--- a/src/local/object_id.rs
+++ b/src/local/object_id.rs
@@ -84,6 +84,16 @@ impl<T> FromStr for ObjectId<T> {
     }
 }
 
+impl<T> TryFrom<u128> for ObjectId<T> {
+    type Err = RawObjectIdParseError;
+
+    fn try_from(val: u128) -> Result<Self, RawObjectIdParseError> {
+        let raw: RawObjectId = val.try_into()?;
+
+        Ok(raw.into())
+    }
+}
+
 impl<T> fmt::Display for ObjectId<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.raw.fmt(f)
@@ -138,6 +148,17 @@ impl<T> ObjectId<T> {
     /// See also [`RawObjectId::from_packed_js_val`].
     pub fn from_packed_js_val(packed_val: Reference) -> Result<Self, ConversionError> {
         RawObjectId::from_packed_js_val(packed_val).map(Into::into)
+    }
+
+    /// Converts this object ID to a `u128` number.
+    ///
+    /// The returned number, when formatted as hex, will produce a string
+    /// parseable into this object id.
+    ///
+    /// The returned number will be less than or equal to `2^96 - 1`, as that's
+    /// the maximum value that `RawObjectId` can hold.
+    pub fn to_u128(self) -> u128 {
+        self.raw.to_u128()
     }
 
     /// Formats this object ID as a string on the stack.

--- a/src/local/object_id.rs
+++ b/src/local/object_id.rs
@@ -282,8 +282,20 @@ impl<T> From<ObjectId<T>> for String {
     }
 }
 
+impl<T> From<ObjectId<T>> for u128 {
+    fn from(id: ObjectId<T>) -> Self {
+        id.raw.into()
+    }
+}
+
 impl<T> From<[u32; 3]> for ObjectId<T> {
     fn from(packed: [u32; 3]) -> Self {
         Self::from_packed(packed)
+    }
+}
+
+impl<T> From<ObjectId<T>> for [u32; 3] {
+    fn from(id: ObjectId<T>) -> Self {
+        id.raw.into()
     }
 }

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -10,7 +10,7 @@ use stdweb::{Reference, UnsafeTypedArray};
 use super::errors::RawObjectIdParseError;
 use crate::{macros::*, traits::TryInto, ConversionError};
 
-const MAX_PACKED_VAL: u128 = 1 << (32 * 3);
+const MAX_PACKED_VAL: u128 = (1 << (32 * 3)) - 1;
 
 /// Represents an Object ID using a packed 12-byte representation
 ///
@@ -247,6 +247,18 @@ mod test {
         for id in TEST_IDS {
             let parsed: RawObjectId = id.parse().unwrap();
             assert_eq!(&*parsed.to_array_string(), *id);
+        }
+    }
+
+    #[test]
+    fn large_values_do_not_parse() {
+        let large_ids = &[
+            "1000000000000000000000000".to_owned(),
+            format!("{:x}", u128::max_value()),
+        ];
+        for id in large_ids {
+            let res: Result<RawObjectId, _> = id.parse();
+            assert!(res.is_err());
         }
     }
 

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -210,6 +210,12 @@ impl From<RawObjectId> for String {
     }
 }
 
+impl From<RawObjectId> for [u32; 3] {
+    fn from(id: RawObjectId) -> Self {
+        id.packed
+    }
+}
+
 impl From<[u32; 3]> for RawObjectId {
     fn from(packed: [u32; 3]) -> Self {
         Self::from_packed(packed)


### PR DESCRIPTION
Looking over the changes made in #229, I realized that using `u128` more could eliminate most/all of the manual formatting code for `RawObjectId`, and that a few more transitions which might be useful were missing.

This:
- adds impls `TryFrom<u128>`, `Into<u128>`, `From<[u32; 3]>`
- fixes the MAX_PACKED_VAL constant, previously off by 1
- removes manual formatting code in favor of calling using `u128`'s code