### PR TITLE
Fix badly typed `game::rooms::keys` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 
 - Rename incorrectly spelled `Density::probabilitiy` to `probability`.
 - Rename incorrectly spelled `Nuke::lauch_room_name` to `launch_room_name`.
+- Change return type of `game::rooms::keys` from `Vec<String>` to `Vec<RoomName>`
 - Fix typos in JavaScript code for `game::market::get_order` and `Nuke::launch_room_name`
 
 0.6.0 (2019-08-15)

--- a/src/game.rs
+++ b/src/game.rs
@@ -68,7 +68,7 @@ pub mod rooms {
     }
 
     /// Retrieve the string keys of this object.
-    pub fn keys() -> Vec<String> {
+    pub fn keys() -> Vec<RoomName> {
         js_unwrap!(Object.keys(Game.rooms))
     }
 


### PR DESCRIPTION
I missed it when implementing #218! With this, the keys function returns `Vec<RoomName>`, rather than `Vec<String>`.