### PR TITLE
Implement game resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Rename incorrectly spelled `Density::probabilitiy` to `probability`.
 - Rename incorrectly spelled `Nuke::lauch_room_name` to `launch_room_name`.
 - Fix typos in JavaScript code for `game::market::get_order` and `Nuke::launch_room_name`
+- Add support for accessing intershard resource amounts, which currently only includes subscription
+  tokens, under `game::resources`.
 
 0.6.0 (2019-08-15)
 ==================

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1008,8 +1008,8 @@ pub const FLAGS_LIMIT: u32 = 10_000;
 ///
 /// *Note:* This constant's `TryFrom<Value>`, `Serialize` and `Deserialize`
 /// implementations only operate on made-up integer constants. If you're ever
-/// using these impls manually, use the `__intershard_resource_num_to_str` and
-/// `__intershard_resource_str_to_num` JavaScript functions,
+/// using these impls manually, use the `__intershard_resource_type_num_to_str`
+/// and `__intershard_resource_type_str_to_num` JavaScript functions,
 /// [`FromStr`][std::str::FromStr] or
 /// [`IntershardResourceType::deserialize_from_str`].
 ///

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1035,6 +1035,8 @@ impl IntershardResourceType {
     }
 }
 
+js_deserializable!(IntershardResourceType);
+
 /// Resource type constant for all possible types of resources.
 ///
 /// *Note:* This constant's `TryFrom<Value>`, `Serialize` and `Deserialize`

--- a/src/game.rs
+++ b/src/game.rs
@@ -39,9 +39,44 @@ pub mod flags {
     game_map_access!(objects::Flag, Game.flags);
 }
 
-// TODO: See [http://docs.screeps.com/api/#Game.resources]
+/// See [http://docs.screeps.com/api/#Game.resources]
 ///
 /// [http://docs.screeps.com/api/#Game.resources]: http://docs.screeps.com/api/#Game.resources
+pub mod resources {
+    use std::collections::HashMap;
+
+    use crate::{constants::IntershardResourceType, macros::*};
+
+    /// Retrieve the full `HashMap<IntershardResourceType, u32>`.
+    pub fn hashmap() -> HashMap<IntershardResourceType, u32> {
+        // `TryFrom<Value>` is only implemented for `HashMap<String, V>`.
+        //
+        // See https://github.com/koute/stdweb/issues/359.
+        let map: HashMap<String, u32> = js_unwrap!(Game.resources);
+        map.into_iter()
+            .map(|(key, val)| {
+                (
+                    key.parse()
+                        .expect("expected resource key in Game.resources to be a known intershard resource type"),
+                    val,
+                )
+            })
+            .collect()
+    }
+
+    /// Retrieve the string keys of this object.
+    pub fn keys() -> Vec<IntershardResourceType> {
+        js_unwrap!(Object
+            .keys(Game.resources)
+            .map(__intershard_resource_type_str_to_num))
+    }
+
+    /// Retrieve a specific value by key.
+    pub fn get(key: IntershardResourceType) -> Option<u32> {
+        js_unwrap!(Game.resources[__intershard_resource_num_to_str(@{key as u32})])
+    }
+}
+
 /// See [http://docs.screeps.com/api/#Game.rooms]
 ///
 /// [http://docs.screeps.com/api/#Game.rooms]: http://docs.screeps.com/api/#Game.rooms

--- a/src/game.rs
+++ b/src/game.rs
@@ -73,7 +73,7 @@ pub mod resources {
 
     /// Retrieve a specific value by key.
     pub fn get(key: IntershardResourceType) -> Option<u32> {
-        js_unwrap!(Game.resources[__intershard_resource_num_to_str(@{key as u32})])
+        js_unwrap!(Game.resources[__intershard_resource_type_num_to_str(@{key as u32})])
     }
 }
 


### PR DESCRIPTION
This provides a way to access intershard / account-bound resources, which is currently just subscription tokens. https://docs.screeps.com/api/#Game.resources should no longer be missing!

I don't believe we had a tracking issue associated with this. I've tested `keys`, `get` and `hashmap`.