### PR TITLE
Clean up some internal macro syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 - Fix typos in JavaScript code for `game::market::get_order` and `Nuke::launch_room_name`
 - Add support for accessing intershard resource amounts, which currently only includes subscription
   tokens, under `game::resources`.
+- Remove remaining usages of internal `get_from_js!` macro, as it was minimally useful
 
 0.6.0 (2019-08-15)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 - Add support for accessing intershard resource amounts, which currently only includes subscription
   tokens, under `game::resources`.
 - Remove remaining usages of internal `get_from_js!` macro, as it was minimally useful
+- Improve syntax and consistency of some internal macros
 
 0.6.0 (2019-08-15)
 ==================

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -87,53 +87,6 @@ macro_rules! js_unwrap_ref {
     )
 }
 
-/// Creates a getter method to unwrap a field of a javascript object.
-///
-/// Macro Syntax (`$name` are expressions):
-///
-/// ```ignore
-/// get_from_js!($method_name -> {$js_statement} -> $rust_type)
-/// get_from_js!($method_name($param1, $param2, ...) -> {$js_statement} -> $rust_type)
-/// ```
-///
-/// Building on top of `js_unwrap!()`, this creates an accessor to a javascript
-/// object method or attribute.
-///
-/// # Example
-/// ```
-/// get_from_js!(
-///     limit -> {
-///         Game.cpu.limit
-///     } -> u32
-/// )
-/// ```
-///
-/// Will become:
-/// ```
-/// pub fn limit() -> u32 {
-///     js_unwrap!(Game.cpu.limit)
-/// }
-/// ```
-/// which would best be used inside the implementation for `cpu` in this case.
-macro_rules! get_from_js {
-    ($name:ident -> { $js_side:expr } -> $rust_ret_type:ty) => (
-        get_from_js!($name() -> { $js_side } -> $rust_ret_type);
-    );
-    (
-        $name:ident(
-            $($param_ident:ident: $param_ty:ty),*
-        ) -> {
-            $($js_side:tt)*
-        } -> $rust_ret_type:ty
-    ) => (
-        pub fn $name(
-            $($param_ident: $param_ty),*
-        ) -> $rust_ret_type {
-            js_unwrap!($($js_side)*)
-        }
-    )
-}
-
 /// Macro used to encapsulate all screeps game objects
 ///
 /// Macro syntax:

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -198,7 +198,7 @@ macro_rules! simple_accessors {
 /// (See `reference_wrapper` macro) which will support all `StructureProperties`
 /// methods.
 macro_rules! impl_structure_properties {
-    ( $( $struct_name:ty ),+ ) => {$(
+    ( $( $struct_name:ty ),+ $(,)? ) => {$(
         unsafe impl StructureProperties for $struct_name {}
     )*};
 }
@@ -218,7 +218,7 @@ macro_rules! impl_structure_properties {
 /// }
 /// ```
 macro_rules! impl_has_id {
-    ($($struct_name:ty);* $(;)*) => {$(
+    ($($struct_name:ty),+ $(,)?) => {$(
         unsafe impl HasId for $struct_name {}
 
         impl PartialEq for $struct_name {
@@ -487,8 +487,12 @@ macro_rules! match_some_structure_variants {
 
 /// Implements `Iterator` for `js_vec::IntoIter` or `js_vec::Iter`, using
 /// `FromExpectedType` and panicking on incorrect types.
+///
+/// Accepts a list of types to implement the traits for. Each type must be a
+/// single ident, optionally followed by `<'lifetime_param>` where
+/// `lifetime_param` is a single named lifetime.
 macro_rules! impl_js_vec_iterators_from_expected_type_panic {
-    ($($name:ident $(<$single_life_param:lifetime>)*),* $(,)*) => {
+    ($($name:ident $(<$single_life_param:lifetime>)*),+ $(,)?) => {
         $(
             impl<$($single_life_param, )* T> Iterator for $name<$($single_life_param, )* T>
             where
@@ -532,8 +536,12 @@ macro_rules! impl_js_vec_iterators_from_expected_type_panic {
 }
 
 /// Implements `Iterator` for `js_vec::IntoIter` or `js_vec::Iter`.
+///
+/// Accepts a list of types to implement the traits for. Each type must be a
+/// single ident, optionally followed by `<'lifetime_param>` where
+/// `lifetime_param` is a single named lifetime.
 macro_rules! impl_js_vec_iterators_from_expected_type_with_result {
-    ($($name:ident $(<$single_life_param:lifetime>)*),* $(,)*) => {
+    ($($name:ident $(<$single_life_param:lifetime>)*),+ $(,)?) => {
         $(
             impl<$($single_life_param, )* T> Iterator for $name<$($single_life_param, )* T>
             where

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -165,35 +165,35 @@ pub unsafe trait HasId: RoomObjectProperties {
 }
 
 impl_has_id! {
-    ConstructionSite;
-    Creep;
-    Mineral;
-    Nuke;
-    Resource;
-    Source;
-    OwnedStructure;
-    Structure;
-    StructureContainer;
-    StructureController;
-    StructureExtension;
-    StructureExtractor;
-    StructureKeeperLair;
-    StructureLab;
-    StructureLink;
-    StructureNuker;
-    StructureObserver;
-    StructurePowerBank;
-    StructurePowerSpawn;
-    StructurePortal;
-    StructureRampart;
-    StructureRoad;
-    StructureSpawn;
-    StructureStorage;
-    StructureTerminal;
-    StructureTower;
-    StructureWall;
-    Tombstone;
-    PowerCreep;
+    ConstructionSite,
+    Creep,
+    Mineral,
+    Nuke,
+    Resource,
+    Source,
+    OwnedStructure,
+    Structure,
+    StructureContainer,
+    StructureController,
+    StructureExtension,
+    StructureExtractor,
+    StructureKeeperLair,
+    StructureLab,
+    StructureLink,
+    StructureNuker,
+    StructureObserver,
+    StructurePowerBank,
+    StructurePowerSpawn,
+    StructurePortal,
+    StructureRampart,
+    StructureRoad,
+    StructureSpawn,
+    StructureStorage,
+    StructureTerminal,
+    StructureTower,
+    StructureWall,
+    Tombstone,
+    PowerCreep,
 }
 
 /// Trait for all wrappers over Screeps JavaScript objects extending

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -15,9 +15,9 @@ pub struct ForeignSegment {
 
 js_deserializable!(ForeignSegment);
 
-get_from_js!(get_active_segments -> {
-    Object.keys(RawMemory.segments).map(Number)
-} -> Vec<u32>);
+pub fn get_active_segments() -> Vec<u32> {
+    js_unwrap!(Object.keys(RawMemory.segments).map(Number))
+}
 
 /// Sets active segments (max 10 ids).
 pub fn set_active_segments(ids: &[u32]) {
@@ -30,9 +30,9 @@ pub fn set_active_segments(ids: &[u32]) {
     }
 }
 
-get_from_js!(get_segment(id: u32) -> {
-    RawMemory.segments[@{id}]
-} -> Option<String>);
+pub fn get_segment(id: u32) -> Option<String> {
+    js_unwrap!(RawMemory.segments[@{id}])
+}
 
 pub fn set_segment(id: u32, data: &str) {
     js! { @(no_return)
@@ -53,9 +53,9 @@ pub fn drop_segment(id: u32) {
     }
 }
 
-get_from_js!(get_foreign_segment -> {
-    RawMemory.foreignSegment
-} -> ForeignSegment);
+pub fn get_foreign_segment() -> ForeignSegment {
+    js_unwrap!(RawMemory.foreignSegment)
+}
 
 /// Implements `RawMemory.setActiveForeignSegment`
 ///
@@ -92,7 +92,9 @@ pub fn set_public_segments(ids: &[u32]) {
     }
 }
 
-get_from_js!(get -> {RawMemory.get()} -> String);
+pub fn get() -> String {
+    js_unwrap!(RawMemory.get())
+}
 
 pub fn set(value: &str) {
     js! { @(no_return)


### PR DESCRIPTION
This is just a bit of general cleanup of internal macros. The first commit removes `get_from_js!`, which I found mostly to hurt readability for very little gain. The second commit makes a few different macros which all accept lists of types consistent in using comma-separated input with one optional trailing comma.