### PR TITLE
Have internal macro syntax more closely resemble the rust code it produces

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -252,32 +252,32 @@ pub mod find {
     }
 
     typesafe_find_constants! {
-        CREEPS, 101, Creep;
-        MY_CREEPS, 102, Creep;
-        HOSTILE_CREEPS, 103, Creep;
-        SOURCES_ACTIVE, 104, Source;
-        SOURCES, 105, Source;
-        DROPPED_RESOURCES, 106, Resource;
-        STRUCTURES, 107, Structure;
-        MY_STRUCTURES, 108, OwnedStructure;
-        HOSTILE_STRUCTURES, 109, OwnedStructure;
-        FLAGS, 110, Flag;
-        CONSTRUCTION_SITES, 111, ConstructionSite;
-        MY_SPAWNS, 112, StructureSpawn;
-        HOSTILE_SPAWNS, 113, StructureSpawn;
-        MY_CONSTRUCTION_SITES, 114, ConstructionSite;
-        HOSTILE_CONSTRUCTION_SITES, 115, ConstructionSite;
-        MINERALS, 116, Mineral;
-        NUKES, 117, Nuke;
-        TOMBSTONES, 118, Tombstone;
-        POWER_CREEPS, 119, PowerCreep;
-        MY_POWER_CREEPS, 120, PowerCreep;
-        HOSTILE_POWER_CREEPS, 121, PowerCreep;
-        EXIT_TOP, Exit::Top as i16, Position;
-        EXIT_RIGHT, Exit::Right as i16, Position;
-        EXIT_BOTTOM, Exit::Bottom as i16, Position;
-        EXIT_LEFT, Exit::Left as i16, Position;
-        EXIT, Exit::All as i16, Position;
+        pub struct CREEPS = (101, Creep);
+        pub struct MY_CREEPS = (102, Creep);
+        pub struct HOSTILE_CREEPS = (103, Creep);
+        pub struct SOURCES_ACTIVE = (104, Source);
+        pub struct SOURCES = (105, Source);
+        pub struct DROPPED_RESOURCES = (106, Resource);
+        pub struct STRUCTURES = (107, Structure);
+        pub struct MY_STRUCTURES = (108, OwnedStructure);
+        pub struct HOSTILE_STRUCTURES = (109, OwnedStructure);
+        pub struct FLAGS = (110, Flag);
+        pub struct CONSTRUCTION_SITES = (111, ConstructionSite);
+        pub struct MY_SPAWNS = (112, StructureSpawn);
+        pub struct HOSTILE_SPAWNS = (113, StructureSpawn);
+        pub struct MY_CONSTRUCTION_SITES = (114, ConstructionSite);
+        pub struct HOSTILE_CONSTRUCTION_SITES = (115, ConstructionSite);
+        pub struct MINERALS = (116, Mineral);
+        pub struct NUKES = (117, Nuke);
+        pub struct TOMBSTONES = (118, Tombstone);
+        pub struct POWER_CREEPS = (119, PowerCreep);
+        pub struct MY_POWER_CREEPS = (120, PowerCreep);
+        pub struct HOSTILE_POWER_CREEPS = (121, PowerCreep);
+        pub struct EXIT_TOP = (Exit::Top as i16, Position);
+        pub struct EXIT_RIGHT = (Exit::Right as i16, Position);
+        pub struct EXIT_BOTTOM = (Exit::Bottom as i16, Position);
+        pub struct EXIT_LEFT = (Exit::Left as i16, Position);
+        pub struct EXIT = (Exit::All as i16, Position);
     }
 }
 
@@ -529,19 +529,19 @@ pub mod look {
     };
 
     typesafe_look_constants! {
-        CREEPS, Look::Creeps, Creep, IntoExpectedType::into_expected_type;
-        ENERGY, Look::Energy, Resource, IntoExpectedType::into_expected_type;
-        RESOURCES, Look::Resources, Resource, IntoExpectedType::into_expected_type;
-        SOURCES, Look::Sources, Source, IntoExpectedType::into_expected_type;
-        MINERALS, Look::Minerals, Mineral, IntoExpectedType::into_expected_type;
-        STRUCTURES, Look::Structures, Structure, IntoExpectedType::into_expected_type;
-        FLAGS, Look::Flags, Flag, IntoExpectedType::into_expected_type;
-        CONSTRUCTION_SITES, Look::ConstructionSites, ConstructionSite,
-            IntoExpectedType::into_expected_type;
-        NUKES, Look::Nukes, Nuke, IntoExpectedType::into_expected_type;
-        TERRAIN, Look::Terrain, Terrain, TryInto::try_into;
-        TOMBSTONES, Look::Tombstones, Tombstone, IntoExpectedType::into_expected_type;
-        POWER_CREEPS, Look::PowerCreeps, PowerCreep, IntoExpectedType::into_expected_type;
+        pub struct CREEPS = (Look::Creeps, Creep, IntoExpectedType::into_expected_type);
+        pub struct ENERGY = (Look::Energy, Resource, IntoExpectedType::into_expected_type);
+        pub struct RESOURCES = (Look::Resources, Resource, IntoExpectedType::into_expected_type);
+        pub struct SOURCES = (Look::Sources, Source, IntoExpectedType::into_expected_type);
+        pub struct MINERALS = (Look::Minerals, Mineral, IntoExpectedType::into_expected_type);
+        pub struct STRUCTURES = (Look::Structures, Structure, IntoExpectedType::into_expected_type);
+        pub struct FLAGS = (Look::Flags, Flag, IntoExpectedType::into_expected_type);
+        pub struct CONSTRUCTION_SITES = (Look::ConstructionSites, ConstructionSite,
+            IntoExpectedType::into_expected_type);
+        pub struct NUKES = (Look::Nukes, Nuke, IntoExpectedType::into_expected_type);
+        pub struct TERRAIN = (Look::Terrain, Terrain, TryInto::try_into);
+        pub struct TOMBSTONES = (Look::Tombstones, Tombstone, IntoExpectedType::into_expected_type);
+        pub struct POWER_CREEPS = (Look::PowerCreeps, PowerCreep, IntoExpectedType::into_expected_type);
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -168,15 +168,15 @@ macro_rules! reference_wrappers {
     (
         $(
             $(#[ $attr:meta ])*
-            $name:ident
-        ),* $(,)*
+            $vis:vis struct $name:ident(...);
+        )+
     ) => {
         $(
             #[derive(Clone, ReferenceType)]
             $(
                 #[$attr]
             )*
-            pub struct $name(Reference);
+            $vis struct $name(Reference);
 
             impl crate::traits::FromExpectedType<Reference> for $name {
                 fn from_expected_type(reference: Reference) -> Result<Self, ConversionError> {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -290,10 +290,12 @@ macro_rules! impl_has_id {
 ///
 /// Macro Syntax:
 /// ```ignore
-/// creep_simple_generic_action!{
-///     ($rust_method_name1($action_target_trait1) -> js_method_name1),
-///     ($rust_method_name2($action_target_trait2) -> js_method_name2),
-///     ...
+/// creep_simple_generic_action! {
+///     impl Creep {
+///         pub fn $rust_method_name1($action_target_trait1) = js_method_name1();
+///         pub fn $rust_method_name2($action_target_trait2) = js_method_name2();
+///         ...
+///     }
 /// }
 /// ```
 ///
@@ -302,10 +304,16 @@ macro_rules! impl_has_id {
 /// The generic comes from the fact that this implements the method to be able
 /// to target any object that conforms to the `action_target_trait` trait.
 macro_rules! creep_simple_generic_action {
-    ($(($method:ident($trait:ident) -> $js_name:ident)),* $(,)*) => (
-        impl Creep {
+    (
+        impl $struct_name:ident {
             $(
-                pub fn $method<T>(&self, target: &T) -> ReturnCode
+                $vis:vis fn $method:ident($trait:ident) = $js_name:ident ();
+            )+
+        }
+    ) => (
+        impl $struct_name {
+            $(
+                $vis fn $method<T>(&self, target: &T) -> ReturnCode
                 where
                     T: ?Sized + $trait,
                 {
@@ -323,10 +331,12 @@ macro_rules! creep_simple_generic_action {
 ///
 /// Macro Syntax:
 /// ```ignore
-/// creep_simple_generic_action!{
-///     ($rust_method_name1($target_type1) -> js_method_name1),
-///     ($rust_method_name2($target_type2) -> js_method_name2),
-///     ...
+/// creep_simple_generic_action! {
+///     impl Creep {
+///         pub fn $rust_method_name1($target_type1) = js_method_name1();
+///         pub fn $rust_method_name2($target_type2) = js_method_name2();
+///         ...
+///     }
 /// }
 /// ```
 ///
@@ -335,10 +345,16 @@ macro_rules! creep_simple_generic_action {
 /// The concrete comes from the fact that this implements the method to be able
 /// to target only the `type` given.
 macro_rules! creep_simple_concrete_action {
-    ($(($method:ident($type:ty) -> $js_name:ident)),* $(,)*) => (
+    (
+        impl $struct_name:ident {
+            $(
+                $vis:vis fn $method:ident($type:ty) = $js_name:ident ();
+            )+
+        }
+    ) => (
         impl Creep {
             $(
-                pub fn $method(&self, target: &$type) -> ReturnCode {
+                $vis fn $method(&self, target: &$type) -> ReturnCode {
                     js_unwrap!(@{self.as_ref()}.$js_name(@{target.as_ref()}))
                 }
             )*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -203,18 +203,23 @@ macro_rules! reference_wrappers {
 /// Method Syntax:
 ///
 /// ```ignore
-/// simple_accessor! {
-///     $struct_name;
-///     ($rust_method_name1 -> $js_field_name1 -> $rust_type1),
-///     ($rust_method_name2 -> $js_field_name2 -> $rust_type2),
-///     ...
+/// simple_accessors! {
+///     impl $struct_name {
+///         pub fn $rust_method_name1() -> $rust_type1 = $js_field_name1;
+///         pub fn $rust_method_name2() -> $rust_type2 = $js_field_name2;
+///         ...
+///     }
 /// }
 /// ```
 macro_rules! simple_accessors {
-    ($struct_name:ident; $(($method:ident -> $prop:ident -> $ret:ty)),* $(,)*) => (
+    (impl $struct_name:ident {
+        $(
+            $vis:vis fn $method:ident () -> $ret:ty = $prop:ident;
+        )+
+    }) => (
         impl $struct_name {
             $(
-                pub fn $method(&self) -> $ret {
+                $vis fn $method(&self) -> $ret {
                     js_unwrap!(@{self.as_ref()}.$prop)
                 }
             )*

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -382,7 +382,7 @@ macro_rules! calculated_doc {
 macro_rules! typesafe_find_constants {
     (
         $(
-            $constant_name:ident, $value:expr, $result:path;
+            $vis:vis struct $constant_name:ident = ($value:expr, $result:path);
         )*
     ) => (
         $(
@@ -394,7 +394,7 @@ macro_rules! typesafe_find_constants {
                 )]
                 #[allow(bad_style)]
                 #[derive(Copy, Clone, Debug, Default)]
-                pub struct $constant_name;
+                $vis struct $constant_name;
             }
             unsafe impl FindConstant for $constant_name {
                 type Item = $result;
@@ -410,11 +410,13 @@ macro_rules! typesafe_find_constants {
 
 macro_rules! typesafe_look_constants {
     (
-        $($constant_name:ident, $value:expr, $result:path, $conversion_method:expr;)*
+        $(
+            $vis:vis struct $constant_name:ident = ($value:expr, $result:path, $conversion_method:expr);
+        )*
     ) => (
         $(
             #[allow(bad_style)]
-            pub struct $constant_name;
+            $vis struct $constant_name;
             unsafe impl LookConstant for $constant_name {
                 type Item = $result;
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -37,77 +37,77 @@ pub use self::{
     structure::Structure,
 };
 
-reference_wrappers!(
+reference_wrappers! {
     #[reference(instance_of = "ConstructionSite")]
-    ConstructionSite,
+    pub struct ConstructionSite(...);
     #[reference(instance_of = "Creep")]
-    Creep,
+    pub struct Creep(...);
     #[reference(instance_of = "Flag")]
-    Flag,
+    pub struct Flag(...);
     #[reference(instance_of = "Mineral")]
-    Mineral,
+    pub struct Mineral(...);
     #[reference(instance_of = "Nuke")]
-    Nuke,
+    pub struct Nuke(...);
     #[reference(instance_of = "OwnedStructure")]
-    OwnedStructure,
+    pub struct OwnedStructure(...);
     #[reference(instance_of = "Resource")]
-    Resource,
+    pub struct Resource(...);
     #[reference(instance_of = "Room")]
-    Room,
+    pub struct Room(...);
     #[reference(instance_of = "RoomObject")]
-    RoomObject,
+    pub struct RoomObject(...);
     #[reference(instance_of = "Room.Terrain")]
-    RoomTerrain,
+    pub struct RoomTerrain(...);
     #[reference(instance_of = "Source")]
-    Source,
+    pub struct Source(...);
     #[reference(instance_of = "StructureContainer")]
-    StructureContainer,
+    pub struct StructureContainer(...);
     #[reference(instance_of = "StructureController")]
-    StructureController,
+    pub struct StructureController(...);
     #[reference(instance_of = "StructureExtension")]
-    StructureExtension,
+    pub struct StructureExtension(...);
     #[reference(instance_of = "StructureExtractor")]
-    StructureExtractor,
+    pub struct StructureExtractor(...);
     #[reference(instance_of = "StructureKeeperLair")]
-    StructureKeeperLair,
+    pub struct StructureKeeperLair(...);
     #[reference(instance_of = "StructureLab")]
-    StructureLab,
+    pub struct StructureLab(...);
     #[reference(instance_of = "StructureLink")]
-    StructureLink,
+    pub struct StructureLink(...);
     #[reference(instance_of = "StructureNuker")]
-    StructureNuker,
+    pub struct StructureNuker(...);
     #[reference(instance_of = "StructureObserver")]
-    StructureObserver,
+    pub struct StructureObserver(...);
     #[reference(instance_of = "StructurePowerBank")]
-    StructurePowerBank,
+    pub struct StructurePowerBank(...);
     #[reference(instance_of = "StructurePowerSpawn")]
-    StructurePowerSpawn,
+    pub struct StructurePowerSpawn(...);
     #[reference(instance_of = "StructurePortal")]
-    StructurePortal,
+    pub struct StructurePortal(...);
     #[reference(instance_of = "StructureRampart")]
-    StructureRampart,
+    pub struct StructureRampart(...);
     #[reference(instance_of = "StructureRoad")]
-    StructureRoad,
+    pub struct StructureRoad(...);
     #[reference(instance_of = "StructureSpawn")]
-    StructureSpawn,
+    pub struct StructureSpawn(...);
     #[reference(instance_of = "Spawning")]
-    Spawning,
+    pub struct Spawning(...);
     #[reference(instance_of = "StructureStorage")]
-    StructureStorage,
+    pub struct StructureStorage(...);
     #[reference(instance_of = "StructureTerminal")]
-    StructureTerminal,
+    pub struct StructureTerminal(...);
     #[reference(instance_of = "StructureTower")]
-    StructureTower,
+    pub struct StructureTower(...);
     #[reference(instance_of = "StructureWall")]
-    StructureWall,
+    pub struct StructureWall(...);
     // this is implemented later
     // #[reference(instance_of = "Structure")]
-    // Structure,
+    // pub struct Structure,
     #[reference(instance_of = "Tombstone")]
-    Tombstone,
+    pub struct Tombstone(...);
     #[reference(instance_of = "PowerCreep")]
-    PowerCreep,
-);
+    pub struct PowerCreep(...);
+}
 
 /// Trait for things which have positions in the Screeps world.
 ///

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -6,10 +6,11 @@ use crate::{
 };
 
 simple_accessors! {
-    ConstructionSite;
-    (my -> my -> bool),
-    (progress -> progress -> u32),
-    (progress_total -> progressTotal -> u32),
+    impl ConstructionSite {
+        pub fn my() -> bool = my;
+        pub fn progress() -> u32 = progress;
+        pub fn progress_total() -> u32 = progressTotal;
+    }
 }
 
 impl ConstructionSite {

--- a/src/objects/impls/container.rs
+++ b/src/objects/impls/container.rs
@@ -1,6 +1,7 @@
 use crate::{macros::*, objects::StructureContainer};
 
 simple_accessors! {
-    StructureContainer;
-    (ticks_to_decay -> ticksToDecay -> u32),
+    impl StructureContainer {
+        pub fn ticks_to_decay() -> u32 = ticksToDecay;
+    }
 }

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -292,14 +292,15 @@ pub struct Bodypart {
 }
 
 simple_accessors! {
-    Creep;
-    (carry_capacity -> carryCapacity -> u32),
-    (fatigue -> fatigue -> u32),
-    (name -> name -> String),
-    (my -> my -> bool),
-    (saying -> saying -> String),
-    (spawning -> spawning -> bool),
-    (ticks_to_live -> ticksToLive -> u32),
+    impl Creep {
+        pub fn carry_capacity() -> u32 = carryCapacity;
+        pub fn fatigue() -> u32 = fatigue;
+        pub fn name() -> String = name;
+        pub fn my() -> bool = my;
+        pub fn saying() -> String = saying;
+        pub fn spawning() -> bool = spawning;
+        pub fn ticks_to_live() -> u32 = ticksToLive;
+    }
 }
 
 creep_simple_generic_action! {

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -304,24 +304,28 @@ simple_accessors! {
 }
 
 creep_simple_generic_action! {
-    (attack(Attackable) -> attack),
-    (dismantle(StructureProperties) -> dismantle),
-    (ranged_attack(Attackable) -> rangedAttack),
-    (repair(StructureProperties) -> repair),
+    impl Creep {
+        pub fn attack(Attackable) = attack();
+        pub fn dismantle(StructureProperties) = dismantle();
+        pub fn ranged_attack(Attackable) = rangedAttack();
+        pub fn repair(StructureProperties) = repair();
+    }
 }
 
 creep_simple_concrete_action! {
-    (attack_controller(StructureController) -> attackController),
-    (build(ConstructionSite) -> build),
-    (claim_controller(StructureController) -> claimController),
-    (generate_safe_mode(StructureController) -> generateSafeMode),
-    (harvest(Source) -> harvest),
-    (heal(Creep) -> heal),
-    (pickup(Resource) -> pickup),
-    (pull(Creep) -> pull),
-    (ranged_heal(Creep) -> rangedHeal),
-    (reserve_controller(StructureController) -> reserveController),
-    (upgrade_controller(StructureController) -> upgradeController),
+    impl Creep {
+        pub fn attack_controller(StructureController) = attackController();
+        pub fn build(ConstructionSite) = build();
+        pub fn claim_controller(StructureController) = claimController();
+        pub fn generate_safe_mode(StructureController) = generateSafeMode();
+        pub fn harvest(Source) = harvest();
+        pub fn heal(Creep) = heal();
+        pub fn pickup(Resource) = pickup();
+        pub fn pull(Creep) = pull();
+        pub fn ranged_heal(Creep) = rangedHeal();
+        pub fn reserve_controller(StructureController) = reserveController();
+        pub fn upgrade_controller(StructureController) = upgradeController();
+    }
 }
 
 pub struct MoveToOptions<'a, F>

--- a/src/objects/impls/flag.rs
+++ b/src/objects/impls/flag.rs
@@ -8,10 +8,11 @@ use crate::{
 };
 
 simple_accessors! {
-    Flag;
-    (color -> color -> Color),
-    (name -> name -> String),
-    (secondary_color -> secondaryColor -> Color),
+    impl Flag {
+        pub fn color() -> Color = color;
+        pub fn name() -> String = name;
+        pub fn secondary_color() -> Color = secondaryColor;
+    }
 }
 
 impl Flag {

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -5,11 +5,12 @@ use crate::{
 };
 
 simple_accessors! {
-    Mineral;
-    (density -> density -> u32),
-    (mineral_amount -> mineralAmount -> Density),
-    // id from HasId trait
-    (ticks_to_regeneration -> ticksToRegeneration -> u32),
+    impl Mineral {
+        pub fn density() -> u32 = density;
+        pub fn mineral_amount() -> Density = mineralAmount;
+        // id from HasId trait
+        pub fn ticks_to_regeneration() -> u32 = ticksToRegeneration;
+    }
 }
 
 impl Mineral {

--- a/src/objects/impls/nuke.rs
+++ b/src/objects/impls/nuke.rs
@@ -1,8 +1,9 @@
 use crate::{local::RoomName, macros::*, objects::Nuke};
 
 simple_accessors! {
-    Nuke;
-    // id from HasID
-    (launch_room_name -> launchRoomName -> RoomName),
-    (time_to_land -> timeToLand -> u32),
+    impl Nuke {
+        // id from HasID
+        pub fn launch_room_name() -> RoomName = launchRoomName;
+        pub fn time_to_land() -> u32 = timeToLand;
+    }
 }

--- a/src/objects/impls/resource.rs
+++ b/src/objects/impls/resource.rs
@@ -7,6 +7,7 @@ impl Resource {
 }
 
 simple_accessors! {
-    Resource;
-    (amount -> amount -> u32),
+    impl Resource {
+        pub fn amount() -> u32 = amount;
+    }
 }

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -30,14 +30,15 @@ use crate::{
 };
 
 simple_accessors! {
-    Room;
-    (controller -> controller -> Option<StructureController>),
-    (energy_available -> energyAvailable -> u32),
-    (energy_capacity_available -> energyCapacityAvailable -> u32),
-    (name -> name -> RoomName),
-    (storage -> storage -> Option<StructureStorage>),
-    (terminal -> terminal -> Option<StructureTerminal>),
-    // todo: visual
+    impl Room {
+        pub fn controller() -> Option<StructureController> = controller;
+        pub fn energy_available() -> u32 = energyAvailable;
+        pub fn energy_capacity_available() -> u32 = energyCapacityAvailable;
+        pub fn name() -> RoomName = name;
+        pub fn storage() -> Option<StructureStorage> = storage;
+        pub fn terminal() -> Option<StructureTerminal> = terminal;
+        // todo: visual
+    }
 }
 
 scoped_thread_local!(static COST_CALLBACK: &'static dyn Fn(RoomName, Reference) -> Option<Reference>);

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -1,8 +1,9 @@
 use crate::{macros::*, objects::Source};
 
 simple_accessors! {
-    Source;
-    (energy -> energy -> u32),
-    (energy_capacity -> energyCapacity -> u32),
-    (ticks_to_regeneration -> ticksToRegeneration -> u32),
+    impl Source {
+        pub fn energy() -> u32 = energy;
+        pub fn energy_capacity() -> u32 = energyCapacity;
+        pub fn ticks_to_regeneration() -> u32 = ticksToRegeneration;
+    }
 }

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -3,15 +3,16 @@ use stdweb::Value;
 use crate::{constants::ReturnCode, macros::*, objects::StructureController};
 
 simple_accessors! {
-    StructureController;
-    (level -> level -> u32),
-    (progress -> progress -> Option<u32>),
-    (progress_total -> progressTotal -> Option<u32>),
-    (safe_mode -> safeMode -> Option<u32>),
-    (safe_mode_available -> safeModeAvailable -> u32),
-    (safe_mode_cooldown -> safeModeCooldown -> Option<u32>),
-    (ticks_to_downgrade -> ticksToDowngrade -> u32),
-    (upgrade_blocked -> upgradeBlocked -> Option<u32>)
+    impl StructureController {
+        pub fn level() -> u32 = level;
+        pub fn progress() -> Option<u32> = progress;
+        pub fn progress_total() -> Option<u32> = progressTotal;
+        pub fn safe_mode() -> Option<u32> = safeMode;
+        pub fn safe_mode_available() -> u32 = safeModeAvailable;
+        pub fn safe_mode_cooldown() -> Option<u32> = safeModeCooldown;
+        pub fn ticks_to_downgrade() -> u32 = ticksToDowngrade;
+        pub fn upgrade_blocked() -> Option<u32> = upgradeBlocked;
+    }
 }
 
 #[derive(Debug)]

--- a/src/objects/impls/structure_keeper_lair.rs
+++ b/src/objects/impls/structure_keeper_lair.rs
@@ -1,6 +1,7 @@
 use crate::{macros::*, objects::StructureKeeperLair};
 
 simple_accessors! {
-    StructureKeeperLair;
-    (ticks_to_spawn -> ticksToSpawn -> u32),
+    impl StructureKeeperLair {
+        pub fn ticks_to_spawn() -> u32 = ticksToSpawn;
+    }
 }

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -5,10 +5,11 @@ use crate::{
 };
 
 simple_accessors! {
-    StructureLab;
-    (mineral_amount -> mineralAmount -> u32),
-    // mineralType
-    (mineral_capacity -> mineralCapacity -> u32),
+    impl StructureLab {
+        pub fn mineral_amount() -> u32 = mineralAmount;
+        // mineralType
+        pub fn mineral_capacity() -> u32 = mineralCapacity;
+    }
 }
 
 impl StructureLab {

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -5,9 +5,10 @@ use crate::{
 };
 
 simple_accessors! {
-    StructureNuker;
-    (ghodium -> ghodium -> u32),
-    (ghodium_capacity -> ghodiumCapacity -> u32),
+    impl StructureNuker {
+        pub fn ghodium() -> u32 = ghodium;
+        pub fn ghodium_capacity() -> u32 = ghodiumCapacity;
+    }
 }
 
 impl StructureNuker {

--- a/src/objects/impls/structure_power_bank.rs
+++ b/src/objects/impls/structure_power_bank.rs
@@ -1,6 +1,7 @@
 use crate::{macros::*, objects::StructurePowerBank};
 
 simple_accessors! {
-    StructurePowerBank;
-    (power -> power -> u32),
+    impl StructurePowerBank {
+        pub fn power() -> u32 = power;
+    }
 }

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -1,9 +1,10 @@
 use crate::{constants::ReturnCode, macros::*, objects::StructurePowerSpawn};
 
 simple_accessors! {
-    StructurePowerSpawn;
-    (power -> power -> u32),
-    (power_capacity -> powerCapacity -> u32),
+    impl StructurePowerSpawn {
+        pub fn power() -> u32 = power;
+        pub fn power_capacity() -> u32 = powerCapacity;
+    }
 }
 
 impl StructurePowerSpawn {

--- a/src/objects/impls/structure_rampart.rs
+++ b/src/objects/impls/structure_rampart.rs
@@ -1,8 +1,9 @@
 use crate::{constants::ReturnCode, macros::*, objects::StructureRampart};
 
 simple_accessors! {
-    StructureRampart;
-    (is_public -> isPublic -> bool),
+    impl StructureRampart {
+        pub fn is_public() -> bool = isPublic;
+    }
 }
 
 impl StructureRampart {

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -9,9 +9,10 @@ use crate::{
 };
 
 simple_accessors! {
-    StructureSpawn;
-    (name -> name -> String),
-    (spawning -> spawning -> Option<Spawning>),
+    impl StructureSpawn {
+        pub fn name() -> String = name;
+        pub fn spawning() -> Option<Spawning> = spawning;
+    }
 }
 
 impl StructureSpawn {
@@ -118,12 +119,13 @@ impl SpawnOptions {
 }
 
 simple_accessors! {
-    Spawning;
-    (directions -> directions -> Vec<Direction>),
-    (name -> name -> String),
-    (need_time -> needTime -> u32),
-    (remaining_time -> remainingTime -> u32),
-    (spawn -> spawn -> StructureSpawn),
+    impl Spawning {
+        pub fn directions() -> Vec<Direction> = directions;
+        pub fn name() -> String = name;
+        pub fn need_time() -> u32 = needTime;
+        pub fn remaining_time() -> u32 = remainingTime;
+        pub fn spawn() -> StructureSpawn = spawn;
+    }
 }
 
 impl Spawning {

--- a/src/objects/impls/tombstone.rs
+++ b/src/objects/impls/tombstone.rs
@@ -4,8 +4,9 @@ use crate::{
 };
 
 simple_accessors! {
-    Tombstone;
-    (creep -> creep -> Creep),
-    (death_time -> deathTime -> u32),
-    (ticks_to_decay -> ticksToDecay -> u32),
+    impl Tombstone {
+        pub fn creep() -> Creep = creep;
+        pub fn death_time() -> u32 = deathTime;
+        pub fn ticks_to_decay() -> u32 = ticksToDecay;
+    }
 }


### PR DESCRIPTION
This changes a number of macros which produce either functions, methods or types to have macro input syntax more closely resembling the code it produces.

I'm hoping this will help newcomers to the codebase understand what things do a bit more, without having to dig into macro internals. 

The new macro syntax should includes visibility of types/methods produced, requires specifying `fn` / `struct` in the syntax, and uses `=` rather than `,` for the separator between the ident of what's being created and special values used by the macro (like JS names, or types in typesafe_*_constants).

Combined with #234, this closes #28.