### PR TITLE
Fix typo where some RATIO constants were called RATIONs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 
 - Rename incorrectly spelled `Density::probabilitiy` to `probability`.
 - Rename incorrectly spelled `Nuke::lauch_room_name` to `launch_room_name`.
+- Rename constants with typo `SPAWN_RENEW_RATION` and  `LINK_LOSS_RATION` to `SPAWN_RENEW_RATIO`
+  and `LINK_LOSS_RATIO` respectively
 - Change return type of `game::rooms::keys` from `Vec<String>` to `Vec<RoomName>`
 - Fix typos in JavaScript code for `game::market::get_order` and `Nuke::launch_room_name`
 - Add support for accessing intershard resource amounts, which currently only includes subscription

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -660,7 +660,7 @@ pub const SPAWN_HITS: u32 = 5000;
 pub const SPAWN_ENERGY_START: u32 = 300;
 pub const SPAWN_ENERGY_CAPACITY: u32 = 300;
 pub const CREEP_SPAWN_TIME: u32 = 3;
-pub const SPAWN_RENEW_RATION: f32 = 1.2;
+pub const SPAWN_RENEW_RATIO: f32 = 1.2;
 
 pub const SOURCE_ENERGY_CAPACITY: u32 = 3000;
 pub const SOURCE_ENERGY_NEUTRAL_CAPACITY: u32 = 1500;
@@ -690,7 +690,7 @@ pub const ROAD_DECAY_TIME: u32 = 1000;
 pub const LINK_HITS: u32 = 1000;
 pub const LINK_CAPACITY: u32 = 800;
 pub const LINK_COOLDOWN: u32 = 1;
-pub const LINK_LOSS_RATION: f32 = 0.03;
+pub const LINK_LOSS_RATIO: f32 = 0.03;
 
 pub const STORAGE_CAPACITY: u32 = 1_000_000;
 pub const STORAGE_HITS: u32 = 10_000;


### PR DESCRIPTION
Apologies for this! I this typo originates back from the beginning of screeps-rust-api.