### PR TITLE
Implement Ord for Position, RoomName, ObjectId and RawObjectId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Unreleased
 - Fix typos in JavaScript code for `game::market::get_order` and `Nuke::launch_room_name`
 - Add support for accessing intershard resource amounts, which currently only includes subscription
   tokens, under `game::resources`.
+- Implement `PartialOrd` and `Ord` for `Position`, `RoomName`, `RawObjectId` and `ObjectId`. See
+  documentation for ordering specifications.
 - Remove remaining usages of internal `get_from_js!` macro, as it was minimally useful
 - Improve syntax and consistency of some internal macros
 

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -25,7 +25,20 @@ const MAX_PACKED_VAL: u128 = (1 << (32 * 3)) - 1;
 /// To convert to a String in JavaScript, either use
 /// [`RawObjectId::to_array_string`], or [`RawObjectId::unsafe_as_uploaded`].
 /// See method documentation for more information.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// # Ordering
+///
+/// To facilitate use as a key in a [`BTreeMap`] or other similar data
+/// structures, `ObjectId` implements [`PartialOrd`] and [`Ord`].
+///
+/// `RawObjectId`'s are ordered by the corresponding order of their underlying
+/// byte values. See [`ObjectId`] documentation for more information.
+///
+/// [`BTreeMap`]: std::collections::BTreeMap
+/// [`Ord`]: std::cmp::Ord
+/// [`PartialOrd`]: std::cmp::PartialOrd
+/// [`ObjectId`]: super::ObjectId
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, PartialOrd, Ord)]
 #[serde(transparent)]
 pub struct RawObjectId {
     packed: [u32; 3],

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -23,6 +23,8 @@ pub struct RoomName {
     ///
     /// This is the same representation of the upper 16 bits of [`Position`]'s
     /// packed representation.
+    ///
+    /// [`Position`]: crate::local::Position
     packed: u16,
 }
 

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -1,4 +1,5 @@
 use std::{
+    cmp::{Ord, Ordering, PartialOrd},
     error,
     fmt::{self, Write},
     ops,
@@ -10,6 +11,22 @@ use arrayvec::ArrayString;
 use super::{HALF_WORLD_SIZE, VALID_ROOM_NAME_COORDINATES};
 
 /// A structure representing a room name.
+///
+/// # Ordering
+///
+/// To facilitate use as a key in a [`BTreeMap`] or other similar data
+/// structures, `RoomName` implements [`PartialOrd`] and [`Ord`].
+///
+/// `RoomName`s are ordered first by y position, then by x position. North is
+/// considered less than south, and west less than east.
+///
+/// The total ordering is `N127W127`, `N127W126`, `N127W125`, ..., `N127W0`,
+/// `N127E0`, ..., `N127E127`, `N126W127`, ..., `S127E126`, `S127E127`.
+///
+/// This follows left-to-right reading order when looking at the Screeps map
+/// from above.
+///
+/// [`BTreeMap`]: std::collections::BTreeMap
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct RoomName {
     /// A bit-packed integer, containing, from highest-order to lowest:
@@ -360,6 +377,21 @@ impl PartialEq<RoomName> for &String {
     #[inline]
     fn eq(&self, other: &RoomName) -> bool {
         <RoomName as PartialEq<str>>::eq(other, self)
+    }
+}
+
+impl PartialOrd for RoomName {
+    #[inline]
+    fn partial_cmp(&self, other: &RoomName) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RoomName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.y_coord()
+            .cmp(&other.y_coord())
+            .then_with(|| self.x_coord().cmp(&other.x_coord()))
     }
 }
 


### PR DESCRIPTION
This implements half of #226! `ObjectId` and `RawObjectId` are per the specification from my last comment, and `Position` / `RoomName` sort by `y` first rather than by `x` first.