### PR TITLE
Padded IDs to a minimum length of 15, in lieu of a better option

### DIFF
--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -273,7 +273,7 @@ function object_id_from_packed(slice) {
            res += slice[i].toString(16);
        }
     }
-    return res;
+    return res.padStart(15, "0");
 }
 
 function object_id_to_packed(id) {


### PR DESCRIPTION
Hack to fix #244. Some other means of detection for activation, such as the one specified in 244's issue, may be better suited as a long-term fix, but at least this gets us unblocked.