### PR TITLE
Fix build - switch back to 2015-style macro_use imports for stdweb

### DIFF
--- a/src/constants/look.rs
+++ b/src/constants/look.rs
@@ -19,7 +19,6 @@ use stdweb::Value;
 
 use super::Terrain;
 use crate::{
-    macros::*,
     objects::{
         ConstructionSite, Creep, Flag, Mineral, Nuke, PowerCreep, Resource, Source, Structure,
         Tombstone,

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -14,7 +14,6 @@ use super::{
     find,
     numbers::{TERRAIN_MASK_SWAMP, TERRAIN_MASK_WALL},
 };
-use crate::macros::*;
 
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, FromPrimitive, Hash, Deserialize_repr, Serialize_repr,

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -9,8 +9,6 @@ use serde::{
 };
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::macros::*;
-
 /// Translates `STRUCTURE_*` constants.
 ///
 /// *Note:* This constant's `TryFrom<Value>`, `Serialize` and `Deserialize`

--- a/src/game.rs
+++ b/src/game.rs
@@ -6,7 +6,6 @@
 //! [`Game`]: http://docs.screeps.com/api/#Game
 use crate::{
     local::{ObjectId, RawObjectId},
-    macros::*,
     objects::{HasId, RoomObject, SizedRoomObject},
     traits::TryInto,
     ConversionError,
@@ -45,7 +44,7 @@ pub mod flags {
 pub mod resources {
     use std::collections::HashMap;
 
-    use crate::{constants::IntershardResourceType, macros::*};
+    use crate::constants::IntershardResourceType;
 
     /// Retrieve the full `HashMap<IntershardResourceType, u32>`.
     pub fn hashmap() -> HashMap<IntershardResourceType, u32> {
@@ -83,7 +82,7 @@ pub mod resources {
 pub mod rooms {
     use std::collections::HashMap;
 
-    use crate::{local::RoomName, macros::*, objects::Room};
+    use crate::{local::RoomName, objects::Room};
 
     /// Retrieve the full `HashMap<RoomName, Room>`.
     pub fn hashmap() -> HashMap<RoomName, Room> {

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -5,7 +5,7 @@ use std::collections;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{constants::ReturnCode, macros::*, traits::TryInto};
+use crate::{constants::ReturnCode, traits::TryInto};
 
 /// See [`v8_getheapstatistics`]
 ///

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -1,7 +1,6 @@
 //! See [http://docs.screeps.com/api/#Game.gcl]
 //!
 //! [http://docs.screeps.com/api/#Game.gcl]: http://docs.screeps.com/api/#Game.gcl
-use crate::macros::*;
 
 /// See [http://docs.screeps.com/api/#Game.gcl]
 ///

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -11,7 +11,6 @@ use stdweb::Value;
 use crate::{
     constants::{Direction, ExitDirection, ReturnCode},
     local::RoomName,
-    macros::*,
     objects::RoomTerrain,
     traits::{TryFrom, TryInto},
 };

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -13,7 +13,6 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::{
     constants::{ResourceType, ReturnCode},
     local::RoomName,
-    macros::*,
     traits::TryInto,
     Room,
 };

--- a/src/game/shards.rs
+++ b/src/game/shards.rs
@@ -1,7 +1,6 @@
 //! See [http://docs.screeps.com/api/#Game.shard]
 //!
 //! [http://docs.screeps.com/api/#Game.shard]: http://docs.screeps.com/api/#Game.shard
-use crate::macros::*;
 
 /// See [http://docs.screeps.com/api/#Game.shard]
 ///

--- a/src/inter_shard_memory.rs
+++ b/src/inter_shard_memory.rs
@@ -15,7 +15,6 @@
 //! > container.
 //!
 //! [`InterShardMemory`]: https://docs.screeps.com/api/#InterShardMemory
-use crate::macros::*;
 
 /// Returns the string contents of the current shard's data.
 pub fn get_local() -> String {

--- a/src/js_collections/js_vec.rs
+++ b/src/js_collections/js_vec.rs
@@ -1,6 +1,5 @@
 //! [`JsVec`]
 use crate::{
-    macros::*,
     traits::{FromExpectedType, IntoExpectedType, TryFrom, TryInto},
     ConversionError,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@
 #![recursion_limit = "128"]
 
 #[macro_use]
+extern crate stdweb;
+
+#[macro_use]
 pub mod macros;
 
 pub mod constants;

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -9,7 +9,6 @@ use stdweb::{Reference, UnsafeTypedArray};
 
 use super::errors::RawObjectIdParseError;
 use crate::{
-    macros::*,
     traits::{TryFrom, TryInto},
     ConversionError,
 };

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -404,7 +404,6 @@ mod serde {
     };
 
     use super::RoomName;
-    use crate::macros::*;
 
     impl Serialize for RoomName {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/local/room_position.rs
+++ b/src/local/room_position.rs
@@ -365,10 +365,7 @@ impl Ord for Position {
 mod stdweb {
     use stdweb::{Reference, Value};
 
-    use crate::{
-        macros::*,
-        traits::{TryFrom, TryInto},
-    };
+    use crate::traits::{TryFrom, TryInto};
 
     use super::Position;
 

--- a/src/local/room_position/game_methods.rs
+++ b/src/local/room_position/game_methods.rs
@@ -3,7 +3,6 @@ use crate::{
     constants::{Color, FindConstant, LookConstant, ReturnCode, StructureType},
     game,
     local::RoomName,
-    macros::*,
     objects::{FindOptions, Flag, HasPosition, LookResult, Path},
     pathfinder::CostMatrix,
 };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,11 +9,6 @@
 //!
 //! [macro-book]: https://danielkeep.github.io/tlborm/book/mbe-README.html
 
-pub use stdweb::{
-    __js_deserializable_serde_boilerplate, __js_raw_asm, __js_serializable_boilerplate,
-    __js_serializable_serde_boilerplate, _js_impl, js, js_deserializable, js_serializable,
-};
-
 /// Used to get data from a javascript reference back into rust code.
 ///
 /// Macro syntax (`$name` are expressions):
@@ -411,7 +406,7 @@ macro_rules! game_map_access {
     ($type:path, $js_inner:expr $(,)?) => {
         use std::collections::HashMap;
 
-        use crate::{macros::*, objects};
+        use crate::{objects};
 
         calculated_doc! {
             #[doc = concat!("Retrieve the full `HashMap<String, ",

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -57,7 +57,6 @@ use std::fmt;
 use stdweb::{JsSerialize, Reference, Value};
 
 use crate::{
-    macros::*,
     traits::{TryFrom, TryInto},
     ConversionError,
 };

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -19,7 +19,6 @@ use stdweb_derive::ReferenceType;
 use crate::{
     constants::{ResourceType, ReturnCode, StructureType},
     local::{ObjectId, Position, RawObjectId},
-    macros::*,
     traits::{IntoExpectedType, TryFrom, TryInto},
     ConversionError,
 };

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -1,6 +1,5 @@
 use crate::{
     constants::{ReturnCode, StructureType},
-    macros::*,
     objects::ConstructionSite,
     traits::TryInto,
 };

--- a/src/objects/impls/container.rs
+++ b/src/objects/impls/container.rs
@@ -1,4 +1,4 @@
-use crate::{macros::*, objects::StructureContainer};
+use crate::objects::StructureContainer;
 
 simple_accessors! {
     impl StructureContainer {

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -7,7 +7,6 @@ use super::room::Step;
 use crate::{
     constants::{Direction, Part, ResourceType, ReturnCode},
     local::{Position, RoomName},
-    macros::*,
     memory::MemoryReference,
     objects::{
         Attackable, ConstructionSite, Creep, FindOptions, HasPosition, Resource, Source,

--- a/src/objects/impls/flag.rs
+++ b/src/objects/impls/flag.rs
@@ -2,7 +2,6 @@ use stdweb::Value;
 
 use crate::{
     constants::{Color, ReturnCode},
-    macros::*,
     objects::{Flag, HasPosition},
     traits::TryFrom,
 };

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -1,6 +1,5 @@
 use crate::{
     constants::{Density, ResourceType},
-    macros::*,
     objects::Mineral,
 };
 

--- a/src/objects/impls/nuke.rs
+++ b/src/objects/impls/nuke.rs
@@ -1,4 +1,4 @@
-use crate::{local::RoomName, macros::*, objects::Nuke};
+use crate::{local::RoomName, objects::Nuke};
 
 simple_accessors! {
     impl Nuke {

--- a/src/objects/impls/resource.rs
+++ b/src/objects/impls/resource.rs
@@ -1,4 +1,4 @@
-use crate::{constants::ResourceType, macros::*, objects::Resource};
+use crate::{constants::ResourceType, objects::Resource};
 
 impl Resource {
     pub fn resource_type(&self) -> ResourceType {

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -17,7 +17,6 @@ use crate::{
         ReturnCode, StructureType, Terrain,
     },
     local::{Position, RoomName},
-    macros::*,
     memory::MemoryReference,
     objects::{
         ConstructionSite, Creep, Flag, HasPosition, Mineral, Nuke, PowerCreep, Resource, Room,

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -3,7 +3,6 @@ use stdweb::UnsafeTypedArray;
 use crate::{
     constants::{ReturnCode, Terrain},
     local::RoomName,
-    macros::*,
     objects::RoomTerrain,
     traits::TryInto,
 };

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -1,4 +1,4 @@
-use crate::{macros::*, objects::Source};
+use crate::objects::Source;
 
 simple_accessors! {
     impl Source {

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -1,6 +1,6 @@
 use stdweb::Value;
 
-use crate::{constants::ReturnCode, macros::*, objects::StructureController};
+use crate::{constants::ReturnCode, objects::StructureController};
 
 simple_accessors! {
     impl StructureController {

--- a/src/objects/impls/structure_keeper_lair.rs
+++ b/src/objects/impls/structure_keeper_lair.rs
@@ -1,4 +1,4 @@
-use crate::{macros::*, objects::StructureKeeperLair};
+use crate::objects::StructureKeeperLair;
 
 simple_accessors! {
     impl StructureKeeperLair {

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -1,6 +1,5 @@
 use crate::{
     constants::{ResourceType, ReturnCode},
-    macros::*,
     objects::{Creep, StructureLab},
 };
 

--- a/src/objects/impls/structure_link.rs
+++ b/src/objects/impls/structure_link.rs
@@ -1,4 +1,4 @@
-use crate::{constants::ReturnCode, macros::*, objects::StructureLink};
+use crate::{constants::ReturnCode, objects::StructureLink};
 
 impl StructureLink {
     pub fn transfer_energy(&self, target: &StructureLink, amount: Option<u32>) -> ReturnCode {

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -1,6 +1,5 @@
 use crate::{
     constants::ReturnCode,
-    macros::*,
     objects::{HasPosition, StructureNuker},
 };
 

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -1,4 +1,4 @@
-use crate::{constants::ReturnCode, local::RoomName, macros::*, objects::StructureObserver};
+use crate::{constants::ReturnCode, local::RoomName, objects::StructureObserver};
 
 impl StructureObserver {
     pub fn observe_room(&self, room_name: RoomName) -> ReturnCode {

--- a/src/objects/impls/structure_portal.rs
+++ b/src/objects/impls/structure_portal.rs
@@ -3,7 +3,6 @@ use stdweb::Value;
 
 use crate::{
     local::{Position, RoomName},
-    macros::*,
     objects::StructurePortal,
     traits::TryInto,
 };

--- a/src/objects/impls/structure_power_bank.rs
+++ b/src/objects/impls/structure_power_bank.rs
@@ -1,4 +1,4 @@
-use crate::{macros::*, objects::StructurePowerBank};
+use crate::objects::StructurePowerBank;
 
 simple_accessors! {
     impl StructurePowerBank {

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -1,4 +1,4 @@
-use crate::{constants::ReturnCode, macros::*, objects::StructurePowerSpawn};
+use crate::{constants::ReturnCode, objects::StructurePowerSpawn};
 
 simple_accessors! {
     impl StructurePowerSpawn {

--- a/src/objects/impls/structure_rampart.rs
+++ b/src/objects/impls/structure_rampart.rs
@@ -1,4 +1,4 @@
-use crate::{constants::ReturnCode, macros::*, objects::StructureRampart};
+use crate::{constants::ReturnCode, objects::StructureRampart};
 
 simple_accessors! {
     impl StructureRampart {

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -2,7 +2,6 @@ use stdweb::Reference;
 
 use crate::{
     constants::{Direction, Part, ReturnCode},
-    macros::*,
     memory::MemoryReference,
     objects::{Creep, HasEnergyForSpawn, SizedRoomObject, Spawning, StructureSpawn},
     traits::TryInto,

--- a/src/objects/impls/structure_terminal.rs
+++ b/src/objects/impls/structure_terminal.rs
@@ -1,6 +1,5 @@
 use crate::{
     constants::{ResourceType, ReturnCode},
-    macros::*,
     objects::StructureTerminal,
 };
 

--- a/src/objects/impls/structure_tower.rs
+++ b/src/objects/impls/structure_tower.rs
@@ -1,6 +1,5 @@
 use crate::{
     constants::ReturnCode,
-    macros::*,
     objects::{Creep, Structure, StructureTower},
 };
 

--- a/src/objects/impls/tombstone.rs
+++ b/src/objects/impls/tombstone.rs
@@ -1,7 +1,4 @@
-use crate::{
-    macros::*,
-    objects::{Creep, Tombstone},
-};
+use crate::objects::{Creep, Tombstone};
 
 simple_accessors! {
     impl Tombstone {

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -14,7 +14,7 @@ use std::{f64, marker::PhantomData, mem};
 use scoped_tls::scoped_thread_local;
 use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray};
 
-use crate::{local::Position, macros::*, objects::HasPosition, traits::TryInto};
+use crate::{local::Position, objects::HasPosition, traits::TryInto};
 
 #[derive(Clone, Debug)]
 pub struct LocalCostMatrix {

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -4,8 +4,6 @@
 
 use serde::Deserialize;
 
-use crate::macros::*;
-
 #[derive(Deserialize, Debug)]
 pub struct ForeignSegment {
     username: String,


### PR DESCRIPTION
I think this is a good idea mostly because of stdweb's macros changing
internally, and them not having full 2018-style-supported macro usage.