### PR TITLE
Migrate to new .store API, removing deprecated API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Unreleased
 ==========
 
+- Remove `CanStoreEnergy` trait, moving all structures and creeps to `HasStore`, migrating from
+  deprecated Screeps API endpoints to new `.store` API (breaking)
+    - Remove `Creep::carry_total()`, `Creep::carry_types()`, `Creep::carry_of()`
+    - Remove `StructureLab::mineral_amount()`, `StructureLab::mineral_capacity()`
+    - Remove `StructureNuker::ghodium()`, `StructureNuker::ghodium_capacity()`
+    - Change `HasStore::store_capacity()` to use new API and now takes `Option<ResourceType>`
+    - Add `HasStore::store_free_capacity()` and `HasStore::store_used_capacity()`, which both
+    take `Option<ResourceType>`
 - Add new `StructureFactory` and `StructureInvaderCore` structure types
 - Add a number of new constants related to factory operation and strongholds
 - Add new resource types for factory commodities

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub type RoomPosition = Position;
 /// This module contains all base functionality traits, and no structures.
 pub mod prelude {
     pub use crate::objects::{
-        CanDecay, CanStoreEnergy, HasCooldown, HasId, HasPosition, HasStore,
-        OwnedStructureProperties, RoomObjectProperties, StructureProperties,
+        CanDecay, HasCooldown, HasId, HasPosition, HasStore, OwnedStructureProperties,
+        RoomObjectProperties, StructureProperties,
     };
 }

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -46,18 +46,6 @@ impl Creep {
         body_parts
     }
 
-    pub fn carry_total(&self) -> u32 {
-        js_unwrap!(_.sum(@{self.as_ref()}.carry))
-    }
-
-    pub fn carry_types(&self) -> Vec<ResourceType> {
-        js_unwrap!(Object.keys(@{self.as_ref()}.carry).map(__resource_type_str_to_num))
-    }
-
-    pub fn carry_of(&self, ty: ResourceType) -> u32 {
-        js_unwrap!(@{self.as_ref()}.carry[__resource_type_num_to_str(@{ty as u32})] || 0)
-    }
-
     pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> ReturnCode {
         match amount {
             Some(v) => js_unwrap!(@{self.as_ref()}.drop(__resource_type_num_to_str(@{ty as u32}), @{v})),
@@ -292,7 +280,6 @@ pub struct Bodypart {
 
 simple_accessors! {
     impl Creep {
-        pub fn carry_capacity() -> u32 = carryCapacity;
         pub fn fatigue() -> u32 = fatigue;
         pub fn name() -> String = name;
         pub fn my() -> bool = my;

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -3,14 +3,6 @@ use crate::{
     objects::{Creep, StructureLab},
 };
 
-simple_accessors! {
-    impl StructureLab {
-        pub fn mineral_amount() -> u32 = mineralAmount;
-        // mineralType
-        pub fn mineral_capacity() -> u32 = mineralCapacity;
-    }
-}
-
 impl StructureLab {
     pub fn mineral_type(&self) -> ResourceType {
         js_unwrap!(__resource_type_str_to_num(@{self.as_ref()}.mineralType))

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -3,13 +3,6 @@ use crate::{
     objects::{HasPosition, StructureNuker},
 };
 
-simple_accessors! {
-    impl StructureNuker {
-        pub fn ghodium() -> u32 = ghodium;
-        pub fn ghodium_capacity() -> u32 = ghodiumCapacity;
-    }
-}
-
 impl StructureNuker {
     pub fn launch_nuke<T: HasPosition + ?Sized>(&self, target: &T) -> ReturnCode {
         let pos = target.pos();

--- a/src/objects/structure.rs
+++ b/src/objects/structure.rs
@@ -3,7 +3,7 @@ use stdweb::{InstanceOf, Reference, ReferenceType, Value};
 use super::*;
 use crate::{
     constants::StructureType,
-    objects::{Attackable, CanDecay, CanStoreEnergy, HasCooldown, HasEnergyForSpawn, HasStore},
+    objects::{Attackable, CanDecay, HasCooldown, HasEnergyForSpawn, HasStore},
     traits::FromExpectedType,
     ConversionError,
 };
@@ -192,16 +192,6 @@ impl Structure {
         )
     }
 
-    pub fn as_can_store_energy(&self) -> Option<&dyn CanStoreEnergy> {
-        match_some_structure_variants!(
-            self,
-            {
-                Extension, Lab, Link, Nuker, PowerSpawn, Spawn, Tower
-            },
-            v => v
-        )
-    }
-
     pub fn as_has_cooldown(&self) -> Option<&dyn HasCooldown> {
         match_some_structure_variants!(
             self,
@@ -226,7 +216,7 @@ impl Structure {
         match_some_structure_variants!(
             self,
             {
-                Container, Factory, Storage, Terminal
+                Container, Extension, Factory, Lab, Link, Nuker, PowerSpawn, Spawn, Storage, Terminal, Tower
             },
             v => v
         )


### PR DESCRIPTION
Resolves #253 

Really big breaking changes - removes `CanStoreEnergy` trait, all of the access to the deprecated storage and carry APIs, and implements `.store` for creeps and structures which were previously handled separately.

Another one where I haven't done much testing other than on a private server, I'll continue to test other cases while this is reviewed.