### PR TITLE
Power Spawn and Creep additional deprecated properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- Remove `StructurePowerSpawn::power()` and `power_capacity()` (replaced with `HasStore` functions)
+- Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now
+  using the `energy()` implementation from `HasStore`
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -53,10 +53,6 @@ impl Creep {
         }
     }
 
-    pub fn energy(&self) -> u32 {
-        js_unwrap!(@{self.as_ref()}.carry[RESOURCE_ENERGY])
-    }
-
     pub fn owner_name(&self) -> String {
         js_unwrap!(@{self.as_ref()}.owner.username)
     }

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -1,17 +1,6 @@
 use crate::{constants::ReturnCode, objects::StructurePowerSpawn};
 
-simple_accessors! {
-    impl StructurePowerSpawn {
-        pub fn power() -> u32 = power;
-        pub fn power_capacity() -> u32 = powerCapacity;
-    }
-}
-
 impl StructurePowerSpawn {
-    // pub fn create_power_creep(&self, name: &str) -> ! {
-    //     unimplemented!()
-    // }
-
     pub fn process_power(&self) -> ReturnCode {
         js_unwrap! {@{self.as_ref()}.processPower()}
     }


### PR DESCRIPTION
Missed a few in the big `HasStore` patch:
 - Remove deprecated `StructurePowerSpawn::power()` and `power_capacity()`
 - Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, `energy()` is implemented in `HasStore` and is now unneeded here