### PR TITLE
Update market API for new features and compatibility with current Screeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 Unreleased
 ==========
 
+- Add `MarketResourceType` enum, which can wrap either a `ResourceType` or `IntershardResourceType`
+  and switch to using it for `game::market` endpoints which accept either type (breaking)
+- Update integer representation of `IntershardResource::SubscriptionToken` to move out of conflict
+  with normal resources to allow parsing market orders which might have either (breaking)
+- Add `game::market::get_history()` and `game::market::OrderHistoryRecord` exposing new
+  `getHistory()` API function
+- Update `game::market` functions to be able to work with intershard orders and transactions for
+  them, making `RoomName` optional in many cases as it's not used for intershard transactions
+  (breaking)
+- Update field visibility on `game::market` structs used as return values to public, update to
+  native types for `ResourceType` and `RoomName` values, and make a number of fields optional for
+  compatibility with intershard orders (breaking)
+- Update `game::market::create_order()` to use the currently documented object syntax and new
+  `MarketResourceType` to specify resource (breaking)
+- Update `game::market::calc_transaction_cost()` to work with `RoomName` instead of `&Room` to
+  avoid requiring visibility of both rooms (breaking)
 - Remove `StructurePowerSpawn::power()` and `power_capacity()` (replaced with `HasStore` functions)
 - Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now
   using the `energy()` implementation from `HasStore`

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -120,21 +120,6 @@ function __structure_type_str_to_num(str) {
     }
 }
 
-function __intershard_resource_type_num_to_str(num) {
-    switch (num) {
-        case 1: return SUBSCRIPTION_TOKEN;
-        default: throw new Error("unknown inter-shard resource type integer encoding " + num);
-    }
-}
-
-function __intershard_resource_type_str_to_num(str) {
-    switch (str) {
-        case SUBSCRIPTION_TOKEN: return 1;
-        default: throw new Error("unknown inter-shard resource type " + str);
-    }
-}
-
-
 function __resource_type_num_to_str(num) {
     switch (num) {
         case 1: return RESOURCE_ENERGY;
@@ -221,6 +206,7 @@ function __resource_type_num_to_str(num) {
         case 82: return RESOURCE_SPIRIT;
         case 83: return RESOURCE_EMANATION;
         case 84: return RESOURCE_ESSENCE;
+        case 1001: return SUBSCRIPTION_TOKEN;
         default: throw new Error("unknown resource type integer encoding " + num);
     }
 }
@@ -311,6 +297,7 @@ function __resource_type_str_to_num(str) {
         case RESOURCE_SPIRIT: return 82;
         case RESOURCE_EMANATION: return 83;
         case RESOURCE_ESSENCE: return 84;
+        case SUBSCRIPTION_TOKEN: return 1001;
         default: throw new Error("unknown resource type " + str);
     }
 }

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -118,8 +118,8 @@ js_deserializable!(StructureType);
 ///
 /// *Note:* This constant's `TryFrom<Value>`, `Serialize` and `Deserialize`
 /// implementations only operate on made-up integer constants. If you're ever
-/// using these impls manually, use the `__intershard_resource_type_num_to_str`
-/// and `__intershard_resource_type_str_to_num` JavaScript functions,
+/// using these impls manually, use the `__resource_type_num_to_str`
+/// and `__resource_type_str_to_num` JavaScript functions,
 /// [`FromStr`][std::str::FromStr] or
 /// [`IntershardResourceType::deserialize_from_str`].
 ///
@@ -522,11 +522,10 @@ pub enum MarketResourceType {
     IntershardResource(IntershardResourceType),
 }
 
-impl<'de> Deserialize<'de> for MarketResourceType {
-    fn deserialize<D>(d: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
+impl MarketResourceType {
+    /// Helper function for deserializing from a string rather than a fake
+    /// integer value.
+    pub fn deserialize_from_str<'de, D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let s: Cow<'de, str> = Cow::deserialize(d)?;
 
         ResourceType::from_str(&s)
@@ -539,6 +538,111 @@ impl<'de> Deserialize<'de> for MarketResourceType {
                     &"a known constant string in RESOURCES_ALL or INTERSHARD_RESOURCES",
                 )
             })
+    }
+}
+
+impl<'de> Deserialize<'de> for MarketResourceType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let resource = u16::deserialize(deserializer)?;
+        let resource_type = match resource {
+            1 => MarketResourceType::Resource(ResourceType::Energy),
+            2 => MarketResourceType::Resource(ResourceType::Power),
+            3 => MarketResourceType::Resource(ResourceType::Hydrogen),
+            4 => MarketResourceType::Resource(ResourceType::Oxygen),
+            5 => MarketResourceType::Resource(ResourceType::Utrium),
+            6 => MarketResourceType::Resource(ResourceType::Lemergium),
+            7 => MarketResourceType::Resource(ResourceType::Keanium),
+            8 => MarketResourceType::Resource(ResourceType::Zynthium),
+            9 => MarketResourceType::Resource(ResourceType::Catalyst),
+            10 => MarketResourceType::Resource(ResourceType::Ghodium),
+            11 => MarketResourceType::Resource(ResourceType::Hydroxide),
+            12 => MarketResourceType::Resource(ResourceType::ZynthiumKeanite),
+            13 => MarketResourceType::Resource(ResourceType::UtriumLemergite),
+            14 => MarketResourceType::Resource(ResourceType::UtriumHydride),
+            15 => MarketResourceType::Resource(ResourceType::UtriumOxide),
+            16 => MarketResourceType::Resource(ResourceType::KeaniumHydride),
+            17 => MarketResourceType::Resource(ResourceType::KeaniumOxide),
+            18 => MarketResourceType::Resource(ResourceType::LemergiumHydride),
+            19 => MarketResourceType::Resource(ResourceType::LemergiumOxide),
+            20 => MarketResourceType::Resource(ResourceType::ZynthiumHydride),
+            21 => MarketResourceType::Resource(ResourceType::ZynthiumOxide),
+            22 => MarketResourceType::Resource(ResourceType::GhodiumHydride),
+            23 => MarketResourceType::Resource(ResourceType::GhodiumOxide),
+            24 => MarketResourceType::Resource(ResourceType::UtriumAcid),
+            25 => MarketResourceType::Resource(ResourceType::UtriumAlkalide),
+            26 => MarketResourceType::Resource(ResourceType::KeaniumAcid),
+            27 => MarketResourceType::Resource(ResourceType::KeaniumAlkalide),
+            28 => MarketResourceType::Resource(ResourceType::LemergiumAcid),
+            29 => MarketResourceType::Resource(ResourceType::LemergiumAlkalide),
+            30 => MarketResourceType::Resource(ResourceType::ZynthiumAcid),
+            31 => MarketResourceType::Resource(ResourceType::ZynthiumAlkalide),
+            32 => MarketResourceType::Resource(ResourceType::GhodiumAcid),
+            33 => MarketResourceType::Resource(ResourceType::GhodiumAlkalide),
+            34 => MarketResourceType::Resource(ResourceType::CatalyzedUtriumAcid),
+            35 => MarketResourceType::Resource(ResourceType::CatalyzedUtriumAlkalide),
+            36 => MarketResourceType::Resource(ResourceType::CatalyzedKeaniumAcid),
+            37 => MarketResourceType::Resource(ResourceType::CatalyzedKeaniumAlkalide),
+            38 => MarketResourceType::Resource(ResourceType::CatalyzedLemergiumAcid),
+            39 => MarketResourceType::Resource(ResourceType::CatalyzedLemergiumAlkalide),
+            40 => MarketResourceType::Resource(ResourceType::CatalyzedZynthiumAcid),
+            41 => MarketResourceType::Resource(ResourceType::CatalyzedZynthiumAlkalide),
+            42 => MarketResourceType::Resource(ResourceType::CatalyzedGhodiumAcid),
+            43 => MarketResourceType::Resource(ResourceType::CatalyzedGhodiumAlkalide),
+            44 => MarketResourceType::Resource(ResourceType::Ops),
+            45 => MarketResourceType::Resource(ResourceType::Silicon),
+            46 => MarketResourceType::Resource(ResourceType::Metal),
+            47 => MarketResourceType::Resource(ResourceType::Biomass),
+            48 => MarketResourceType::Resource(ResourceType::Mist),
+            49 => MarketResourceType::Resource(ResourceType::UtriumBar),
+            50 => MarketResourceType::Resource(ResourceType::LemergiumBar),
+            51 => MarketResourceType::Resource(ResourceType::ZynthiumBar),
+            52 => MarketResourceType::Resource(ResourceType::KeaniumBar),
+            53 => MarketResourceType::Resource(ResourceType::GhodiumMelt),
+            54 => MarketResourceType::Resource(ResourceType::Oxidant),
+            55 => MarketResourceType::Resource(ResourceType::Reductant),
+            56 => MarketResourceType::Resource(ResourceType::Purifier),
+            57 => MarketResourceType::Resource(ResourceType::Battery),
+            58 => MarketResourceType::Resource(ResourceType::Composite),
+            59 => MarketResourceType::Resource(ResourceType::Crystal),
+            60 => MarketResourceType::Resource(ResourceType::Liquid),
+            61 => MarketResourceType::Resource(ResourceType::Wire),
+            62 => MarketResourceType::Resource(ResourceType::Switch),
+            63 => MarketResourceType::Resource(ResourceType::Transistor),
+            64 => MarketResourceType::Resource(ResourceType::Microchip),
+            65 => MarketResourceType::Resource(ResourceType::Circuit),
+            66 => MarketResourceType::Resource(ResourceType::Device),
+            67 => MarketResourceType::Resource(ResourceType::Cell),
+            68 => MarketResourceType::Resource(ResourceType::Phlegm),
+            69 => MarketResourceType::Resource(ResourceType::Tissue),
+            70 => MarketResourceType::Resource(ResourceType::Muscle),
+            71 => MarketResourceType::Resource(ResourceType::Organoid),
+            72 => MarketResourceType::Resource(ResourceType::Organism),
+            73 => MarketResourceType::Resource(ResourceType::Alloy),
+            74 => MarketResourceType::Resource(ResourceType::Tube),
+            75 => MarketResourceType::Resource(ResourceType::Fixtures),
+            76 => MarketResourceType::Resource(ResourceType::Frame),
+            77 => MarketResourceType::Resource(ResourceType::Hydraulics),
+            78 => MarketResourceType::Resource(ResourceType::Machine),
+            79 => MarketResourceType::Resource(ResourceType::Condensate),
+            80 => MarketResourceType::Resource(ResourceType::Concentrate),
+            81 => MarketResourceType::Resource(ResourceType::Extract),
+            82 => MarketResourceType::Resource(ResourceType::Spirit),
+            83 => MarketResourceType::Resource(ResourceType::Emanation),
+            84 => MarketResourceType::Resource(ResourceType::Essence),
+            1001 => {
+                MarketResourceType::IntershardResource(IntershardResourceType::SubscriptionToken)
+            }
+            _ => {
+                return Err(D::Error::invalid_value(
+                    Unexpected::Unsigned(resource as u64),
+                    &"a valid RESOURCES_ALL or INTERSHARD_RESOURCES type integer",
+                ))
+            }
+        };
+        Ok(resource_type)
     }
 }
 

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -514,7 +514,8 @@ impl ResourceType {
 
 js_deserializable!(ResourceType);
 
-/// Translates effect types which can include both `PWR_*` and `EFFECT_*` constants.
+/// Translates market resource types which can include both `RESOURCE_*`
+/// and `INTERSHARD_RESOURCES` constants.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum MarketResourceType {
     Resource(ResourceType),

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -529,20 +529,16 @@ impl<'de> Deserialize<'de> for MarketResourceType {
     {
         let s: Cow<'de, str> = Cow::deserialize(d)?;
 
-        // first try to deserialize as a ResourceType
-        match ResourceType::from_str(&s) {
-            Ok(v) => Ok(MarketResourceType::Resource(v)),
-            Err(_) => {
-                // then try to deserialize as an IntershardResourceType
-                match IntershardResourceType::from_str(&s) {
-                    Ok(v) => Ok(MarketResourceType::IntershardResource(v)),
-                    Err(_) => Err(D::Error::invalid_value(
-                        Unexpected::Str(&s),
-                        &"a known constant string in RESOURCES_ALL or INTERSHARD_RESOURCES",
-                    )),
-                }
-            }
-        }
+        ResourceType::from_str(&s)
+            .map(|ty| MarketResourceType::Resource(ty))
+            .or(IntershardResourceType::from_str(&s)
+                .map(|ty| MarketResourceType::IntershardResource(ty)))
+            .map_err(|_| {
+                D::Error::invalid_value(
+                    Unexpected::Str(&s),
+                    &"a known constant string in RESOURCES_ALL or INTERSHARD_RESOURCES",
+                )
+            })
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -65,14 +65,12 @@ pub mod resources {
 
     /// Retrieve the string keys of this object.
     pub fn keys() -> Vec<IntershardResourceType> {
-        js_unwrap!(Object
-            .keys(Game.resources)
-            .map(__intershard_resource_type_str_to_num))
+        js_unwrap!(Object.keys(Game.resources).map(__resource_type_str_to_num))
     }
 
     /// Retrieve a specific value by key.
     pub fn get(key: IntershardResourceType) -> Option<u32> {
-        js_unwrap!(Game.resources[__intershard_resource_type_num_to_str(@{key as u32})])
+        js_unwrap!(Game.resources[__resource_type_num_to_str(@{key as u32})])
     }
 }
 

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -171,7 +171,7 @@ pub fn orders() -> HashMap<String, MyOrder> {
     js_unwrap!(Game.market.orders)
 }
 
-pub fn calc_transaction_cost(amount: u32, room1: RoomName, room2: RoomName) -> f64 {
+pub fn calc_transaction_cost(amount: u32, room1: &RoomName, room2: &RoomName) -> f64 {
     js_unwrap!(Game.market.calcTransactionCost(@{amount}, @{room1.to_string()}, @{room2.to_string()}))
 }
 
@@ -188,7 +188,7 @@ pub fn create_order(
     resource_type: MarketResourceType,
     price: f64,
     total_amount: u32,
-    room: Option<RoomName>,
+    room: Option<&RoomName>,
 ) -> ReturnCode {
     let resource_num = match resource_type {
         MarketResourceType::Resource(ty) => ty as u32,
@@ -224,7 +224,7 @@ pub fn create_order(
 /// `target_room` is your owned room whose terminal will send or receive
 /// resources in this transaction, or `None` if this is an order for an
 /// intershard resource type
-pub fn deal(order_id: &str, amount: u32, target_room: Option<RoomName>) -> ReturnCode {
+pub fn deal(order_id: &str, amount: u32, target_room: Option<&RoomName>) -> ReturnCode {
     match target_room {
         Some(target_room_name) => {
             js_unwrap!(Game.market.deal(@{order_id}, @{amount}, @{target_room_name.to_string()}))

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -77,9 +77,11 @@ js_deserializable!(TransactionOrder);
 pub struct Transaction {
     pub transaction_id: String,
     pub time: u32,
-    /// The player who sent resources for this transaction, or `None` if it was an NPC terminal
+    /// The player who sent resources for this transaction, or `None` if it was
+    /// an NPC terminal
     pub sender: Option<Player>,
-    /// The recipient of the resources for this transaction, or `None` if it was an NPC terminal
+    /// The recipient of the resources for this transaction, or `None` if it was
+    /// an NPC terminal
     pub recipient: Option<Player>,
     #[serde(deserialize_with = "ResourceType::deserialize_from_str")]
     pub resource_type: ResourceType,
@@ -88,9 +90,11 @@ pub struct Transaction {
     pub from: RoomName,
     /// The room that received resources in this transaction
     pub to: RoomName,
-    /// The description set in the sender's `StructureTerminal::send()` call, if any
+    /// The description set in the sender's `StructureTerminal::send()` call, if
+    /// any
     pub description: Option<String>,
-    /// Information about the market order that this transaction was fulfilling, if any
+    /// Information about the market order that this transaction was fulfilling,
+    /// if any
     pub order: Option<TransactionOrder>,
 }
 js_deserializable!(Transaction);
@@ -217,8 +221,9 @@ pub fn create_order(
 
 /// Execute a market trade
 ///
-/// target_room is your owned room whose terminal will send or receive resources in this
-/// transaction resources, or `None` if this is an order for an intershard resource type
+/// `target_room` is your owned room whose terminal will send or receive
+/// resources in this transaction, or `None` if this is an order for an
+/// intershard resource type
 pub fn deal(order_id: &str, amount: u32, target_room: Option<RoomName>) -> ReturnCode {
     match target_room {
         Some(target_room_name) => {

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -109,6 +109,7 @@ pub struct Order {
     pub created_timestamp: u64,
     #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
     pub order_type: OrderType,
+    #[serde(deserialize_with = "MarketResourceType::deserialize_from_str")]
     pub resource_type: MarketResourceType,
     /// Room that owns the order, `None` for intershard orders
     pub room_name: Option<RoomName>,
@@ -129,6 +130,7 @@ pub struct MyOrder {
     pub active: bool,
     #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
     pub order_type: OrderType,
+    #[serde(deserialize_with = "MarketResourceType::deserialize_from_str")]
     pub resource_type: MarketResourceType,
     /// Room that owns the order, `None` for intershard orders
     pub room_name: Option<RoomName>,
@@ -142,6 +144,7 @@ js_deserializable!(MyOrder);
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct OrderHistoryRecord {
+    #[serde(deserialize_with = "MarketResourceType::deserialize_from_str")]
     pub resource_type: MarketResourceType,
     /// Calendar date in string format, eg "2018-12-31"
     pub date: String,
@@ -171,7 +174,7 @@ pub fn orders() -> HashMap<String, MyOrder> {
     js_unwrap!(Game.market.orders)
 }
 
-pub fn calc_transaction_cost(amount: u32, room1: &RoomName, room2: &RoomName) -> f64 {
+pub fn calc_transaction_cost(amount: u32, room1: RoomName, room2: RoomName) -> f64 {
     js_unwrap!(Game.market.calcTransactionCost(@{amount}, @{room1.to_string()}, @{room2.to_string()}))
 }
 
@@ -188,7 +191,7 @@ pub fn create_order(
     resource_type: MarketResourceType,
     price: f64,
     total_amount: u32,
-    room: Option<&RoomName>,
+    room: Option<RoomName>,
 ) -> ReturnCode {
     let resource_num = match resource_type {
         MarketResourceType::Resource(ty) => ty as u32,
@@ -224,7 +227,7 @@ pub fn create_order(
 /// `target_room` is your owned room whose terminal will send or receive
 /// resources in this transaction, or `None` if this is an order for an
 /// intershard resource type
-pub fn deal(order_id: &str, amount: u32, target_room: Option<&RoomName>) -> ReturnCode {
+pub fn deal(order_id: &str, amount: u32, target_room: Option<RoomName>) -> ReturnCode {
     match target_room {
         Some(target_room_name) => {
             js_unwrap!(Game.market.deal(@{order_id}, @{amount}, @{target_room_name.to_string()}))

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -11,10 +11,9 @@ use serde::{
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::{
-    constants::{ResourceType, ReturnCode},
+    constants::{MarketResourceType, ResourceType, ReturnCode},
     local::RoomName,
     traits::TryInto,
-    Room,
 };
 
 /// Translates the `ORDER_SELL` and `ORDER_BUY` constants.
@@ -60,94 +59,116 @@ impl OrderType {
 
 #[derive(Deserialize, Debug)]
 pub struct Player {
-    username: String,
+    pub username: String,
 }
 js_deserializable!(Player);
 
 #[derive(Deserialize, Debug)]
 pub struct TransactionOrder {
-    id: String,
+    pub id: String,
     #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
-    order_type: OrderType,
-    price: f64,
+    pub order_type: OrderType,
+    pub price: f64,
 }
 js_deserializable!(TransactionOrder);
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Transaction {
-    transaction_id: String,
-    time: u32,
-    sender: Player,
-    recipient: Player,
-    resource_type: String,
-    amount: u32,
-    from: String,
-    to: String,
-    description: String,
-    order: Option<TransactionOrder>,
+    pub transaction_id: String,
+    pub time: u32,
+    /// The player who sent resources for this transaction, or `None` if it was an NPC terminal
+    pub sender: Option<Player>,
+    /// The recipient of the resources for this transaction, or `None` if it was an NPC terminal
+    pub recipient: Option<Player>,
+    #[serde(deserialize_with = "ResourceType::deserialize_from_str")]
+    pub resource_type: ResourceType,
+    pub amount: u32,
+    /// The room that sent resources for this transaction
+    pub from: RoomName,
+    /// The room that received resources in this transaction
+    pub to: RoomName,
+    /// The description set in the sender's `StructureTerminal::send()` call, if any
+    pub description: Option<String>,
+    /// Information about the market order that this transaction was fulfilling, if any
+    pub order: Option<TransactionOrder>,
 }
 js_deserializable!(Transaction);
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Order {
-    id: String,
-    created: u32,
+    pub id: String,
+    /// Tick of order creation, `None` for intershard orders
+    pub created: Option<u32>,
+    /// Timestamp of order creation in milliseconds since epoch
+    pub created_timestamp: u64,
     #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
-    order_type: OrderType,
-    resource_type: String,
-    room_name: RoomName,
-    amount: u32,
-    remaining_amount: u32,
-    price: f64,
+    pub order_type: OrderType,
+    pub resource_type: MarketResourceType,
+    /// Room that owns the order, `None` for intershard orders
+    pub room_name: Option<RoomName>,
+    pub amount: u32,
+    pub remaining_amount: u32,
+    pub price: f64,
 }
 js_deserializable!(Order);
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct MyOrder {
-    id: String,
-    created: u32,
-    active: bool,
+    pub id: String,
+    /// Tick of order creation, `None` for intershard orders
+    pub created: Option<u32>,
+    /// Timestamp of order creation in milliseconds since epoch
+    pub created_timestamp: u64,
+    pub active: bool,
     #[serde(rename = "type", deserialize_with = "OrderType::deserialize_from_str")]
-    order_type: OrderType,
-    resource_type: String,
-    room_name: RoomName,
-    amount: u32,
-    remaining_amount: u32,
-    total_amount: u32,
-    price: f64,
+    pub order_type: OrderType,
+    pub resource_type: MarketResourceType,
+    /// Room that owns the order, `None` for intershard orders
+    pub room_name: Option<RoomName>,
+    pub amount: u32,
+    pub remaining_amount: u32,
+    pub total_amount: u32,
+    pub price: f64,
 }
 js_deserializable!(MyOrder);
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderHistoryRecord {
+    pub resource_type: MarketResourceType,
+    /// Calendar date in string format, eg "2018-12-31"
+    pub date: String,
+    /// Total number of transactions for this resource on this day
+    pub transactions: u32,
+    /// Total volume of this resource bought and sold on this day
+    pub volume: u32,
+    pub avg_price: f64,
+    pub stddev_price: f64,
+}
+js_deserializable!(OrderHistoryRecord);
 
 pub fn credits() -> f64 {
     js_unwrap!(Game.market.credits)
 }
 
 pub fn incoming_transactions() -> Vec<Transaction> {
-    let arr_transaction_value = js! {
-        return Game.market.incomingTransactions;
-    };
-    arr_transaction_value.try_into().unwrap()
+    js_unwrap!(Game.market.incomingTransactions)
 }
 
 pub fn outgoing_transactions() -> Vec<Transaction> {
-    let arr_transaction_value = js! {
-        return Game.market.outgoingTransactions;
-    };
-    arr_transaction_value.try_into().unwrap()
+    js_unwrap!(Game.market.outgoingTransactions)
 }
 
+/// Get a `HashMap` of the player's currently-listed market orders
 pub fn orders() -> HashMap<String, MyOrder> {
-    let order_book_value = js! {
-        return Game.market.orders;
-    };
-    order_book_value.try_into().unwrap()
+    js_unwrap!(Game.market.orders)
 }
 
-pub fn calc_transaction_cost(amount: u32, room1: &Room, room2: &Room) -> f64 {
-    js_unwrap!(Game.market.calcTransactionCost(@{amount}, @{room1.name()}, @{room2.name()}))
+pub fn calc_transaction_cost(amount: u32, room1: RoomName, room2: RoomName) -> f64 {
+    js_unwrap!(Game.market.calcTransactionCost(@{amount}, @{room1.to_string()}, @{room2.to_string()}))
 }
 
 pub fn cancel_order(order_id: &str) -> ReturnCode {
@@ -160,41 +181,101 @@ pub fn change_order_price(order_id: &str, new_price: f64) -> ReturnCode {
 
 pub fn create_order(
     order_type: OrderType,
-    resource_type: ResourceType,
+    resource_type: MarketResourceType,
     price: f64,
     total_amount: u32,
-    room: &Room,
+    room: Option<RoomName>,
 ) -> ReturnCode {
-    js_unwrap! {
-        Game.market.createOrder(__order_type_num_to_str(@{order_type as u32}),
-                                __resource_type_num_to_str(@{resource_type as u32}),
-                                @{price},
-                                @{total_amount},
-                                @{room.name()})
+    let resource_num = match resource_type {
+        MarketResourceType::Resource(ty) => ty as u32,
+        MarketResourceType::IntershardResource(ty) => ty as u32,
+    };
+    match room {
+        Some(room_name) => {
+            js_unwrap! {
+                Game.market.createOrder({
+                    type: __order_type_num_to_str(@{order_type as u32}),
+                    resourceType: __resource_type_num_to_str(@{resource_num}),
+                    price: @{price},
+                    totalAmount: @{total_amount},
+                    roomName: @{room_name.to_string()}
+                })
+            }
+        }
+        None => {
+            js_unwrap! {
+                Game.market.createOrder({
+                    type: __order_type_num_to_str(@{order_type as u32}),
+                    resourceType: __resource_type_num_to_str(@{resource_num}),
+                    price: @{price},
+                    totalAmount: @{total_amount}
+                })
+            }
+        }
     }
 }
 
-pub fn deal(order_id: &str, amount: u32, target_room: &Room) -> ReturnCode {
-    js_unwrap! {Game.market.deal(@{order_id}, @{amount}, @{target_room.name()})}
+/// Execute a market trade
+///
+/// target_room is your owned room whose terminal will send or receive resources in this
+/// transaction resources, or `None` if this is an order for an intershard resource type
+pub fn deal(order_id: &str, amount: u32, target_room: Option<RoomName>) -> ReturnCode {
+    match target_room {
+        Some(target_room_name) => {
+            js_unwrap!(Game.market.deal(@{order_id}, @{amount}, @{target_room_name.to_string()}))
+        }
+        None => js_unwrap!(Game.market.deal(@{order_id}, @{amount})),
+    }
 }
 
 pub fn extend_order(order_id: &str, add_amount: u32) -> ReturnCode {
-    js_unwrap! {Game.market.extendOrder(@{order_id}, @{add_amount})}
+    js_unwrap!(Game.market.extendOrder(@{order_id}, @{add_amount}))
 }
 
 /// Get all orders from the market
 ///
 /// Contrary to the JS version, filtering should be done afterwards.
 pub fn get_all_orders() -> Vec<Order> {
-    let all_order = js! {
-        return Game.market.getAllOrders();
-    };
-    all_order.try_into().unwrap()
+    js_unwrap!(Game.market.getAllOrders())
+}
+
+/// Provides historical information on the price of each resource over the last
+/// 14 days
+///
+/// Provide a resource type to get history for using `Some(ResourceType)`, or
+/// get data for all resources by passing `None`
+pub fn get_history(resource: Option<MarketResourceType>) -> Vec<OrderHistoryRecord> {
+    match resource {
+        Some(resource_type) => {
+            match resource_type {
+                // workaround: Game.market.getHistory returns `{}` instead of `[]` when querying a resource type
+                // that has no history records
+                // Verify records are present otherwise return an empty array to prevent panics
+                MarketResourceType::Resource(ty) => js!(
+                    const history = Game.market.getHistory(__resource_type_num_to_str(@{ty as u32}));
+                    if (history && history.length > 0) {
+                        return history;
+                    } else {
+                        return [];
+                    }
+                ).try_into().unwrap(),
+                MarketResourceType::IntershardResource(ty) => js!(
+                    const history = Game.market.getHistory(__resource_type_num_to_str(@{ty as u32}));
+                    if (history && history.length > 0) {
+                        return history;
+                    } else {
+                        return [];
+                    }
+                ).try_into().unwrap(),
+            }
+        }
+        None => js_unwrap!(Game.market.getHistory()),
+    }
 }
 
 pub fn get_order(id: &str) -> Option<Order> {
     let order = js! {
-        return Game.market.getOrder(@{id});
+        return Game.market.getOrderById(@{id});
     };
     order.try_into().ok()
 }


### PR DESCRIPTION
Resolves #256, I bit off a little more than I thought I had with this one.  It turned out that intershard resources had broken a lot of the market code's assumptions for deserializing the struct representations, so a bunch of breaking changes were needed to get these functions to where they wouldn't panic on the live servers.

Market API calls can return the string representations of either a resource or intershard resource, so I added an new enum wrapper to contain them in the places the market code accepts or returns a variable type; moving the integer representation of `token` out of the same spaces used for normal resources was needed in this case, so I used `1001` to kinda match how the new natural effects are offset by the base game, but opinions welcome if another value is preferred.