### PR TITLE
Change room() to returning Option<Room> to fix panics when undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 - Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now
   using the `energy()` implementation from `HasStore`
 - Change `RoomObjectProperties::room()` to return `Option<Room>` to handle the cases that the base
-  game API leaves it undefined: for construction sites and flags in non-visible rooms
+  game API leaves it undefined: for construction sites and flags in non-visible rooms (breaking)
 
 0.7.0 (2019-10-19)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Remove `StructurePowerSpawn::power()` and `power_capacity()` (replaced with `HasStore` functions)
 - Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now
   using the `energy()` implementation from `HasStore`
+- Change `RoomObjectProperties::room()` to return `Option<Room>` to handle the cases that the base
+  game API leaves it undefined: for construction sites and flags in non-visible rooms
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -215,7 +215,9 @@ impl_has_id! {
 /// The reference returned by `AsRef<Reference>::as_ref` must reference a
 /// JavaScript object extending the `RoomObject` class.
 pub unsafe trait RoomObjectProperties: AsRef<Reference> + HasPosition {
-    fn room(&self) -> Room {
+    /// The room that the object is in, or `None` if an object is a flag or a
+    /// construction site and is placed in a room that is not visible to you.
+    fn room(&self) -> Option<Room> {
         js_unwrap_ref!(@{self.as_ref()}.room)
     }
 }


### PR DESCRIPTION
The game API documentation covers two expected cases where `room` on a room object will be undefined ([link](https://docs.screeps.com/api/#RoomObject.room)):

> The link to the Room object. May be undefined in case if an object is a flag or a construction site and is placed in a room that is not visible to you.

This changes the return type of `RoomObjectProperties::room()` from `Room` to `Option<Room>` to prevent panic in the cases where that room isn't visible and `undefined` is returned by js.