### PR TITLE
Fix call to underlying js function in Room::find_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 - Remove `StructurePowerSpawn::power()` and `power_capacity()` (replaced with `HasStore` functions)
 - Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now
   using the `energy()` implementation from `HasStore`
+- Fix `Room::find_path` function call to underlying javascript
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -238,12 +238,12 @@ impl Room {
         // See https://docs.rs/scoped-tls/0.1/scoped_tls/
         COST_CALLBACK.set(&callback_lifetime_erased, || {
             let v = js! {
-                return @{&self.as_ref()}.search(
+                return @{&self.as_ref()}.findPath(
                     pos_from_packed(@{from.packed_repr()}),
                     pos_from_packed(@{to.packed_repr()}),
                     {
                         ignoreCreeps: @{ignore_creeps},
-                        ignoreDestructibleStructures: @{ignore_destructible_structures}
+                        ignoreDestructibleStructures: @{ignore_destructible_structures},
                         costCallback: @{callback},
                         maxOps: @{max_ops},
                         heuristicWeight: @{heuristic_weight},


### PR DESCRIPTION
Corrects the function name on the underlying room object and adds a missing comma in `Room::find_path()` - fixes #264