### PR TITLE
Minor fixes for creating named construction sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased
 - Change `RoomObjectProperties::room()` to return `Option<Room>` to handle the cases that the base
   game API leaves it undefined: for construction sites and flags in non-visible rooms (breaking)
 - Fix `Room::find_path` function call to underlying javascript
+- Fix typo in `Position::create_named_construction_site` and work around screeps bug in
+  `Room::create_named_construction_site` by passing x and y instead of position object
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/local/room_position/game_methods.rs
+++ b/src/local/room_position/game_methods.rs
@@ -20,7 +20,7 @@ impl Position {
     pub fn create_named_construction_site(self, ty: StructureType, name: &str) -> ReturnCode {
         js_unwrap!(
             pos_from_packed(@{self.packed_repr()})
-                .createConstructionSite(__structure_type_num_to_str(@{ty as u32}, @{name}))
+                .createConstructionSite(__structure_type_num_to_str(@{ty as u32}), @{name})
         )
     }
 

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -73,7 +73,11 @@ impl Room {
     {
         let pos = at.pos();
         js_unwrap!(@{self.as_ref()}.createConstructionSite(
-            pos_from_packed(@{pos.packed_repr()}),
+            // pos_from_packed(@{pos.packed_repr()}),
+            // workaround - passing with a position and a name
+            // currently broken, use x,y instead
+            @{pos.x()},
+            @{pos.y()},
             __structure_type_num_to_str(@{ty as u32}),
             @{name}
         ))


### PR DESCRIPTION
 - `Position::create_named_construction_site` had a minor parentheses typo causing the name to be discarded, fixed.
 - `Room::create_named_construction_site` is correct but there's currently a bug in the underlying screeps code that's causing it to always return as invalid args when used in the `(pos, structureType, name)` form which isn't present in the `(x, y, structureType, name)` form.  Need to open an issue against the base game, but the issue's easy to reproduce:

```
// broken, always returns -10
Game.rooms.W9N9.createConstructionSite(new RoomPosition(17, 30, 'W9N9'), STRUCTURE_SPAWN, 'foo')
// works
Game.rooms.W9N9.createConstructionSite(17, 30, STRUCTURE_SPAWN, 'foo')
// also works
Game.rooms.W9N9.createConstructionSite(new RoomPosition(17, 30, 'W9N9'), STRUCTURE_SPAWN)
```

This works around that for now by using the x, y form.