### PR TITLE
Screeps 4.1 new features and deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- Add `game::map::get_room_status()` as interface to new `Game.map.getRoomStatus()` function
+- Deprecate `game::map::is_room_available()`, the underlying function it uses is now deprecated
+- Add `StructureLab::reverse_reaction()` as interface to new `reverseReaction()`
 - Add `effects()` to room objects, allowing access to the effects applied on room objects which
   are used by both strongholds and power creeps.  New `EffectType` enum returned by this call
   represents the `NaturalEffectType` (for stronghold effects) or `PowerType` (for power creeps)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Unreleased
 ==========
 
 - Add `game::map::get_room_status()` as interface to new `Game.map.getRoomStatus()` function
-- Deprecate `game::map::is_room_available()`, the underlying function it uses is now deprecated
+- Remove deprecated `game::map::is_room_available()`, use new `get_room_status` instead
 - Add `StructureLab::reverse_reaction()` as interface to new `reverseReaction()`
 - Add `effects()` to room objects, allowing access to the effects applied on room objects which
   are used by both strongholds and power creeps.  New `EffectType` enum returned by this call

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -19,6 +19,10 @@ impl StructureLab {
         js_unwrap! {@{self.as_ref()}.runReaction(@{lab1.as_ref()}, @{lab2.as_ref()})}
     }
 
+    pub fn reverse_reaction(&self, lab1: &StructureLab, lab2: &StructureLab) -> ReturnCode {
+        js_unwrap! {@{self.as_ref()}.reverseReaction(@{lab1.as_ref()}, @{lab2.as_ref()})}
+    }
+
     pub fn unboost_creep(&self, creep: &Creep) -> ReturnCode {
         js_unwrap!(@{self.as_ref()}.unboostCreep(@{creep.as_ref()}))
     }


### PR DESCRIPTION
Updates to track changes to the base game API in version 4.1 - note that this version is currently in the public test realm branch and is not yet released, so these endpoints don't work on non-PTR servers yet.  Changelog [here](https://screeps.com/forum/topic/2900/ptr-changelog-2019-12-21).

 - `Game.map.isRoomAvailable` is now giving deprecation warnings in the base game, marked as deprecated.  It's replaced with `Game.map.getRoomStatus`, which returns more details about the room's state.
 - Labs can now break down components; added `StructureLab::reverse_reaction`