### PR TITLE
Add move_pulled_by to allow accepting pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased
   `repair()` to accept `StructureProperties` matching `Creep::repair()`
 - Update `Creep::heal()` and `ranged_heal()` to target anything with the `SharedCreepProperties`
   trait to allow use on power creeps
+- Add `Creep::move_pulled_by()` which allows a creep to accept another creep's attempt to `pull`
 - Remove `StructurePowerSpawn::power()` and `power_capacity()` (replaced with `HasStore` functions)
 - Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now
   using the `energy()` implementation from `HasStore`

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -124,6 +124,7 @@ creep_simple_concrete_action! {
         pub fn build(ConstructionSite) = build();
         pub fn claim_controller(StructureController) = claimController();
         pub fn generate_safe_mode(StructureController) = generateSafeMode();
+        pub fn move_pulled_by(Creep) = move();
         pub fn pull(Creep) = pull();
         pub fn reserve_controller(StructureController) = reserveController();
         pub fn upgrade_controller(StructureController) = upgradeController();


### PR DESCRIPTION
Fixes #261, adding a function to call the underlying `move()` function with a creep reference, allowing a creep to accept a `pull()` from another creep.