### PR TITLE
Return RoomName for game::map::describe_exits values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Unreleased
   `MarketResourceType` to specify resource (breaking)
 - Update `game::market::calc_transaction_cost()` to work with `RoomName` instead of `&Room` to
   avoid requiring visibility of both rooms (breaking)
+- Change `game::map::describe_exits()` to use `RoomName` instead of `String` for values (breaking)
 - Add `Creep::move_pulled_by()` which allows a creep to accept another creep's attempt to `pull`
 - Remove `StructurePowerSpawn::power()` and `power_capacity()` (replaced with `HasStore` functions)
 - Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -18,8 +18,8 @@ use crate::{
 /// See [http://docs.screeps.com/api/#Game.map.describeExits]
 ///
 /// [http://docs.screeps.com/api/#Game.map.describeExits]: http://docs.screeps.com/api/#Game.map.describeExits
-pub fn describe_exits(room_name: RoomName) -> collections::HashMap<Direction, String> {
-    let orig: collections::HashMap<String, String> =
+pub fn describe_exits(room_name: RoomName) -> collections::HashMap<Direction, RoomName> {
+    let orig: collections::HashMap<String, RoomName> =
         js_unwrap!(Game.map.describeExits(@{room_name}));
 
     orig.into_iter()


### PR DESCRIPTION
Just a little one - parse `describeExits` returned values as `RoomName` native types instead of `String`