### PR TITLE
Fix property name mismatch in controller reservation function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Unreleased
 - Fix `Room::find_path` function call to underlying javascript
 - Fix typo in `Position::create_named_construction_site` and work around screeps bug in
   `Room::create_named_construction_site` by passing x and y instead of position object
+- Fix typo in `StructureController::reservation()` ticks_to_end return value
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -39,7 +39,7 @@ impl StructureController {
         if let Value::Reference(r) = js!(return @{self.as_ref()}.reservation;) {
             Some(Reservation {
                 username: js_unwrap!(@{&r}.username),
-                ticks_to_end: js_unwrap!(@{&r}.ticks_to_end),
+                ticks_to_end: js_unwrap!(@{&r}.ticksToEnd),
             })
         } else {
             None


### PR DESCRIPTION
Minor one, the underlying js property for `ticks_to_end` is the camelcase `ticksToEnd`, but the parse is currently looking for it at `ticks_to_end` causing a panic.