### PR TITLE
Mineral amount and density return value types reversed, work around non-integer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Unreleased
 - Fix `Room::find_path` function call to underlying javascript
 - Fix typo in `Position::create_named_construction_site` and work around screeps bug in
   `Room::create_named_construction_site` by passing x and y instead of position object
+- Correct swapped return types for `Mineral::density()` and `Mineral::mineral_amount()` and add
+  a workaround for some private servers returning floating point `mineralAmount` values
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -5,8 +5,7 @@ use crate::{
 
 simple_accessors! {
     impl Mineral {
-        pub fn density() -> u32 = density;
-        pub fn mineral_amount() -> Density = mineralAmount;
+        pub fn density() -> Density = density;
         // id from HasId trait
         pub fn ticks_to_regeneration() -> u32 = ticksToRegeneration;
     }
@@ -15,5 +14,10 @@ simple_accessors! {
 impl Mineral {
     pub fn mineral_type(&self) -> ResourceType {
         js_unwrap!(__resource_type_str_to_num(@{self.as_ref()}.mineralType))
+    }
+
+    pub fn mineral_amount(&self) -> u32 {
+        // workaround for the fact that some private servers return floating point mineralAmount values
+        js_unwrap!(Math.floor(@{self.as_ref()}.mineralAmount))
     }
 }


### PR DESCRIPTION
A couple changes with `Mineral`:

- `density()` and `mineral_amount()` had their return types swapped, fixed.
- `mineral_amount()` seems to return floating-point values on some (at least those that are mongo-backed) private server implementations - worked around that by wrapping the returned value in `Math.floor()`.