### PR TITLE
Fix Spawning javascript object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Unreleased
 - Fix `Room::find_path` function call to underlying javascript
 - Fix typo in `Position::create_named_construction_site` and work around screeps bug in
   `Room::create_named_construction_site` by passing x and y instead of position object
+- Fix javascript associated object name for `StructureSpawn::spawning`
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -99,7 +99,7 @@ reference_wrappers! {
     pub struct StructureRoad(...);
     #[reference(instance_of = "StructureSpawn")]
     pub struct StructureSpawn(...);
-    #[reference(instance_of = "Spawning")]
+    #[reference(instance_of = "StructureSpawn.Spawning")]
     pub struct Spawning(...);
     #[reference(instance_of = "StructureStorage")]
     pub struct StructureStorage(...);


### PR DESCRIPTION
The underlying js object for the `StructureSpawn.spawning` interface is `StructureSpawn.Spawning`, but the rust interface currently points to `Spawning` which doesn't exist.  Fixes #275.