### PR TITLE
Fix has_owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Unreleased
   a workaround for some private servers returning floating point `mineralAmount` values
 - Fix typo in `StructureController::reservation()` ticks_to_end return value
 - Fix reversed conversion of `TOUGH` and `HEAL` parts
+- Fix `OwnedStructureProperties::has_owner()` to correctly return false for unowned structures
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -302,10 +302,10 @@ pub unsafe trait OwnedStructureProperties: StructureProperties {
     fn my(&self) -> bool {
         js_unwrap!(@{self.as_ref()}.my || false)
     }
-    /// Whether this structure is currently owned by someone (in JS: `my !==
+    /// Whether this structure is currently owned by someone (in JS: `owner !==
     /// undefined`)
     fn has_owner(&self) -> bool {
-        js_unwrap!(@{self.as_ref()}.my !== undefined)
+        js_unwrap!(@{self.as_ref()}.owner !== undefined)
     }
     /// The name of the owner of this structure, if any.
     fn owner_name(&self) -> Option<String> {


### PR DESCRIPTION
It's not the `my` property but the `owner` property that gets undefined when a structure is unowned.

Tested only for StructureController, which returns `controller.my == false` in JS for unowned controllers but I think this likely extends to other structures too.