### PR TITLE
Work around null return from describeExits function for closed rooms on private servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Unreleased
 - Fix typo in `StructureController::reservation()` ticks_to_end return value
 - Fix reversed conversion of `TOUGH` and `HEAL` parts
 - Fix `OwnedStructureProperties::has_owner()` to correctly return false for unowned structures
+- Work around a case where `map::describe_exits()` would panic when a private server returns null
+  for an unavailable room
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -20,7 +20,7 @@ use crate::{
 /// [http://docs.screeps.com/api/#Game.map.describeExits]: http://docs.screeps.com/api/#Game.map.describeExits
 pub fn describe_exits(room_name: RoomName) -> collections::HashMap<Direction, RoomName> {
     let orig: collections::HashMap<String, RoomName> =
-        js_unwrap!(Game.map.describeExits(@{room_name}));
+        js_unwrap!(Game.map.describeExits(@{room_name}) || {});
 
     orig.into_iter()
         .map(|(key, value)| {

--- a/src/local.rs
+++ b/src/local.rs
@@ -16,6 +16,6 @@ mod room_position;
 const HALF_WORLD_SIZE: i32 = 128;
 
 /// Valid room name coordinates.
-const VALID_ROOM_NAME_COORDINATES: Range<i32> = (-HALF_WORLD_SIZE..HALF_WORLD_SIZE);
+const VALID_ROOM_NAME_COORDINATES: Range<i32> = -HALF_WORLD_SIZE..HALF_WORLD_SIZE;
 
 pub use self::{object_id::*, room_name::*, room_position::*};

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -17,7 +17,8 @@ impl Mineral {
     }
 
     pub fn mineral_amount(&self) -> u32 {
-        // workaround for the fact that some private servers return floating point mineralAmount values
+        // workaround for the fact that some private servers return floating point
+        // mineralAmount values
         js_unwrap!(Math.floor(@{self.as_ref()}.mineralAmount))
     }
 }


### PR DESCRIPTION
On mongo-backed private servers, calls to `Game.map.describeExits()` for a 'closed' room will return `null` instead of the exit data, which is returned properly for closed rooms on the main servers, causing a panic - this works around the problem by defaulting to an empty object if the function returned nothing.

Also a couple unrelated formatting changes the nightly formatter preferred ;)