### PR TITLE
Filter hidden _sum key from store keys.

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -346,7 +346,7 @@ pub unsafe trait HasStore: RoomObjectProperties {
     }
 
     fn store_types(&self) -> Vec<ResourceType> {
-        js_unwrap!(Object.keys(@{self.as_ref()}.store).map(__resource_type_str_to_num))
+        js_unwrap!(Object.keys(@{self.as_ref()}.store).filter(function (r) { return r !== "_sum" }).map(__resource_type_str_to_num))
     }
 
     fn store_of(&self, ty: ResourceType) -> u32 {


### PR DESCRIPTION
There is an undocumented "_sum" key on the store API that contains the total resources available on the store. This breaks querying the store types which attempts to map all the keys to a resource type.

I did not change the store_total API to use the hidden key as despite it being faster, it is not documented in the official API and may just be an implementation detail.