### PR TITLE
Fix potential panic on calling source or mineral ticks_to_regeneration() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Unreleased
 - Fix `OwnedStructureProperties::has_owner()` to correctly return false for unowned structures
 - Work around a case where `map::describe_exits()` would panic when a private server returns null
   for an unavailable room
+- Change `Source` and `Mineral` `ticks_to_regeneration()` functions to return `Option<u32>`, to
+  avoid a panic when js returns undefined when the regen timers have not been started
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -7,7 +7,7 @@ simple_accessors! {
     impl Mineral {
         pub fn density() -> Density = density;
         // id from HasId trait
-        pub fn ticks_to_regeneration() -> u32 = ticksToRegeneration;
+        pub fn ticks_to_regeneration() -> Option<u32> = ticksToRegeneration;
     }
 }
 

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -4,6 +4,6 @@ simple_accessors! {
     impl Source {
         pub fn energy() -> u32 = energy;
         pub fn energy_capacity() -> u32 = energyCapacity;
-        pub fn ticks_to_regeneration() -> u32 = ticksToRegeneration;
+        pub fn ticks_to_regeneration() -> Option<u32> = ticksToRegeneration;
     }
 }


### PR DESCRIPTION
In cases where the regeneration timer hasn't started (nothing has been harvested since last regen), sources and minerals return undefined for `ticksToRegeneration`. This changes both to `Option<u32>` to be able to handle those cases without a panic.