### PR TITLE
Handle negative ticksToRegeneration return values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ Unreleased
 - Fix `OwnedStructureProperties::has_owner()` to correctly return false for unowned structures
 - Work around a case where `map::describe_exits()` would panic when a private server returns null
   for an unavailable room
-- Change `Source` and `Mineral` `ticks_to_regeneration()` functions to return `Option<u32>`, to
-  avoid a panic when js returns undefined when the regen timers have not been started
+- Change `Source` and `Mineral` `ticks_to_regeneration()` functions to return 0, preventing panics
+  in cases where the game API returns negative or undefined values
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -22,6 +22,6 @@ impl Mineral {
     }
 
     pub fn ticks_to_regeneration(&self) -> u32 {
-        js_unwrap!(Math.max(0, @{self.as_ref()}.ticksToRegeneration))
+        js_unwrap!(Math.max(0, @{self.as_ref()}.ticksToRegeneration || 0))
     }
 }

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -7,7 +7,6 @@ simple_accessors! {
     impl Mineral {
         pub fn density() -> Density = density;
         // id from HasId trait
-        pub fn ticks_to_regeneration() -> Option<u32> = ticksToRegeneration;
     }
 }
 
@@ -20,5 +19,9 @@ impl Mineral {
         // workaround for the fact that some private servers return floating point
         // mineralAmount values
         js_unwrap!(Math.floor(@{self.as_ref()}.mineralAmount))
+    }
+
+    pub fn ticks_to_regeneration(&self) -> u32 {
+        js_unwrap!(Math.max(0, @{self.as_ref()}.ticksToRegeneration))
     }
 }

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -4,6 +4,11 @@ simple_accessors! {
     impl Source {
         pub fn energy() -> u32 = energy;
         pub fn energy_capacity() -> u32 = energyCapacity;
-        pub fn ticks_to_regeneration() -> Option<u32> = ticksToRegeneration;
+    }
+}
+
+impl Source {
+    pub fn ticks_to_regeneration(&self) -> u32 {
+        js_unwrap!(Math.max(0, @{self.as_ref()}.ticksToRegeneration))
     }
 }

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -9,6 +9,6 @@ simple_accessors! {
 
 impl Source {
     pub fn ticks_to_regeneration(&self) -> u32 {
-        js_unwrap!(Math.max(0, @{self.as_ref()}.ticksToRegeneration))
+        js_unwrap!(Math.max(0, @{self.as_ref()}.ticksToRegeneration || 0))
     }
 }


### PR DESCRIPTION
On the official servers, sources in rooms that regenerate while the room is considered 'inactive' by the servers can sometimes return negative values for `ticksToRegeneration` - this wraps the returned value in a `Math.max` with 0 to handle that case.  Since I'd just made that an `Option<u32>` in  #285 but that condition is also handled by this fix, I switched the returned value back to no longer be option-wrapped (and applied the change to minerals for consistency, even though I'm not certain they can also get negative values).