### PR TITLE
Disable nodejs test due to upstream cargo-web issues with rust >= 1.44

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,3 @@ script:
 jobs:
   allow_failures:
     - rust: nightly
-    - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,5 @@ script:
 - cargo web test --verbose --nodejs
 jobs:
   allow_failures:
-    - rust: 
-      - nightly
-      - stable
+    - rust: nightly
+    - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,5 @@ script:
 - cargo web build --target=wasm32-unknown-unknown --verbose
 - cargo web build --target=wasm32-unknown-unknown --all-features --verbose
 - cargo test --verbose
-- cargo web test --verbose --nodejs
+# Temporarily disabled due to issues on 1.44 nightly builds, see issue #287
+#- cargo web test --verbose --nodejs

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,4 +32,6 @@ script:
 - cargo web test --verbose --nodejs
 jobs:
   allow_failures:
-    - rust: nightly
+    - rust: 
+      - nightly
+      - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 - cargo web build --target=wasm32-unknown-unknown --verbose
 - cargo web build --target=wasm32-unknown-unknown --all-features --verbose
 - cargo test --verbose
-- cargo web test --verbose --nodejs
+#- cargo web test --verbose --nodejs
 jobs:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
Temporarily comments out the test that's failing on current nightly builds.