### PR TITLE
0.8.0 release changelog prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,61 +1,76 @@
 Unreleased
 ==========
 
-- Add `game::map::get_room_status()` as interface to new `Game.map.getRoomStatus()` function
-- Remove deprecated `game::map::is_room_available()`, use new `get_room_status` instead
-- Add `StructureLab::reverse_reaction()` as interface to new `reverseReaction()`
-- Add `effects()` to room objects, allowing access to the effects applied on room objects which
-  are used by both strongholds and power creeps.  New `EffectType` enum returned by this call
-  represents the `NaturalEffectType` (for stronghold effects) or `PowerType` (for power creeps)
+
+0.8.0 (2020-03-26)
+==================
+
+### Notably breaking:
+
+- Remove deprecated `game::map::is_room_available`, use new `get_room_status` instead
 - Move creep functions which are implemented identically on power creeps to `SharedCreepProperties`
-  trait (breaking)
-- Add `game::gpl::level()`, `game::gpl::progress()` and `game::gpl::progress_total()`
-- Add `StructureController::is_power_enabled()`
-- Add `game::power_creeps` access, which returns a special `AccountPowerCreep` reference due
-  to the fact that these power creeps may not be spawned on the current shard and allow spawning.
-  Use `AccountPowerCreep::get_power_creep()` which returns `Option<PowerCreep>` to get the living
-  power creep, if spawned on the current shard.
-- Add `PowerCreepClass` enum to represent power creep classes, currently only `Operator`
-- Update `StructureTower::attack()` and `heal()` to allow targeting power creeps, and update
-  `repair()` to accept `StructureProperties` matching `Creep::repair()`
-- Update `Creep::heal()` and `ranged_heal()` to target anything with the `SharedCreepProperties`
-  trait to allow use on power creeps
-- Add `MarketResourceType` enum, which can wrap either a `ResourceType` or `IntershardResourceType`
-  and switch to using it for `game::market` endpoints which accept either type (breaking)
+  trait
 - Update integer representation of `IntershardResource::SubscriptionToken` to move out of conflict
-  with normal resources to allow parsing market orders which might have either (breaking)
-- Add `game::market::get_history()` and `game::market::OrderHistoryRecord` exposing new
-  `getHistory()` API function
+  with normal resources to allow parsing market orders which might have either
 - Update `game::market` functions to be able to work with intershard orders and transactions for
   them, making `RoomName` optional in many cases as it's not used for intershard transactions
-  (breaking)
 - Update field visibility on `game::market` structs used as return values to public, update to
   native types for `ResourceType` and `RoomName` values, and make a number of fields optional for
-  compatibility with intershard orders (breaking)
-- Update `game::market::create_order()` to use the currently documented object syntax and new
-  `MarketResourceType` to specify resource (breaking)
-- Update `game::market::calc_transaction_cost()` to work with `RoomName` instead of `&Room` to
-  avoid requiring visibility of both rooms (breaking)
-- Change `game::map::describe_exits()` to use `RoomName` instead of `String` for values (breaking)
-- Add `Creep::move_pulled_by()` which allows a creep to accept another creep's attempt to `pull`
-- Remove `StructurePowerSpawn::power()` and `power_capacity()` (replaced with `HasStore` functions)
-- Remove explicitly implemented `Creep::energy()` function which used deprecated `.carry`, now
-  using the `energy()` implementation from `HasStore`
-- Change `RoomObjectProperties::room()` to return `Option<Room>` to handle the cases that the base
-  game API leaves it undefined: for construction sites and flags in non-visible rooms (breaking)
+  compatibility with intershard orders
+- Update `game::market::create_order` to use the currently documented object syntax and new
+  `MarketResourceType` to specify resource
+- Update `game::market::calc_transaction_cost` to work with `RoomName` instead of `&Room` to
+  avoid requiring visibility of both rooms
+- Change `game::map::describe_exits` to use `RoomName` instead of `String` for values
+- Remove `StructurePowerSpawn::power` and `power_capacity` (replaced with `HasStore` functions)
+- Remove explicitly implemented `Creep::energy` function which used deprecated `.carry`, now
+  using the `energy` implementation from `HasStore`
+- Change `RoomObjectProperties::room` to return `Option<Room>` to handle the cases that the base
+  game API leaves it undefined: for construction sites and flags in non-visible rooms
+- Add `MarketResourceType` enum, which can wrap either a `ResourceType` or `IntershardResourceType`
+  and switch to using it for `game::market` endpoints which accept either type
+
+### Additions:
+
+- Add `game::map::get_room_status` as interface to new `Game.map.getRoomStatus` function
+- Add `StructureLab::reverse_reaction` as interface to new `reverseReaction`
+- Add `effects` to room objects, allowing access to the effects applied on room objects which
+  are used by both strongholds and power creeps.  New `EffectType` enum returned by this call
+  represents the `NaturalEffectType` (for stronghold effects) or `PowerType` (for power creeps)
+- Add `game::gpl::level`, `game::gpl::progress` and `game::gpl::progress_total`
+- Add `StructureController::is_power_enabled`
+- Add `game::power_creeps` access, which returns a special `AccountPowerCreep` reference due
+  to the fact that these power creeps may not be spawned on the current shard and allow spawning.
+  Use `AccountPowerCreep::get_power_creep` which returns `Option<PowerCreep>` to get the living
+  power creep, if spawned on the current shard.
+- Add `PowerCreepClass` enum to represent power creep classes, currently only `Operator`
+
+- Add `game::market::get_history` and `game::market::OrderHistoryRecord` exposing new
+  `getHistory` API function
+- Add `Creep::move_pulled_by` which allows a creep to accept another creep's attempt to `pull`
+
+### Bugfixes:
+
 - Fix `Room::find_path` function call to underlying javascript
 - Fix typo in `Position::create_named_construction_site` and work around screeps bug in
   `Room::create_named_construction_site` by passing x and y instead of position object
 - Fix javascript associated object name for `StructureSpawn::spawning`
-- Correct swapped return types for `Mineral::density()` and `Mineral::mineral_amount()` and add
+- Correct swapped return types for `Mineral::density` and `Mineral::mineral_amount` and add
   a workaround for some private servers returning floating point `mineralAmount` values
-- Fix typo in `StructureController::reservation()` ticks_to_end return value
+- Fix typo in `StructureController::reservation` ticks_to_end return value
 - Fix reversed conversion of `TOUGH` and `HEAL` parts
-- Fix `OwnedStructureProperties::has_owner()` to correctly return false for unowned structures
-- Work around a case where `map::describe_exits()` would panic when a private server returns null
+- Fix `OwnedStructureProperties::has_owner` to correctly return false for unowned structures
+- Work around a case where `map::describe_exits` would panic when a private server returns null
   for an unavailable room
-- Change `Source` and `Mineral` `ticks_to_regeneration()` functions to return 0, preventing panics
+- Change `Source` and `Mineral` `ticks_to_regeneration` functions to return 0, preventing panics
   in cases where the game API returns negative or undefined values
+
+### Misc:
+
+- Update `StructureTower::attack` and `heal` to allow targeting power creeps, and update
+  `repair` to accept `StructureProperties` matching `Creep::repair`
+- Update `Creep::heal` and `ranged_heal` to target anything with the `SharedCreepProperties`
+  trait to allow use on power creeps
 
 0.7.0 (2019-10-19)
 ==================
@@ -64,11 +79,11 @@ Unreleased
 
 - Remove `CanStoreEnergy` trait, moving all structures and creeps to `HasStore`, migrating from
   deprecated Screeps API endpoints to new `.store` API (breaking)
-    - Remove `Creep::carry_total()`, `Creep::carry_types()`, `Creep::carry_of()`
-    - Remove `StructureLab::mineral_amount()`, `StructureLab::mineral_capacity()`
-    - Remove `StructureNuker::ghodium()`, `StructureNuker::ghodium_capacity()`
-    - Change `HasStore::store_capacity()` to use new API and now takes `Option<ResourceType>`
-    - Add `HasStore::store_free_capacity()` and `HasStore::store_used_capacity()`, which both
+    - Remove `Creep::carry_total`, `Creep::carry_types`, `Creep::carry_of`
+    - Remove `StructureLab::mineral_amount`, `StructureLab::mineral_capacity`
+    - Remove `StructureNuker::ghodium`, `StructureNuker::ghodium_capacity`
+    - Change `HasStore::store_capacity` to use new API and now takes `Option<ResourceType>`
+    - Add `HasStore::store_free_capacity` and `HasStore::store_used_capacity`, which both
     take `Option<ResourceType>`
 - Change return type of `game::rooms::keys` from `Vec<String>` to `Vec<RoomName>`
 - Change `HasCooldown` trait to apply to objects with `RoomObjectProperties` instead of
@@ -82,7 +97,7 @@ Unreleased
 - Add new resource types for factory commodities
 - Add `Deposit` objects and related find/look constants
 - Add `Ruin` objects and related find/look constants
-- Change `Creep.harvest()` to work with any harvestable object type; `Deposit`, `Mineral`, and
+- Change `Creep.harvest` to work with any harvestable object type; `Deposit`, `Mineral`, and
   `Source`
 - Add `ObjectId<T>`, a typed binary object ID, and `RawObjectId`, an untyped binary object ID
   - untyped ids can be converted to typed freely - the type is purely for type inference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Unreleased
   game API leaves it undefined: for construction sites and flags in non-visible rooms
 - Add `MarketResourceType` enum, which can wrap either a `ResourceType` or `IntershardResourceType`
   and switch to using it for `game::market` endpoints which accept either type
+- Change `StructureTerminal::send` to take the destination room name as `RoomName` instead of
+  `&str` (breaking)
+- Change `game::market::get_all_orders` to accept an `Option<MarketResourceType>` as a filter
+  since this is optimized in the server code (breaking)
 
 ### Additions:
 
@@ -67,10 +71,6 @@ Unreleased
   for an unavailable room
 - Change `Source` and `Mineral` `ticks_to_regeneration` functions to return 0, preventing panics
   in cases where the game API returns negative or undefined values
-- Change `StructureTerminal::send` to take the destination room name as `RoomName` instead of
-  `&str` (breaking)
-- Change `game::market::get_all_orders` to accept an `Option<MarketResourceType>` as a filter
-  since this is optimized in the server code (breaking)
 
 ### Misc:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ Unreleased
 - Add `MarketResourceType` enum, which can wrap either a `ResourceType` or `IntershardResourceType`
   and switch to using it for `game::market` endpoints which accept either type
 - Change `StructureTerminal::send` to take the destination room name as `RoomName` instead of
-  `&str` (breaking)
+  `&str`
 - Change `game::market::get_all_orders` to accept an `Option<MarketResourceType>` as a filter
-  since this is optimized in the server code (breaking)
+  since this is optimized in the server code
 
 ### Additions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,14 @@ Unreleased
   `&str`
 - Change `game::market::get_all_orders` to accept an `Option<MarketResourceType>` as a filter
   since this is optimized in the server code
+- Change `HasStore::store_free_capacity` to return `i32`, handling potential negative values due
+  to expiration of `OPERATE_STORAGE`
 
 ### Additions:
 
+- Add `RoomVisual`, rendering primitives (`Circle`, `Line`, `Rect`, `Poly`, `Text`).
+- Add Visual rendering primitive enum for storage and batching.
+- Add `MoveToOptions::visualize_path_style`to allow for path visualization of movement system.
 - Add `ResourceType::reaction_components` function translating the `REACTIONS` constant
 - Add `ResourceType::commodity_recipe` function and `FactoryRecipe` struct translating the
   `COMMODITIES` constant
@@ -82,11 +87,6 @@ Unreleased
 - Update `Creep::heal` and `ranged_heal` to target anything with the `SharedCreepProperties`
   trait to allow use on power creeps
 - Change `MemoryReference::get` to return a generic error type
-- Add `RoomVisual`, rendering primitives (`Circle`, `Line`, `Rect`, `Poly`, `Text`).
-- Add Visual rendering primitive enum for storage and batching.
-- Add `MoveToOptions::visualize_path_style`to allow for path visualization of movement system.
-- Change `HasStore::store_free_capacity` to return `i32`, handling potential negative values due
-  to expiration of `OPERATE_STORAGE`
 
 0.7.0 (2019-10-19)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ Unreleased
   Use `AccountPowerCreep::get_power_creep` which returns `Option<PowerCreep>` to get the living
   power creep, if spawned on the current shard.
 - Add `PowerCreepClass` enum to represent power creep classes, currently only `Operator`
-
 - Add `game::market::get_history` and `game::market::OrderHistoryRecord` exposing new
   `getHistory` API function
 - Add `Creep::move_pulled_by` which allows a creep to accept another creep's attempt to `pull`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Unreleased
 - Add `game::market::get_history` and `game::market::OrderHistoryRecord` exposing new
   `getHistory` API function
 - Add `Creep::move_pulled_by` which allows a creep to accept another creep's attempt to `pull`
+- Add `SearchOptions::max_cost` to limit the maximum path cost for pathfinder searches
 
 ### Bugfixes:
 
@@ -71,6 +72,7 @@ Unreleased
   for an unavailable room
 - Change `Source` and `Mineral` `ticks_to_regeneration` functions to return 0, preventing panics
   in cases where the game API returns negative or undefined values
+- Fix visibility of struct fields on `MapRoomStatus` and `RoomRouteStep`
 
 ### Misc:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screeps-game-api"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["David Ross <daboross@daboross.net>"]
 documentation = "https://docs.rs/screeps-game-api/"
 edition = "2018"

--- a/src/constants/recipes.rs
+++ b/src/constants/recipes.rs
@@ -10,7 +10,8 @@ pub struct FactoryRecipe {
     pub cooldown: u32,
     /// Components - resource type and amount
     pub components: HashMap<ResourceType, u32>,
-    /// Required factory level to be able to create this commodity, if restricted
+    /// Required factory level to be able to create this commodity, if
+    /// restricted
     pub level: Option<u32>,
 }
 

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -70,8 +70,8 @@ pub fn get_room_status(room_name: RoomName) -> MapRoomStatus {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MapRoomStatus {
-    status: RoomStatus,
-    timestamp: Option<u64>,
+    pub status: RoomStatus,
+    pub timestamp: Option<u64>,
 }
 js_deserializable!(MapRoomStatus);
 

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -256,7 +256,7 @@ pub fn get_all_orders(resource: Option<MarketResourceType>) -> Vec<Order> {
                     resourceType: __resource_type_num_to_str(@{resource_num})
                 })
             }
-        },
+        }
         None => js_unwrap!(Game.market.getAllOrders()),
     }
 }

--- a/src/objects/creep_shared.rs
+++ b/src/objects/creep_shared.rs
@@ -8,8 +8,8 @@ use crate::{
     local::{Position, RoomName},
     memory::MemoryReference,
     objects::{
-        Creep, FindOptions, HasPosition, PowerCreep, Resource, RoomObjectProperties, Step,
-        Transferable, Withdrawable, PolyStyle
+        Creep, FindOptions, HasPosition, PolyStyle, PowerCreep, Resource, RoomObjectProperties,
+        Step, Transferable, Withdrawable,
     },
     pathfinder::{CostMatrix, SearchResults},
     ConversionError,
@@ -318,7 +318,8 @@ where
         self
     }
 
-    /// Sets the style to trace the path used by this creep. See doc for default.
+    /// Sets the style to trace the path used by this creep. See doc for
+    /// default.
     pub fn visualize_path_style(mut self, style: PolyStyle) -> Self {
         self.visualize_path_style = Some(style);
         self

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -5,9 +5,10 @@
 //! optimized for Screeps.
 //!
 //! This is both more fine-grained and less automatic than other pathing
-//! methods, such as [`Room::find_path`]. `PathFinder` knows about terrain by
+//! methods, such as [`Room::find_path`][1]. `PathFinder` knows about terrain by
 //! default, but you must configure any other obstacles you want it to consider.
 //!
+//! [1]: crate::objects::Room::find_path
 //! [`PathFinder`]: https://docs.screeps.com/api/#PathFinder
 use std::{f64, marker::PhantomData, mem};
 


### PR DESCRIPTION
Reorganize changelog to prep for a release, ~~as well as a minor fix to the visibility of the MapRoomStatus struct~~ (handled in #300)