### PR TITLE
Fill an array buffer from room terrain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Unreleased
   `&str` (breaking)
 - Change `game::market::get_all_orders` to accept an `Option<MarketResourceType>` as a filter
   since this is optimized in the server code (breaking)
+- Add `RoomTerrain::get_raw_buffer_to_array` to load a room's terrain into an existing `[u8; 2500]`
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -45,4 +45,26 @@ impl RoomTerrain {
             Err(ReturnCode::InvalidArgs)
         }
     }
+
+    pub fn get_raw_buffer_to_array<'a>(
+        &self,
+        buffer: &'a mut [u8; 2500],
+    ) -> Result<(), ReturnCode> {
+        let is_success: bool;
+        {
+            let arr: UnsafeTypedArray<'_, u8> = unsafe { UnsafeTypedArray::new(&buffer[0..2500]) };
+
+            is_success = js! {
+                var bytes = @{arr};
+                return @{self.as_ref()}.getRawBuffer(bytes) === bytes;
+            }
+            .try_into()
+            .unwrap();
+        }
+        if is_success {
+            Ok(())
+        } else {
+            Err(ReturnCode::InvalidArgs)
+        }
+    }
 }


### PR DESCRIPTION
This adds a function, similar to `get_raw_buffer_to_vec`, but it fills caller's buffer instead of allocating new storage.

Allowing use of the caller's buffer allows the caller to do more advanced memory management.