### PR TITLE
Implement move_to visualization options

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -28,7 +28,7 @@ mod impls;
 mod structure;
 
 pub use self::{
-    creep_shared::{MoveToOptions, SharedCreepProperties},
+    creep_shared::{LineStyle, MoveToOptions, PolyStyle, SharedCreepProperties},
     impls::{
         AttackEvent, AttackType, Bodypart, BuildEvent, Effect, Event, EventType, ExitEvent,
         FindOptions, HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path,


### PR DESCRIPTION
This implements the visualization options for move_to in #79.  

Introduces a few types that could be useful for someday implementing #46.  However a more comprehensive implementation of `RoomVisual` is outside the scope of this PR.

A lot of the JS serialization stuff is new to me, send feedback