### PR TITLE
Use RoomName for destination on StructureTerminal::send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Unreleased
   for an unavailable room
 - Change `Source` and `Mineral` `ticks_to_regeneration()` functions to return 0, preventing panics
   in cases where the game API returns negative or undefined values
+- Change `StructureTerminal::send` to take the destination room name as `RoomName` instead of
+  `&str` (breaking)
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/structure_terminal.rs
+++ b/src/objects/impls/structure_terminal.rs
@@ -1,5 +1,6 @@
 use crate::{
     constants::{ResourceType, ReturnCode},
+    local::RoomName,
     objects::StructureTerminal,
 };
 
@@ -8,7 +9,7 @@ impl StructureTerminal {
         &self,
         resource_type: ResourceType,
         amount: u32,
-        destination: &str,
+        destination: RoomName,
         description: Option<&str>,
     ) -> ReturnCode {
         js_unwrap! {


### PR DESCRIPTION
Missed another when moving to native `RoomName` for game object function calls - change `StructureTerminal`'s `send()` function to take `RoomName` instead of `&str`.