### PR TITLE
Improve the situation in the simulation mode

### DIFF
--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -54,19 +54,22 @@ impl fmt::Display for RoomName {
     /// [`RoomName::new`]: struct.RoomName.html#method.new
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let x_coord = self.x_coord();
-
-        if x_coord >= 0 {
-            write!(f, "E{}", x_coord)?;
-        } else {
-            write!(f, "W{}", -x_coord - 1)?;
-        }
-
         let y_coord = self.y_coord();
 
-        if y_coord >= 0 {
-            write!(f, "S{}", y_coord)?;
+        if self.packed == 0 {
+            write!(f, "sim")?;
         } else {
-            write!(f, "N{}", -y_coord - 1)?;
+            if x_coord >= 0 {
+                write!(f, "E{}", x_coord)?;
+            } else {
+                write!(f, "W{}", -x_coord - 1)?;
+            }
+
+            if y_coord >= 0 {
+                write!(f, "S{}", y_coord)?;
+            } else {
+                write!(f, "N{}", -y_coord - 1)?;
+            }
         }
 
         Ok(())
@@ -220,7 +223,7 @@ impl FromStr for RoomName {
 
 fn parse_to_coords(s: &str) -> Result<(i32, i32), ()> {
     if s == "sim" {
-        return Ok((0, 0));
+        return Ok((-HALF_WORLD_SIZE, -HALF_WORLD_SIZE));
     }
 
     let mut chars = s.char_indices();
@@ -452,7 +455,7 @@ mod test {
     #[test]
     fn test_string_equality() {
         use super::RoomName;
-        let room_names = vec!["E21N4", "w6S42", "W17s5", "e2n5"];
+        let room_names = vec!["E21N4", "w6S42", "W17s5", "e2n5", "sim"];
         for room_name in room_names {
             assert_eq!(room_name, RoomName::new(room_name).unwrap());
             assert_eq!(RoomName::new(room_name).unwrap(), room_name);


### PR DESCRIPTION
See #279

RoomName does not work in simulation mode, due to the way it is packed.  The room is named "sim", which does not unpack correctly into the integer.  There may be some clever way to reserve a value for it, but I am not sure how that would interface with screeps on the JS side.

I gather that sim mode is not used very heavily, although I find it useful for my problems.  Here are some hacks I've accumulated to make this work better

* new API to detect simulation mode in bots so they can special-case their own behavior
* game::room::get() will try `sim` if it can't find the room you asked for.  In sim mode, this is the only valid room, and in non-sim mode it should be `None`


