### PR TITLE
Add resource filter to market::get_all_orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Unreleased
   for an unavailable room
 - Change `Source` and `Mineral` `ticks_to_regeneration()` functions to return 0, preventing panics
   in cases where the game API returns negative or undefined values
+- Change `game::market::get_all_orders` to accept an `Option<MarketResourceType>` as a filter
+  since this is optimized in the server code (breaking)
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -246,17 +246,16 @@ pub fn extend_order(order_id: &str, add_amount: u32) -> ReturnCode {
 /// is available and will reduce the CPU cost compared to getting all orders
 pub fn get_all_orders(resource: Option<MarketResourceType>) -> Vec<Order> {
     match resource {
-        Some(resource_type) => match resource_type {
-            MarketResourceType::Resource(ty) => js_unwrap! {
+        Some(resource_type) => {
+            let resource_num = match resource_type {
+                MarketResourceType::Resource(ty) => ty as u32,
+                MarketResourceType::IntershardResource(ty) => ty as u32,
+            };
+            js_unwrap! {
                 Game.market.getAllOrders({
-                    resourceType: __resource_type_num_to_str(@{ty as u32})
+                    resourceType: __resource_type_num_to_str(@{resource_num})
                 })
-            },
-            MarketResourceType::IntershardResource(ty) => js_unwrap! {
-                Game.market.getAllOrders({
-                    resourceType: __resource_type_num_to_str(@{ty as u32})
-                })
-            },
+            }
         },
         None => js_unwrap!(Game.market.getAllOrders()),
     }

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -242,9 +242,24 @@ pub fn extend_order(order_id: &str, add_amount: u32) -> ReturnCode {
 
 /// Get all orders from the market
 ///
-/// Contrary to the JS version, filtering should be done afterwards.
-pub fn get_all_orders() -> Vec<Order> {
-    js_unwrap!(Game.market.getAllOrders())
+/// Full filtering support is not available, but filtering by resource type
+/// is available and will reduce the CPU cost compared to getting all orders
+pub fn get_all_orders(resource: Option<MarketResourceType>) -> Vec<Order> {
+    match resource {
+        Some(resource_type) => match resource_type {
+            MarketResourceType::Resource(ty) => js_unwrap! {
+                Game.market.getAllOrders({
+                    resourceType: __resource_type_num_to_str(@{ty as u32})
+                })
+            },
+            MarketResourceType::IntershardResource(ty) => js_unwrap! {
+                Game.market.getAllOrders({
+                    resourceType: __resource_type_num_to_str(@{ty as u32})
+                })
+            },
+        },
+        None => js_unwrap!(Game.market.getAllOrders()),
+    }
 }
 
 /// Provides historical information on the price of each resource over the last


### PR DESCRIPTION
The base game has an optimization for filtering by resource on `Game.market.getAllOrders` - it uses a 'full' lodash filter after retrieval but also grabs the `resourceType` key from that filter to limit what it's retrieving: https://github.com/screeps/engine/blob/d24939e8b5f44af3cefc0ca910a01e27e2aa2ae2/src/game/market.js#L37

This changes our `get_all_orders` interface to accept an `Option<MarketResourceType>` - sending `None` gets the normal behavior, while sending a specific resource will utilize that optimization, spending significantly less CPU time.