### PR TITLE
Allow for returning 'false' to pathfinder to prevent room pathing.

### DIFF
--- a/src/local/room_position/game_methods.rs
+++ b/src/local/room_position/game_methods.rs
@@ -4,7 +4,7 @@ use crate::{
     game,
     local::RoomName,
     objects::{FindOptions, Flag, HasPosition, LookResult, Path},
-    pathfinder::CostMatrix,
+    pathfinder::{SingleRoomCostResult, CostMatrix},
 };
 
 use super::Position;
@@ -64,18 +64,18 @@ impl Position {
         )
     }
 
-    pub fn find_path_to<'a, F, T>(self, target: &T, opts: FindOptions<'a, F>) -> Path
+    pub fn find_path_to<'a, F, T>(self, target: &T, opts: FindOptions<F, SingleRoomCostResult<'a>>) -> Path
     where
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'_>) -> SingleRoomCostResult<'a> + 'a,
         T: ?Sized + HasPosition,
     {
         let self_room = game::rooms::get(self.room_name()).unwrap();
         self_room.find_path(&self, target, opts)
     }
 
-    pub fn find_path_to_xy<'a, F>(self, x: u32, y: u32, opts: FindOptions<'a, F>) -> Path
+    pub fn find_path_to_xy<'a, F>(self, x: u32, y: u32, opts: FindOptions<F, SingleRoomCostResult<'a>>) -> Path
     where
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'_>) -> SingleRoomCostResult<'a> + 'a,
     {
         let target = Position::new(x, y, self.room_name());
         self.find_path_to(&target, opts)

--- a/src/objects/creep_shared.rs
+++ b/src/objects/creep_shared.rs
@@ -1,7 +1,7 @@
 use std::{marker::PhantomData, mem};
 
 use scoped_tls::scoped_thread_local;
-use stdweb::Reference;
+use stdweb::{Value, Reference};
 
 use crate::{
     constants::{Direction, ResourceType, ReturnCode},
@@ -11,11 +11,11 @@ use crate::{
         Creep, FindOptions, HasPosition, PowerCreep, Resource, RoomObjectProperties, Step,
         Transferable, Withdrawable,
     },
-    pathfinder::{CostMatrix, SearchResults},
+    pathfinder::{MultiRoomCostResult, CostMatrix, SearchResults},
     ConversionError,
 };
 
-scoped_thread_local!(static COST_CALLBACK: Box<dyn Fn(RoomName, Reference) -> Option<Reference>>);
+scoped_thread_local!(static COST_CALLBACK: Box<dyn Fn(RoomName, Reference) -> Value>);
 
 /// Trait for all wrappers over Screeps JavaScript objects that are creeps or
 /// power creeps
@@ -53,7 +53,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
         move_options: MoveToOptions<'a, F>,
     ) -> ReturnCode
     where
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'a> + 'a,
     {
         let pos = Position::new(x, y, self.pos().room_name());
         self.move_to_with_options(&pos, move_options)
@@ -71,7 +71,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
     ) -> ReturnCode
     where
         T: ?Sized + HasPosition,
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'a> + 'a,
     {
         let MoveToOptions {
             reuse_path,
@@ -94,7 +94,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
         } = move_options;
 
         // This callback is the one actually passed to JavaScript.
-        fn callback(room_name: String, cost_matrix: Reference) -> Option<Reference> {
+        fn callback(room_name: String, cost_matrix: Reference) -> Value {
             let room_name = room_name.parse().expect(
                 "expected room name passed into Creep.moveTo \
                  callback to be a valid room name",
@@ -111,12 +111,12 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
                 inner: cost_matrix_ref,
                 lifetime: PhantomData,
             };
-            raw_callback(room_name, cmatrix).map(|cm| cm.inner)
+            raw_callback(room_name, cmatrix).into()
         };
 
         // Type erased and boxed callback: no longer a type specific to the closure
         // passed in, now unified as Box<Fn>
-        let callback_type_erased: Box<dyn Fn(RoomName, Reference) -> Option<Reference> + 'a> =
+        let callback_type_erased: Box<dyn Fn(RoomName, Reference) -> Value + 'a> =
             Box::new(callback_boxed);
 
         // Overwrite lifetime of box inside closure so it can be stuck in
@@ -127,7 +127,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
         // scope but otherwise unknown" is not a valid lifetime to have
         // PF_CALLBACK have.
         let callback_lifetime_erased: Box<
-            dyn Fn(RoomName, Reference) -> Option<Reference> + 'static,
+            dyn Fn(RoomName, Reference) -> Value + 'static,
         > = unsafe { mem::transmute(callback_type_erased) };
 
         // Store callback_lifetime_erased in COST_CALLBACK for the duration of the
@@ -264,17 +264,17 @@ unsafe impl SharedCreepProperties for PowerCreep {}
 
 pub struct MoveToOptions<'a, F>
 where
-    F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: Fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'a>,
 {
     pub(crate) reuse_path: u32,
     pub(crate) serialize_memory: bool,
     pub(crate) no_path_finding: bool,
     // pub(crate) visualize_path_style: PolyStyle,
-    pub(crate) find_options: FindOptions<'a, F>,
+    pub(crate) find_options: FindOptions<F, MultiRoomCostResult<'a>>,
 }
 
 impl Default
-    for MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>>
+    for MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'static>>
 {
     fn default() -> Self {
         // TODO: should we fall back onto the game's default values, or is
@@ -289,7 +289,7 @@ impl Default
     }
 }
 
-impl MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>> {
+impl MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'static>> {
     /// Creates default SearchOptions
     pub fn new() -> Self {
         Self::default()
@@ -298,7 +298,7 @@ impl MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'s
 
 impl<'a, F> MoveToOptions<'a, F>
 where
-    F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: Fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'a>,
 {
     /// Enables caching of the calculated path. Default: 5 ticks
     pub fn reuse_path(mut self, n_ticks: u32) -> Self {
@@ -338,9 +338,9 @@ where
     }
 
     /// Sets cost callback - default `|_, _| {}`.
-    pub fn cost_callback<'b, F2>(self, cost_callback: F2) -> MoveToOptions<'b, F2>
+    pub fn cost_callback<F2>(self, cost_callback: F2) -> MoveToOptions<'a, F2>
     where
-        F2: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
+        F2: Fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'a>,
     {
         MoveToOptions {
             reuse_path: self.reuse_path,
@@ -393,9 +393,9 @@ where
     }
 
     /// Sets options related to FindOptions. Defaults to FindOptions default.
-    pub fn find_options<'b, F2>(self, find_options: FindOptions<'b, F2>) -> MoveToOptions<'b, F2>
+    pub fn find_options<'b, F2>(self, find_options: FindOptions<F2, MultiRoomCostResult<'b>>) -> MoveToOptions<'b, F2>
     where
-        F2: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
+        F2: Fn(RoomName, CostMatrix<'_>) -> MultiRoomCostResult<'b>
     {
         MoveToOptions {
             reuse_path: self.reuse_path,

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -12,7 +12,7 @@
 use std::{f64, marker::PhantomData, mem};
 
 use scoped_tls::scoped_thread_local;
-use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray};
+use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray, Value};
 
 use crate::{local::Position, objects::HasPosition, traits::TryInto};
 
@@ -175,9 +175,57 @@ mod serde_impls {
     }
 }
 
+pub trait RoomCostResult: Into<Value> {}
+
+pub enum MultiRoomCostResult<'a> {
+    CostMatrix(CostMatrix<'a>),
+    Impassable,
+    Default
+}
+
+impl<'a> RoomCostResult for MultiRoomCostResult<'a> {}
+
+impl<'a> Default for MultiRoomCostResult<'a> {
+    fn default() -> Self {
+        MultiRoomCostResult::Default
+    }
+}
+
+impl<'a> Into<Value> for MultiRoomCostResult<'a> {
+    fn into(self) -> Value {
+        match self {
+            MultiRoomCostResult::CostMatrix(m) => m.inner.into(),
+            MultiRoomCostResult::Impassable => Value::Bool(false),
+            MultiRoomCostResult::Default => Value::Undefined
+        }
+    }
+}
+
+pub enum SingleRoomCostResult<'a> {
+    CostMatrix(CostMatrix<'a>),
+    Default
+}
+
+impl<'a> RoomCostResult for SingleRoomCostResult<'a> {}
+
+impl<'a> Default for SingleRoomCostResult<'a> {
+    fn default() -> Self {
+        SingleRoomCostResult::Default
+    }
+}
+
+impl<'a> Into<Value> for SingleRoomCostResult<'a> {
+    fn into(self) -> Value {
+        match self {
+            SingleRoomCostResult::CostMatrix(m) => m.inner.into(),
+            SingleRoomCostResult::Default => Value::Undefined
+        }
+    }
+}
+
 pub struct SearchOptions<'a, F>
 where
-    F: Fn(String) -> CostMatrix<'a>,
+    F: Fn(String) -> MultiRoomCostResult<'a>,
 {
     room_callback: F,
     plain_cost: u8,
@@ -189,10 +237,10 @@ where
     heuristic_weight: f64,
 }
 
-impl Default for SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
+impl Default for SearchOptions<'static, fn(String) -> MultiRoomCostResult<'static>> {
     fn default() -> Self {
-        fn cost_matrix(_: String) -> CostMatrix<'static> {
-            CostMatrix::default()
+        fn cost_matrix(_: String) -> MultiRoomCostResult<'static> {
+            MultiRoomCostResult::Default
         }
 
         // TODO: should we fall back onto the game's default values, or is
@@ -210,7 +258,7 @@ impl Default for SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
     }
 }
 
-impl SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
+impl SearchOptions<'static, fn(String) -> MultiRoomCostResult<'static>> {
     /// Creates default SearchOptions
     #[inline]
     pub fn new() -> Self {
@@ -220,12 +268,12 @@ impl SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
 
 impl<'a, F> SearchOptions<'a, F>
 where
-    F: Fn(String) -> CostMatrix<'a>,
+    F: Fn(String) -> MultiRoomCostResult<'a>,
 {
     /// Sets room callback - default `|_| { CostMatrix::default() }`.
     pub fn room_callback<'b, F2>(self, room_callback: F2) -> SearchOptions<'b, F2>
     where
-        F2: Fn(String) -> CostMatrix<'b>,
+        F2: Fn(String) -> MultiRoomCostResult<'b>,
     {
         let SearchOptions {
             room_callback: _,
@@ -329,7 +377,7 @@ pub fn search<'a, O, G, F>(
 where
     O: ?Sized + HasPosition,
     G: ?Sized + HasPosition,
-    F: Fn(String) -> CostMatrix<'a> + 'a,
+    F: Fn(String) -> MultiRoomCostResult<'a> + 'a,
 {
     let pos = goal.pos();
     search_real(
@@ -345,7 +393,7 @@ where
     O: HasPosition,
     G: IntoIterator<Item = (I, u32)>,
     I: HasPosition,
-    F: Fn(String) -> CostMatrix<'a> + 'a,
+    F: Fn(String) -> MultiRoomCostResult<'a> + 'a,
 {
     let goals: Vec<Object> = goal
         .into_iter()
@@ -358,7 +406,7 @@ where
     search_real(origin.pos(), &goals_js, opts)
 }
 
-scoped_thread_local!(static PF_CALLBACK: &'static dyn Fn(String) -> Reference);
+scoped_thread_local!(static PF_CALLBACK: &'static dyn Fn(String) -> Value);
 
 fn search_real<'a, F>(
     origin: Position,
@@ -366,13 +414,13 @@ fn search_real<'a, F>(
     opts: SearchOptions<'a, F>,
 ) -> SearchResults
 where
-    F: Fn(String) -> CostMatrix<'a> + 'a,
+    F: Fn(String) -> MultiRoomCostResult<'a> + 'a,
 {
     // TODO: should we just accept `fn()` and force the user
     // to do this? it would... greatly simplify all of this.
 
     // This callback is the one actually passed to JavaScript.
-    fn callback(input: String) -> Reference {
+    fn callback(input: String) -> Value {
         PF_CALLBACK.with(|callback| callback(input))
     }
 
@@ -380,11 +428,11 @@ where
     let raw_callback = opts.room_callback;
 
     // Wrapped user callback: rust String -> Reference
-    let callback_unboxed = move |input| raw_callback(input).inner;
+    let callback_unboxed = move |input| raw_callback(input).into();
 
     // Type erased and boxed callback: no longer a type specific to the closure
     // passed in, now unified as &Fn
-    let callback_type_erased: &(dyn Fn(String) -> Reference + 'a) = &callback_unboxed;
+    let callback_type_erased: &(dyn Fn(String) -> Value + 'a) = &callback_unboxed;
 
     // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
     // storage: it's now pretending to be static data. This should be entirely safe
@@ -392,7 +440,7 @@ where
     // use of it, but it's still necessary because "some lifetime above the
     // current scope but otherwise unknown" is not a valid lifetime to have
     // PF_CALLBACK have.
-    let callback_lifetime_erased: &'static dyn Fn(String) -> Reference =
+    let callback_lifetime_erased: &'static dyn Fn(String) -> Value =
         unsafe { mem::transmute(callback_type_erased) };
 
     let SearchOptions {


### PR DESCRIPTION
There are 3 return options for multi-room pathfinding functions:
1. Return a new cost-matrix. This value is used instead of the passed in one.
2. Return false which prevents the path finder from using this room.
3. Returning any other value results in the default cost-matrix being used. (This only contains room terrain I believe.)

This requires splitting all pathfinding related functions in to ones that either operate on a single room or deal with multiple room pathing. There is still a common set of options that are represented by FindOptions. To support both multi and single room, FindOptions is now generic with respect to the type returned by the cost callback. To limit this to sane values a tag of RoomCostResult is required.