### PR TITLE
Prevent panic when store_free_capacity returns a negative value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,8 @@ Unreleased
   since this is optimized in the server code (breaking)
 - Add `RoomTerrain::get_raw_buffer_to_array` to load a room's terrain into an existing `[u8; 2500]`
 - Change `MemoryReference::get` to return a generic error type
-- Change `HasStore::store_free_capacity` to prevent panics on negative values due to expiration of
-  `OPERATE_STORAGE`
+- Change `HasStore::store_free_capacity` to return `i32`, handling potential negative values due
+  to expiration of `OPERATE_STORAGE`
 
 0.7.0 (2019-10-19)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Unreleased
   since this is optimized in the server code (breaking)
 - Add `RoomTerrain::get_raw_buffer_to_array` to load a room's terrain into an existing `[u8; 2500]`
 - Change `MemoryReference::get` to return a generic error type
+- Change `HasStore::store_free_capacity` to prevent panics on negative values due to expiration of
+  `OPERATE_STORAGE`
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -369,9 +369,9 @@ pub unsafe trait HasStore: RoomObjectProperties {
     fn store_free_capacity(&self, resource: Option<ResourceType>) -> u32 {
         match resource {
             Some(ty) => {
-                js_unwrap!(@{self.as_ref()}.store.getFreeCapacity(__resource_type_num_to_str(@{ty as u32})) || 0)
+                js_unwrap!(Math.max(0, @{self.as_ref()}.store.getFreeCapacity(__resource_type_num_to_str(@{ty as u32})) || 0))
             }
-            None => js_unwrap!(@{self.as_ref()}.store.getFreeCapacity() || 0),
+            None => js_unwrap!(Math.max(0, @{self.as_ref()}.store.getFreeCapacity() || 0)),
         }
     }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -366,12 +366,12 @@ pub unsafe trait HasStore: RoomObjectProperties {
         }
     }
 
-    fn store_free_capacity(&self, resource: Option<ResourceType>) -> u32 {
+    fn store_free_capacity(&self, resource: Option<ResourceType>) -> i32 {
         match resource {
             Some(ty) => {
-                js_unwrap!(Math.max(0, @{self.as_ref()}.store.getFreeCapacity(__resource_type_num_to_str(@{ty as u32})) || 0))
+                js_unwrap!(@{self.as_ref()}.store.getFreeCapacity(__resource_type_num_to_str(@{ty as u32})))
             }
-            None => js_unwrap!(Math.max(0, @{self.as_ref()}.store.getFreeCapacity() || 0)),
+            None => js_unwrap!(@{self.as_ref()}.store.getFreeCapacity()),
         }
     }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -369,9 +369,9 @@ pub unsafe trait HasStore: RoomObjectProperties {
     fn store_free_capacity(&self, resource: Option<ResourceType>) -> i32 {
         match resource {
             Some(ty) => {
-                js_unwrap!(@{self.as_ref()}.store.getFreeCapacity(__resource_type_num_to_str(@{ty as u32})))
+                js_unwrap!(@{self.as_ref()}.store.getFreeCapacity(__resource_type_num_to_str(@{ty as u32})) || 0)
             }
-            None => js_unwrap!(@{self.as_ref()}.store.getFreeCapacity()),
+            None => js_unwrap!(@{self.as_ref()}.store.getFreeCapacity() || 0),
         }
     }
 


### PR DESCRIPTION
Power creep `OPERATE_STORAGE` expiring can leave a storage with less capacity than resources, which causes `.store.getFreeCapacity()` to return a negative number, potentially causing a panic. Normalizes the return values to return 0 instead of panicking.