### PR TITLE
Prevent panic in calls to mineral_type() when labs are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ Unreleased
   since this is optimized in the server code (breaking)
 - Add `RoomTerrain::get_raw_buffer_to_array` to load a room's terrain into an existing `[u8; 2500]`
 - Change `MemoryReference::get` to return a generic error type
+- Change `StructureLab::mineral_type` to return `Option<ResourceType>`, avoiding panic when labs
+  are empty
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -1,11 +1,25 @@
+use stdweb::Value;
+
 use crate::{
     constants::{ResourceType, ReturnCode},
     objects::{Creep, StructureLab},
+    traits::TryFrom,
 };
 
 impl StructureLab {
     pub fn mineral_type(&self) -> Option<ResourceType> {
-        js_unwrap!(__resource_type_str_to_num(@{self.as_ref()}.mineralType))
+        let mineral_v = js! {
+            const mineral = @{self.as_ref()}.mineralType;
+            if (mineral) {
+                return __resource_type_str_to_num(mineral);
+            }
+        };
+        match mineral_v {
+            Value::Number(_) => {
+                Some(ResourceType::try_from(mineral_v).expect("lab resource unknown."))
+            }
+            _ => None,
+        }
     }
 
     pub fn boost_creep(&self, creep: &Creep, body_part_count: Option<u32>) -> ReturnCode {

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 impl StructureLab {
-    pub fn mineral_type(&self) -> ResourceType {
+    pub fn mineral_type(&self) -> Option<ResourceType> {
         js_unwrap!(__resource_type_str_to_num(@{self.as_ref()}.mineralType))
     }
 


### PR DESCRIPTION
Labs will return undefined for `mineralType` when empty - this changes our `mineral_type()` function to return an `Option<ResourceType>` to prevent panic when that's encountered.