### PR TITLE
Room visual API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ Unreleased
   since this is optimized in the server code (breaking)
 - Add `RoomTerrain::get_raw_buffer_to_array` to load a room's terrain into an existing `[u8; 2500]`
 - Change `MemoryReference::get` to return a generic error type
+- Add `RoomVisual`, rendering primitives (`Circle`, `Line`, `Rect`, `Poly`, `Text`).
+- Add Visual rendering primitive enum for storage and batching.
+- Add `MoveToOptions::visualize_path_style`to allow for path visualization of movement system.
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -30,10 +30,11 @@ mod structure;
 pub use self::{
     creep_shared::{MoveToOptions, SharedCreepProperties},
     impls::{
-        AttackEvent, AttackType, Bodypart, BuildEvent, Effect, Event, EventType, ExitEvent,
-        FindOptions, HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path,
-        PortalDestination, PositionedLookResult, RepairEvent, Reservation, ReserveControllerEvent,
-        Sign, SpawnOptions, Step, UpgradeControllerEvent,
+        AttackEvent, AttackType, Bodypart, BuildEvent, CircleStyle, Effect, Event, EventType,
+        ExitEvent, FindOptions, FontStyle, HarvestEvent, HealEvent, HealType, LineDrawStyle,
+        LineStyle, LookResult, ObjectDestroyedEvent, Path, PolyStyle, PortalDestination,
+        PositionedLookResult, RectStyle, RepairEvent, Reservation, ReserveControllerEvent,
+        RoomVisual, Sign, SpawnOptions, Step, TextAlign, TextStyle, UpgradeControllerEvent, Visual,
     },
     structure::Structure,
 };

--- a/src/objects/creep_shared.rs
+++ b/src/objects/creep_shared.rs
@@ -9,7 +9,7 @@ use crate::{
     memory::MemoryReference,
     objects::{
         Creep, FindOptions, HasPosition, PowerCreep, Resource, RoomObjectProperties, Step,
-        Transferable, Withdrawable,
+        Transferable, Withdrawable, PolyStyle
     },
     pathfinder::{CostMatrix, SearchResults},
     ConversionError,
@@ -77,7 +77,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
             reuse_path,
             serialize_memory,
             no_path_finding,
-            // visualize_path_style,
+            visualize_path_style,
             find_options:
                 FindOptions {
                     ignore_creeps,
@@ -143,7 +143,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
                         reusePath: @{reuse_path},
                         serializeMemory: @{serialize_memory},
                         noPathFinding: @{no_path_finding},
-                        visualizePathStyle: undefined,  // todo
+                        visualizePathStyle: @{visualize_path_style},
                         ignoreCreeps: @{ignore_creeps},
                         ignoreDestructibleStructures: @{ignore_destructible_structures},
                         costCallback: @{callback},
@@ -269,7 +269,7 @@ where
     pub(crate) reuse_path: u32,
     pub(crate) serialize_memory: bool,
     pub(crate) no_path_finding: bool,
-    // pub(crate) visualize_path_style: PolyStyle,
+    pub(crate) visualize_path_style: Option<PolyStyle>,
     pub(crate) find_options: FindOptions<'a, F>,
 }
 
@@ -283,7 +283,7 @@ impl Default
             reuse_path: 5,
             serialize_memory: true,
             no_path_finding: false,
-            // visualize_path_style: None,
+            visualize_path_style: None,
             find_options: FindOptions::default(),
         }
     }
@@ -318,11 +318,11 @@ where
         self
     }
 
-    // /// Sets the style to trace the path used by this creep. See doc for default.
-    // pub fn visualize_path_style(mut self, style: ) -> Self {
-    //     self.visualize_path_style = style;
-    //     self
-    // }
+    /// Sets the style to trace the path used by this creep. See doc for default.
+    pub fn visualize_path_style(mut self, style: PolyStyle) -> Self {
+        self.visualize_path_style = Some(style);
+        self
+    }
 
     /// Sets whether the algorithm considers creeps as walkable. Default: False.
     pub fn ignore_creeps(mut self, ignore: bool) -> Self {
@@ -346,7 +346,7 @@ where
             reuse_path: self.reuse_path,
             serialize_memory: self.serialize_memory,
             no_path_finding: self.no_path_finding,
-            // self.visualize_path_style,
+            visualize_path_style: self.visualize_path_style,
             find_options: self.find_options.cost_callback(cost_callback),
         }
     }
@@ -401,7 +401,7 @@ where
             reuse_path: self.reuse_path,
             serialize_memory: self.serialize_memory,
             no_path_finding: self.no_path_finding,
-            // self.visualize_path_style,
+            visualize_path_style: self.visualize_path_style,
             find_options,
         }
     }

--- a/src/objects/impls.rs
+++ b/src/objects/impls.rs
@@ -9,6 +9,7 @@ mod power_creep;
 mod resource;
 mod room;
 mod room_terrain;
+mod room_visual;
 mod ruin;
 mod source;
 mod structure_controller;
@@ -34,6 +35,10 @@ pub use self::{
         AttackEvent, AttackType, BuildEvent, Effect, Event, EventType, ExitEvent, FindOptions,
         HarvestEvent, HealEvent, HealType, LookResult, ObjectDestroyedEvent, Path,
         PositionedLookResult, RepairEvent, ReserveControllerEvent, Step, UpgradeControllerEvent,
+    },
+    room_visual::{
+        CircleStyle, FontStyle, LineDrawStyle, LineStyle, PolyStyle, RectStyle, RoomVisual,
+        TextAlign, TextStyle, Visual,
     },
     structure_controller::{Reservation, Sign},
     structure_portal::PortalDestination,

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -20,8 +20,8 @@ use crate::{
     memory::MemoryReference,
     objects::{
         ConstructionSite, Creep, Deposit, Flag, HasPosition, Mineral, Nuke, PowerCreep, Resource,
-        Room, RoomTerrain, Ruin, Source, Structure, StructureController, StructureStorage,
-        StructureTerminal, Tombstone,
+        Room, RoomTerrain, RoomVisual, Ruin, Source, Structure, StructureController,
+        StructureStorage, StructureTerminal, Tombstone,
     },
     pathfinder::CostMatrix,
     traits::{TryFrom, TryInto},
@@ -36,7 +36,6 @@ simple_accessors! {
         pub fn name() -> RoomName = name;
         pub fn storage() -> Option<StructureStorage> = storage;
         pub fn terminal() -> Option<StructureTerminal> = terminal;
-        // todo: visual
     }
 }
 
@@ -340,6 +339,10 @@ impl Room {
 
     pub fn name_local(&self) -> RoomName {
         js_unwrap!(@{self.as_ref()}.name)
+    }
+
+    pub fn visual(&self) -> RoomVisual {
+        RoomVisual::new(Some(self.name()))
     }
 }
 

--- a/src/objects/impls/room_visual.rs
+++ b/src/objects/impls/room_visual.rs
@@ -1,0 +1,411 @@
+use crate::local::RoomName;
+use serde::Serialize;
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CircleStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    radius: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fill: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+}
+js_serializable!(CircleStyle);
+
+impl CircleStyle {
+    pub fn radius(mut self, val: f32) -> CircleStyle {
+        self.radius = Some(val);
+        self
+    }
+
+    pub fn fill(mut self, val: &str) -> CircleStyle {
+        self.fill = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> CircleStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> CircleStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> CircleStyle {
+        self.stroke_width = Some(val);
+        self
+    }
+}
+
+#[derive(Serialize)]
+pub struct CircleData {
+    x: f32,
+    y: f32,
+    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
+    style: Option<CircleStyle>,
+}
+js_serializable!(CircleData);
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LineDrawStyle {
+    Solid,
+    Dashed,
+    Dotted,
+}
+js_serializable!(LineDrawStyle);
+
+impl Default for LineDrawStyle {
+    fn default() -> LineDrawStyle {
+        LineDrawStyle::Solid
+    }
+}
+
+impl LineDrawStyle {
+    pub fn is_solid(&self) -> bool {
+        match self {
+            LineDrawStyle::Solid => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LineStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "LineDrawStyle::is_solid")]
+    line_style: LineDrawStyle,
+}
+js_serializable!(LineStyle);
+
+impl LineStyle {
+    pub fn width(mut self, val: f32) -> LineStyle {
+        self.width = Some(val);
+        self
+    }
+
+    pub fn color(mut self, val: &str) -> LineStyle {
+        self.color = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> LineStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn line_style(mut self, val: LineDrawStyle) -> LineStyle {
+        self.line_style = val;
+        self
+    }
+}
+
+#[derive(Serialize)]
+pub struct LineData {
+    x1: f32,
+    y1: f32,
+    x2: f32,
+    y2: f32,
+    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
+    style: Option<LineStyle>,
+}
+js_serializable!(LineData);
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RectStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fill: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+    #[serde(skip_serializing_if = "LineDrawStyle::is_solid")]
+    line_style: LineDrawStyle,
+}
+js_serializable!(RectStyle);
+
+impl RectStyle {
+    pub fn fill(mut self, val: &str) -> RectStyle {
+        self.fill = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> RectStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> RectStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> RectStyle {
+        self.stroke_width = Some(val);
+        self
+    }
+
+    pub fn line_style(mut self, val: LineDrawStyle) -> RectStyle {
+        self.line_style = val;
+        self
+    }
+}
+
+#[derive(Serialize)]
+pub struct RectData {
+    x: f32,
+    y: f32,
+    #[serde(rename = "w")]
+    width: f32,
+    #[serde(rename = "h")]
+    height: f32,
+    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
+    style: Option<RectStyle>,
+}
+js_serializable!(RectData);
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PolyStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fill: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+    #[serde(skip_serializing_if = "LineDrawStyle::is_solid")]
+    line_style: LineDrawStyle,
+}
+js_serializable!(PolyStyle);
+
+impl PolyStyle {
+    pub fn fill(mut self, val: &str) -> PolyStyle {
+        self.fill = Some(val.to_string());
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> PolyStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> PolyStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> PolyStyle {
+        self.stroke_width = Some(val);
+        self
+    }
+
+    pub fn line_style(mut self, val: LineDrawStyle) -> PolyStyle {
+        self.line_style = val;
+        self
+    }
+}
+
+#[derive(Serialize)]
+pub struct PolyData {
+    points: Vec<(f32, f32)>,
+    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
+    style: Option<PolyStyle>,
+}
+js_serializable!(PolyData);
+
+#[derive(Serialize, Clone)]
+#[serde(untagged)]
+pub enum FontStyle {
+    Size(f32),
+    Custom(String),
+}
+js_serializable!(FontStyle);
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum TextAlign {
+    Center,
+    Left,
+    Right,
+}
+js_serializable!(TextAlign);
+
+impl Default for TextAlign {
+    fn default() -> TextAlign {
+        TextAlign::Center
+    }
+}
+
+impl TextAlign {
+    pub fn is_center(&self) -> bool {
+        match self {
+            TextAlign::Center => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Serialize, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TextStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font: Option<FontStyle>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background_padding: Option<f32>,
+    #[serde(skip_serializing_if = "TextAlign::is_center")]
+    align: TextAlign,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+}
+js_serializable!(TextStyle);
+
+impl TextStyle {
+    pub fn color(mut self, val: &str) -> TextStyle {
+        self.color = Some(val.to_string());
+        self
+    }
+
+    pub fn font(mut self, val: f32) -> TextStyle {
+        self.font = Some(FontStyle::Size(val));
+        self
+    }
+
+    pub fn custom_font(mut self, val: &str) -> TextStyle {
+        self.font = Some(FontStyle::Custom(val.to_string()));
+        self
+    }
+
+    pub fn stroke(mut self, val: &str) -> TextStyle {
+        self.stroke = Some(val.to_string());
+        self
+    }
+
+    pub fn stroke_width(mut self, val: f32) -> TextStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn background_color(mut self, val: &str) -> TextStyle {
+        self.background_color = Some(val.to_string());
+        self
+    }
+
+    pub fn background_padding(mut self, val: f32) -> TextStyle {
+        self.opacity = Some(val);
+        self
+    }
+
+    pub fn align(mut self, val: TextAlign) -> TextStyle {
+        self.align = val;
+        self
+    }
+
+    pub fn opacity(mut self, val: f32) -> TextStyle {
+        self.opacity = Some(val);
+        self
+    }
+}
+
+#[derive(Serialize)]
+pub struct TextData {
+    text: String,
+    x: f32,
+    y: f32,
+    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
+    style: Option<TextStyle>,
+}
+js_serializable!(TextData);
+
+#[derive(Serialize)]
+#[serde(tag = "t")]
+pub enum Visual {
+    #[serde(rename = "c")]
+    Circle(CircleData),
+    #[serde(rename = "l")]
+    Line(LineData),
+    #[serde(rename = "r")]
+    Rect(RectData),
+    #[serde(rename = "p")]
+    Poly(PolyData),
+    #[serde(rename = "t")]
+    Text(TextData),
+}
+js_serializable!(Visual);
+
+pub struct RoomVisual {
+    room_name: Option<RoomName>,
+}
+
+impl RoomVisual {
+    pub fn new(room_name: Option<RoomName>) -> RoomVisual {
+        RoomVisual { room_name }
+    }
+
+    pub fn draw(&self, visual: &Visual) {
+        js! { console.addVisual(@{self.room_name}, @{visual}); };
+    }
+
+    pub fn draw_multi(&self, visuals: &[Visual]) {
+        if !visuals.is_empty() {
+            js! { (@{&visuals}).forEach(function(v) { console.addVisual(@{self.room_name}, v); }); };
+        }
+    }
+
+    pub fn circle(&self, x: f32, y: f32, style: Option<CircleStyle>) {
+        self.draw(&Visual::Circle(CircleData { x, y, style }));
+    }
+
+    pub fn line(&self, from: (f32, f32), to: (f32, f32), style: Option<LineStyle>) {
+        self.draw(&Visual::Line(LineData {
+            x1: from.0,
+            y1: from.1,
+            x2: to.0,
+            y2: to.1,
+            style,
+        }));
+    }
+
+    pub fn rect(&self, x: f32, y: f32, width: f32, height: f32, style: Option<RectStyle>) {
+        self.draw(&Visual::Rect(RectData {
+            x,
+            y,
+            width,
+            height,
+            style,
+        }));
+    }
+
+    pub fn poly(&self, points: Vec<(f32, f32)>, style: Option<PolyStyle>) {
+        self.draw(&Visual::Poly(PolyData { points, style }));
+    }
+
+    pub fn text(&self, x: f32, y: f32, text: String, style: Option<TextStyle>) {
+        self.draw(&Visual::Text(TextData { x, y, text, style }));
+    }
+}

--- a/src/objects/impls/room_visual.rs
+++ b/src/objects/impls/room_visual.rs
@@ -1,7 +1,7 @@
 use crate::local::RoomName;
 use serde::Serialize;
 
-#[derive(Serialize, Default)]
+#[derive(Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CircleStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -44,7 +44,7 @@ impl CircleStyle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct CircleData {
     x: f32,
     y: f32,
@@ -53,7 +53,7 @@ pub struct CircleData {
 }
 js_serializable!(CircleData);
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum LineDrawStyle {
     Solid,
@@ -77,7 +77,7 @@ impl LineDrawStyle {
     }
 }
 
-#[derive(Serialize, Default)]
+#[derive(Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LineStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -113,7 +113,7 @@ impl LineStyle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct LineData {
     x1: f32,
     y1: f32,
@@ -124,7 +124,7 @@ pub struct LineData {
 }
 js_serializable!(LineData);
 
-#[derive(Serialize, Default)]
+#[derive(Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RectStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -167,7 +167,7 @@ impl RectStyle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct RectData {
     x: f32,
     y: f32,
@@ -180,7 +180,7 @@ pub struct RectData {
 }
 js_serializable!(RectData);
 
-#[derive(Serialize, Default)]
+#[derive(Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PolyStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -223,7 +223,7 @@ impl PolyStyle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct PolyData {
     points: Vec<(f32, f32)>,
     #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
@@ -231,7 +231,7 @@ pub struct PolyData {
 }
 js_serializable!(PolyData);
 
-#[derive(Serialize, Clone)]
+#[derive(Clone, Serialize)]
 #[serde(untagged)]
 pub enum FontStyle {
     Size(f32),
@@ -239,7 +239,7 @@ pub enum FontStyle {
 }
 js_serializable!(FontStyle);
 
-#[derive(Serialize, Clone)]
+#[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TextAlign {
     Center,
@@ -263,7 +263,7 @@ impl TextAlign {
     }
 }
 
-#[derive(Serialize, Default, Clone)]
+#[derive(Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TextStyle {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -332,7 +332,7 @@ impl TextStyle {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 pub struct TextData {
     text: String,
     x: f32,
@@ -342,7 +342,7 @@ pub struct TextData {
 }
 js_serializable!(TextData);
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 #[serde(tag = "t")]
 pub enum Visual {
     #[serde(rename = "c")]

--- a/src/objects/impls/room_visual.rs
+++ b/src/objects/impls/room_visual.rs
@@ -358,6 +358,40 @@ pub enum Visual {
 }
 js_serializable!(Visual);
 
+impl Visual {
+    pub fn circle(x: f32, y: f32, style: Option<CircleStyle>) -> Visual {
+        Visual::Circle(CircleData { x, y, style })
+    }
+
+    pub fn line(from: (f32, f32), to: (f32, f32), style: Option<LineStyle>) -> Visual {
+        Visual::Line(LineData {
+            x1: from.0,
+            y1: from.1,
+            x2: to.0,
+            y2: to.1,
+            style,
+        })
+    }
+
+    pub fn rect(x: f32, y: f32, width: f32, height: f32, style: Option<RectStyle>) -> Visual {
+        Visual::Rect(RectData {
+            x,
+            y,
+            width,
+            height,
+            style,
+        })
+    }
+
+    pub fn poly(points: Vec<(f32, f32)>, style: Option<PolyStyle>) -> Visual {
+        Visual::Poly(PolyData { points, style })
+    }
+
+    pub fn text(x: f32, y: f32, text: String, style: Option<TextStyle>) -> Visual {
+        Visual::Text(TextData { x, y, text, style })
+    }
+}
+
 pub struct RoomVisual {
     room_name: Option<RoomName>,
 }
@@ -378,34 +412,22 @@ impl RoomVisual {
     }
 
     pub fn circle(&self, x: f32, y: f32, style: Option<CircleStyle>) {
-        self.draw(&Visual::Circle(CircleData { x, y, style }));
+        self.draw(&Visual::circle(x, y, style));
     }
 
     pub fn line(&self, from: (f32, f32), to: (f32, f32), style: Option<LineStyle>) {
-        self.draw(&Visual::Line(LineData {
-            x1: from.0,
-            y1: from.1,
-            x2: to.0,
-            y2: to.1,
-            style,
-        }));
+        self.draw(&Visual::line(from, to, style));
     }
 
     pub fn rect(&self, x: f32, y: f32, width: f32, height: f32, style: Option<RectStyle>) {
-        self.draw(&Visual::Rect(RectData {
-            x,
-            y,
-            width,
-            height,
-            style,
-        }));
+        self.draw(&Visual::rect(x, y, width, height, style));
     }
 
     pub fn poly(&self, points: Vec<(f32, f32)>, style: Option<PolyStyle>) {
-        self.draw(&Visual::Poly(PolyData { points, style }));
+        self.draw(&Visual::poly(points, style));
     }
 
     pub fn text(&self, x: f32, y: f32, text: String, style: Option<TextStyle>) {
-        self.draw(&Visual::Text(TextData { x, y, text, style }));
+        self.draw(&Visual::text(x, y, text, style));
     }
 }


### PR DESCRIPTION
This includes all the visual types and formatting options for the room visual API.

It directly calls the console addVisual to rather than more expensive calls through the RoomVisual API. This allows most of the operation to stay on the Rust side of the boundary until required.

For large batches of visuals it's actually faster to serialize the batch to a string, serialize that across and re-hydrate with JSON.parse. However, that's a tradeoff that can only really be made with knowledge of the data and likely not appropriate to put in the API layer itself. To enable this scenario there is the Visual enum that can be used for storage as well as appropriate serde annotations for all types.