### PR TITLE
Add GCL and GPL total point calculation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Unreleased
 - Add `MoveToOptions::visualize_path_style`to allow for path visualization of movement system.
 - Change `HasStore::store_free_capacity` to return `i32`, handling potential negative values due
   to expiration of `OPERATE_STORAGE`
+- Add `game::gcl::total_for_level` and `game::gpl::total_for_level` which calculate the total
+  lifetime points required for a given level of GCL or GPL
 
 0.7.0 (2019-10-19)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ Unreleased
   to expiration of `OPERATE_STORAGE`
 - Add `game::gcl::total_for_level` and `game::gpl::total_for_level` which calculate the total
   lifetime points required for a given level of GCL or GPL
+- Change `constants::GCL_POW` to f64 from f32 due to slightly incorrect calculations when using
+  this from f32 to calculate GCL levels (breaking)
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/constants/numbers.rs
+++ b/src/constants/numbers.rs
@@ -185,7 +185,7 @@ pub const LAB_UNBOOST_MINERAL: u32 = 15;
 
 pub const LAB_REACTION_AMOUNT: u32 = 5;
 
-pub const GCL_POW: f32 = 2.4;
+pub const GCL_POW: f64 = 2.4;
 pub const GCL_MULTIPLY: u32 = 1_000_000;
 pub const GCL_NOVICE: u32 = 3;
 

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -2,6 +2,8 @@
 //!
 //! [http://docs.screeps.com/api/#Game.gcl]: http://docs.screeps.com/api/#Game.gcl
 
+use crate::constants::{GCL_MULTIPLY, GCL_POW};
+
 /// See [http://docs.screeps.com/api/#Game.gcl]
 ///
 /// [http://docs.screeps.com/api/#Game.gcl]: http://docs.screeps.com/api/#Game.gcl
@@ -31,5 +33,7 @@ pub fn progress_total() -> f64 {
 /// your [`gcl::progress`][crate::game::gcl::progress], would calculate your
 /// total lifetime control points.
 pub fn total_for_level(level: u32) -> f64 {
-    ((level - 1) as f64).powf(2.4) * 1_000_000.0
+    // formula from
+    // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L117
+    ((level - 1) as f64).powf(GCL_POW as f64) * GCL_MULTIPLY as f64
 }

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -23,10 +23,10 @@ pub fn progress_total() -> f64 {
     js_unwrap!(Game.gcl.progressTotal)
 }
 
-/// Provides the total number of control points needed to acheieve each level of
+/// Provides the total number of control points needed to achieve each level of
 /// GCL
 ///
-/// Calculates the total number of control points needed to acheive a given
+/// Calculates the total number of control points needed to achieve a given
 /// Global Control Level. The resulting value for your current level, added to
 /// your [`gcl::progress`][crate::game::gcl::progress], would calculate your
 /// total lifetime control points.

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -22,3 +22,14 @@ pub fn progress() -> f64 {
 pub fn progress_total() -> f64 {
     js_unwrap!(Game.gcl.progressTotal)
 }
+
+/// Provides the total number of control points needed to acheieve each level of
+/// GCL
+///
+/// Calculates the total number of control points needed to acheive a given
+/// Global Control Level. The resulting value for your current level, added to
+/// your [`gcl::progress`][crate::game::gcl::progress], would calculate your
+/// total lifetime control points.
+pub fn total_for_level(level: u32) -> f64 {
+    ((level - 1) as f64).powf(2.4) * 1_000_000.0
+}

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -2,6 +2,8 @@
 //!
 //! [http://docs.screeps.com/api/#Game.gpl]: http://docs.screeps.com/api/#Game.gpl
 
+use crate::constants::{POWER_LEVEL_MULTIPLY, POWER_LEVEL_POW};
+
 /// See [http://docs.screeps.com/api/#Game.gpl]
 ///
 /// [http://docs.screeps.com/api/#Game.gpl]: http://docs.screeps.com/api/#Game.gpl
@@ -31,5 +33,7 @@ pub fn progress_total() -> f64 {
 /// to your [`gpl::progress`][crate::game::gpl::progress], would calculate your
 /// total lifetime power points.
 pub fn total_for_level(level: u32) -> u64 {
-    (level as u64).pow(2) * 1_000
+    // formula from
+    // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L120
+    (level as u64).pow(POWER_LEVEL_POW) * POWER_LEVEL_MULTIPLY as u64
 }

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -22,3 +22,14 @@ pub fn progress() -> f64 {
 pub fn progress_total() -> f64 {
     js_unwrap!(Game.gpl.progressTotal)
 }
+
+/// Provides the total number of processed power needed to acheieve each level
+/// of GPL
+///
+/// Calculates the total number of power that need to be processed to acheive a
+/// given Global Power Level. The resulting value for your current level, added
+/// to your [`gpl::progress`][crate::game::gpl::progress], would calculate your
+/// total lifetime power points.
+pub fn total_for_level(level: u32) -> u64 {
+    (level as u64).pow(2) * 1_000
+}

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -23,10 +23,10 @@ pub fn progress_total() -> f64 {
     js_unwrap!(Game.gpl.progressTotal)
 }
 
-/// Provides the total number of processed power needed to acheieve each level
+/// Provides the total number of processed power needed to achieve each level
 /// of GPL
 ///
-/// Calculates the total number of power that need to be processed to acheive a
+/// Calculates the total number of power that need to be processed to achieve a
 /// given Global Power Level. The resulting value for your current level, added
 /// to your [`gpl::progress`][crate::game::gpl::progress], would calculate your
 /// total lifetime power points.


### PR DESCRIPTION
The progress values returned by the game's GCL and GPL functions only shows number of points of progress toward the next level; if you're looking to calculate your total points, you also need to calculate the absolute lifetime point total for your current level.

It's a little iffy whether this should be in the library directly, but I figured I'd propose 'em after needing them for my own statistics - the formulas are not documented, so one needs to root around in the engine code or get the right answer in slack, then implement and test these functions, to be able to get at fairly basic 'should be in a constant' information.