### PR TITLE
Return an "incomplete" value when we are asked to search for zero goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Unreleased
 - Add `RoomVisual`, rendering primitives (`Circle`, `Line`, `Rect`, `Poly`, `Text`).
 - Add Visual rendering primitive enum for storage and batching.
 - Add `MoveToOptions::visualize_path_style`to allow for path visualization of movement system.
+- Change `pathfinder::search_many` to return an incomplete result when called with no goals to
+  prevent a panic due to unexpected return data from javascript.
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -354,6 +354,14 @@ where
             js_unwrap!({pos: pos_from_packed(@{pos.packed_repr()}), range: @{range}})
         })
         .collect();
+    if goals.len() == 0 {
+        return SearchResults {
+            cost: 0,
+            incomplete: true,
+            ops: 0,
+            path: js_unwrap!([]),
+        };
+    }
     let goals_js: Reference = js_unwrap!(@{goals});
     search_real(origin.pos(), &goals_js, opts)
 }

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -354,7 +354,7 @@ where
             js_unwrap!({pos: pos_from_packed(@{pos.packed_repr()}), range: @{range}})
         })
         .collect();
-    if goals.len() == 0 {
+    if goals.is_empty() {
         return SearchResults {
             cost: 0,
             incomplete: true,


### PR DESCRIPTION
I'm not sure whether doing `search_many` on an empty iterator makes sense, but I did it without realizing it and the results obscured the problem.

JS returns a value in this situation, which is missing half the documented properties.  We expect them all which causes a very opaque panic when it gets bridged to rust.

IMO the most sensible approach is to follow the spirit of the JS API and return a value.  It's an interesting question what value is correct for this query (is a path nowhere `incomplete`?) but this is the value that would have worked in my case.
