### PR TITLE
Add StructureFactory::level()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Unreleased
   lifetime points required for a given level of GCL or GPL
 - Change `constants::GCL_POW` to f64 from f32 due to slightly incorrect calculations when using
   this from f32 to calculate GCL levels (breaking)
+- Add missed `StructureFactory::level` function to determine a factory's level (or `None` if a
+  power creep has not yet used `OPERATE_FACTORY`)
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls/structure_factory.rs
+++ b/src/objects/impls/structure_factory.rs
@@ -3,6 +3,12 @@ use crate::{
     objects::StructureFactory,
 };
 
+simple_accessors! {
+    impl StructureFactory {
+        pub fn level() -> Option<u32> = level;
+    }
+}
+
 impl StructureFactory {
     pub fn produce(&self, ty: ResourceType) -> ReturnCode {
         js_unwrap! {@{self.as_ref()}.produce(__resource_type_num_to_str(@{ty as u32}))}


### PR DESCRIPTION
Missed adding an interface to `StuctureFactory.level` when I added factories, whoops.