### PR TITLE
Support object_ids that start with 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,5 @@ stdweb-derive = "0.5"
 
 [features]
 check-all-casts = []
+#Shorten ObjectID representations to their minimum size.  Does not preserve leading 0s, see #311 for details
+short-ids = []

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -352,6 +352,19 @@ function pos_from_packed(repr) {
     return pos;
 }
 
+function object_id_from_packed_16(slice) {
+    // reconstruct string in JS
+    let res = "";
+    for (var i = 0; i < slice.length; i++) {
+       if (i > 0) {
+           res += slice[i].toString(16).padStart(8, "0");
+       } else {
+           res += slice[i].toString(16);
+       }
+    }
+    return res.padStart(15, "0");
+}
+
 function object_id_from_packed(slice) {
     // reconstruct string in JS
     let res = "";

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -356,11 +356,7 @@ function object_id_from_packed(slice) {
     // reconstruct string in JS
     let res = "";
     for (var i = 0; i < slice.length; i++) {
-       if (i > 0) {
            res += slice[i].toString(16).padStart(8, "0");
-       } else {
-           res += slice[i].toString(16);
-       }
     }
     return res.padStart(15, "0");
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -189,10 +189,17 @@ where
     T: HasId + SizedRoomObject,
 {
     let array_view = unsafe { id.unsafe_as_uploaded() };
-    (js! {
-        return Game.getObjectById(object_id_from_packed(@{array_view}));
-    })
-    .try_into()
+    let f;
+    if cfg!(feature = "short-ids") {
+        f = js! {
+            return Game.getObjectById(object_id_from_packed_16(@{array_view}));
+        }
+    } else {
+        f = js! {
+            return Game.getObjectById(object_id_from_packed(@{array_view}));
+        }
+    }
+    f.try_into()
 }
 
 /// See [http://docs.screeps.com/api/#Game.getObjectById]
@@ -209,7 +216,11 @@ where
 pub fn get_object_erased(id: impl Into<RawObjectId>) -> Option<RoomObject> {
     let id = id.into();
     let array_view = unsafe { id.unsafe_as_uploaded() };
-    js_unwrap_ref!(Game.getObjectById(object_id_from_packed(@{array_view})))
+    if cfg!(feature = "short-ids") {
+        js_unwrap_ref!(Game.getObjectById(object_id_from_packed_16(@{array_view})))
+    } else {
+        js_unwrap_ref!(Game.getObjectById(object_id_from_packed(@{array_view})))
+    }
 }
 
 pub fn notify(message: &str, group_interval: Option<u32>) {

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -54,7 +54,7 @@ impl fmt::Debug for RawObjectId {
 
 impl fmt::Display for RawObjectId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:x}", self.to_u128())
+        write!(f, "{:024x}", self.to_u128())
     }
 }
 
@@ -272,14 +272,9 @@ mod test {
     use crate::traits::TryInto;
 
     const TEST_IDS: &[&str] = &[
-        "bc03381d32f6790",
-        "1",
+        "000000000000000000000000",
         "ffffffffffffffffffffffff",
-        "100000000000000000000000",
-        "10000000000000000",
-        "1000000000000000",
-        "100000000",
-        "10000000",
+        "044a9c7ba32ab2588bd6d3a5",
     ];
 
     #[test]

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -54,7 +54,11 @@ impl fmt::Debug for RawObjectId {
 
 impl fmt::Display for RawObjectId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:024x}", self.to_u128())
+        if cfg!(feature = "short-ids") {
+            write!(f, "{:x}", self.to_u128())
+        } else {
+            write!(f, "{:024x}", self.to_u128())
+        }
     }
 }
 
@@ -270,11 +274,22 @@ mod test {
     #[cfg(target_arch = "wasm32")]
     use crate::macros::*;
     use crate::traits::TryInto;
-
+    #[cfg(not(feature = "short-ids"))]
     const TEST_IDS: &[&str] = &[
         "000000000000000000000000",
         "ffffffffffffffffffffffff",
         "044a9c7ba32ab2588bd6d3a5",
+    ];
+    #[cfg(feature = "short-ids")]
+    const TEST_IDS: &[&str] = &[
+        "bc03381d32f6790",
+        "1",
+        "ffffffffffffffffffffffff",
+        "100000000000000000000000",
+        "10000000000000000",
+        "1000000000000000",
+        "100000000",
+        "10000000",
     ];
 
     #[test]


### PR DESCRIPTION
Resolve #278

This lets us parse and roundtrip ids that start with 0 correctly, both on Rust and JS.

To do this, we pad the packed value into a 12-byte (24-character) string, which is the expected length on [mongodb](https://docs.mongodb.com/manual/reference/method/ObjectId/).  This works for me in both sim and production.

I'm kind of unclear on whether there are other backends that may not like this format or if there is any reason to keep the shorter format around.