### PR TITLE
Change appropriate CPU values to integer and add missing heap stats field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ Unreleased
   this from f32 to calculate GCL levels (breaking)
 - Add missed `StructureFactory::level` function to determine a factory's level (or `None` if a
   power creep has not yet used `OPERATE_FACTORY`)
+- Change `game::cpu::limit`, `tick_limit`, `bucket`, `shard_limits`, and `set_shard_limits` to
+  use `u32` from `f64`
+- Add `total_available_size` field to `game::cpu::HeapStatistics`
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -15,6 +15,7 @@ pub struct HeapStatistics {
     pub total_heap_size: u32,
     pub total_heap_size_executable: u32,
     pub total_physical_size: u32,
+    pub total_available_size: i32,
     pub used_heap_size: u32,
     pub heap_size_limit: u32,
     pub malloced_memory: u32,
@@ -29,28 +30,28 @@ js_deserializable!(HeapStatistics);
 /// See [http://docs.screeps.com/api/#Game.cpu]
 ///
 /// [http://docs.screeps.com/api/#Game.cpu]: http://docs.screeps.com/api/#Game.cpu
-pub fn limit() -> f64 {
+pub fn limit() -> u32 {
     js_unwrap!(Game.cpu.limit)
 }
 
 /// See [http://docs.screeps.com/api/#Game.cpu]
 ///
 /// [http://docs.screeps.com/api/#Game.cpu]: http://docs.screeps.com/api/#Game.cpu
-pub fn tick_limit() -> f64 {
+pub fn tick_limit() -> u32 {
     js_unwrap!(Game.cpu.tickLimit)
 }
 
 /// See [http://docs.screeps.com/api/#Game.cpu]
 ///
 /// [http://docs.screeps.com/api/#Game.cpu]: http://docs.screeps.com/api/#Game.cpu
-pub fn bucket() -> f64 {
+pub fn bucket() -> u32 {
     js_unwrap!(Game.cpu.bucket)
 }
 
 /// See [http://docs.screeps.com/api/#Game.cpu]
 ///
 /// [http://docs.screeps.com/api/#Game.cpu]: http://docs.screeps.com/api/#Game.cpu
-pub fn shard_limits() -> collections::HashMap<String, f64> {
+pub fn shard_limits() -> collections::HashMap<String, u32> {
     js_unwrap!(Game.cpu.shardLimits)
 }
 
@@ -82,7 +83,7 @@ pub fn get_used() -> f64 {
 /// See [http://docs.screeps.com/api/#Game.setShardLimits]
 ///
 /// [http://docs.screeps.com/api/#Game.setShardLimits]: http://docs.screeps.com/api/#Game.setShardLimits
-pub fn set_shard_limits(limits: collections::HashMap<String, f64>) -> ReturnCode {
+pub fn set_shard_limits(limits: collections::HashMap<String, u32>) -> ReturnCode {
     js_unwrap!(Game.cpu.setShardLimits(@{limits}))
 }
 


### PR DESCRIPTION
A handful of the Game.cpu functions work only in integers - most notably in what's passed into `set_shard_limits` - this changes those fields to work in `u32` types. Additionally, the `total_available_size` field from `getHeapStatistics` wasn't deserializing - added that.