### PR TITLE
Use CanDecay instead of explicit ticks_to_decay implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ Unreleased
   this from f32 to calculate GCL levels (breaking)
 - Add missed `StructureFactory::level` function to determine a factory's level (or `None` if a
   power creep has not yet used `OPERATE_FACTORY`)
+- Remove explicit `ticks_to_decay` implementations on `StructureContainer` and `Tombstone`, use
+  the implementation on `CanDecay` instead (breaking)
 
 0.7.0 (2019-10-19)
 ==================

--- a/src/objects/impls.rs
+++ b/src/objects/impls.rs
@@ -1,5 +1,4 @@
 mod construction_site;
-mod container;
 mod creep;
 mod deposit;
 mod flag;

--- a/src/objects/impls/container.rs
+++ b/src/objects/impls/container.rs
@@ -1,7 +1,0 @@
-use crate::objects::StructureContainer;
-
-simple_accessors! {
-    impl StructureContainer {
-        pub fn ticks_to_decay() -> u32 = ticksToDecay;
-    }
-}

--- a/src/objects/impls/tombstone.rs
+++ b/src/objects/impls/tombstone.rs
@@ -4,6 +4,5 @@ simple_accessors! {
     impl Tombstone {
         pub fn creep() -> Creep = creep;
         pub fn death_time() -> u32 = deathTime;
-        pub fn ticks_to_decay() -> u32 = ticksToDecay;
     }
 }


### PR DESCRIPTION
Removes the ticks_to_decay implementations explicitly on container and tombstone, using the `CanDecay` implementation instead.