### PR TITLE
Add an IsStructure trait and related functionality

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -782,3 +782,27 @@ macro_rules! mem_set {
         compile_error!(concat!("Unexpected usage of mem_set! usage: ", stringify!($($not_valid)*)))
     }
 }
+
+macro_rules! impl_is_structure {
+    ($structure_struct_type: ty, $structure_type_pattern: pat,$c: ident,$structure_type: expr) => {
+        impl std::convert::TryFrom<Structure> for $structure_struct_type {
+            type Error = ConversionError;
+            fn try_from(s: Structure) -> Result<Self, Self::Error> {
+                match s {
+                    $structure_type_pattern => Ok($c),
+                    wrong => Err(ConversionError::Custom(format!(
+                        "Expected {}, got {:?}",
+                        stringify!($structure_struct_type),
+                        wrong.structure_type()
+                    ))),
+                }
+            }
+        }
+
+        impl IsStructure for $structure_struct_type {
+            fn structure_type() -> StructureType {
+                $structure_type
+            }
+        }
+    };
+}

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -36,7 +36,7 @@ pub use self::{
         PositionedLookResult, RectStyle, RepairEvent, Reservation, ReserveControllerEvent,
         RoomVisual, Sign, SpawnOptions, Step, TextAlign, TextStyle, UpgradeControllerEvent, Visual,
     },
-    structure::Structure,
+    structure::{IsStructure, Structure},
 };
 
 reference_wrappers! {

--- a/src/objects/structure.rs
+++ b/src/objects/structure.rs
@@ -3,7 +3,7 @@ use stdweb::{InstanceOf, Reference, ReferenceType, Value};
 use super::*;
 use crate::{
     constants::StructureType,
-    objects::{Attackable, CanDecay, HasCooldown, HasEnergyForSpawn, HasStore},
+    objects::{Attackable, CanDecay, HasCooldown, HasEnergyForSpawn, HasId, HasStore},
     traits::FromExpectedType,
     ConversionError,
 };
@@ -291,3 +291,99 @@ impl ReferenceType for Structure {
         )
     }
 }
+
+pub trait IsStructure: HasId + std::convert::TryFrom<Structure> + SizedRoomObject {
+    fn structure_type() -> StructureType;
+}
+//stdweb::unstable::TryFrom<stdweb::Value,Error=stdweb::private::ConversionError> + stdweb::unstable::TryFrom<stdweb::Reference,Error=stdweb::private::ConversionError>
+impl_is_structure!(
+    StructureContainer,
+    Structure::Container(c),
+    c,
+    StructureType::Container
+);
+impl_is_structure!(
+    StructureController,
+    Structure::Controller(c),
+    c,
+    StructureType::Controller
+);
+impl_is_structure!(
+    StructureExtension,
+    Structure::Extension(c),
+    c,
+    StructureType::Extension
+);
+impl_is_structure!(
+    StructureExtractor,
+    Structure::Extractor(c),
+    c,
+    StructureType::Extractor
+);
+impl_is_structure!(
+    StructureFactory,
+    Structure::Factory(c),
+    c,
+    StructureType::Factory
+);
+impl_is_structure!(
+    StructureInvaderCore,
+    Structure::InvaderCore(c),
+    c,
+    StructureType::InvaderCore
+);
+impl_is_structure!(
+    StructureKeeperLair,
+    Structure::KeeperLair(c),
+    c,
+    StructureType::KeeperLair
+);
+impl_is_structure!(StructureLab, Structure::Lab(c), c, StructureType::Lab);
+impl_is_structure!(StructureLink, Structure::Link(c), c, StructureType::Link);
+impl_is_structure!(StructureNuker, Structure::Nuker(c), c, StructureType::Nuker);
+impl_is_structure!(
+    StructureObserver,
+    Structure::Observer(c),
+    c,
+    StructureType::Observer
+);
+impl_is_structure!(
+    StructurePowerBank,
+    Structure::PowerBank(c),
+    c,
+    StructureType::PowerBank
+);
+impl_is_structure!(
+    StructurePowerSpawn,
+    Structure::PowerSpawn(c),
+    c,
+    StructureType::PowerSpawn
+);
+impl_is_structure!(
+    StructurePortal,
+    Structure::Portal(c),
+    c,
+    StructureType::Portal
+);
+impl_is_structure!(
+    StructureRampart,
+    Structure::Rampart(c),
+    c,
+    StructureType::Rampart
+);
+impl_is_structure!(StructureRoad, Structure::Road(c), c, StructureType::Road);
+impl_is_structure!(StructureSpawn, Structure::Spawn(c), c, StructureType::Spawn);
+impl_is_structure!(
+    StructureStorage,
+    Structure::Storage(c),
+    c,
+    StructureType::Storage
+);
+impl_is_structure!(
+    StructureTerminal,
+    Structure::Terminal(c),
+    c,
+    StructureType::Terminal
+);
+impl_is_structure!(StructureTower, Structure::Tower(c), c, StructureType::Tower);
+impl_is_structure!(StructureWall, Structure::Wall(c), c, StructureType::Wall);


### PR DESCRIPTION
I have recently been writing construction planners.  Mostly, planning is specific to a single `structure_type`; for example a wall planner or a mine planner are intimately involved with the details of walls or mines respectively.  However, some functionality is similar across `structure_type`, like checking if a structure exists or is damaged.

Currently we have e.g. `StructureSpawn`, the specific type, and `Structure`, the general type.  For the purposes of boxing API results, this makes some sense, but there are a few issues for a planning usecase:

1.  Writing code broadly against `Structure` involves a lot of boxing/unboxing between specific and general types at runtime.  In my situation there are bajillions of these in a single logical planning operation which performs poorly.
2.  In practice, the planner wants to know about "approximately 1" `structure_type`, which is statically known, and this boxing introduces a lot of panic opportunities for logic errors that could be statically checked.

This PR introduces a trait `IsStructure` to which structures conform, allowing generic code to be written across `<S: IsStructure>` when the structure type is known, rather than across the runtimey `Structure`.  The `IsStructure` behavior is fairly minimal, is mostly what I needed for my case, and can be extended later.

Personally, I would prefer a more invasive change than this one – perhaps renaming `Structure` to `AnyStructure` and implementing a trait on it via [enum_dispatch](https://docs.rs/enum_dispatch/0.3.0/enum_dispatch/).  However, that would be much more invasive than this PR so I decided to start with something compatible.  Since JS doesn't fuss about e.g. "which" `.pos()` you call, I'm not sure how much strong typing matters internally, vs just exposing a typed interface ourselves.