### PR TITLE
Intershard memory edge case fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 Unreleased
 ==========
 
-- Change `game::inter_shard_memory` functions to avoid panicking on private servers where the interface doesn't
-  exist
-- Change `game::inter_shard_memory::get_local` and `get_remote` to return `Option<String>` accounting for cases
-  where they have not been set
-
+- Change `game::inter_shard_memory` functions to avoid panicking on private servers where the
+  interface doesn't exist
+- Change `game::inter_shard_memory::get_local` and `get_remote` to return `Option<String>`,
+  accounting for cases where they have not been set (breaking)
 
 0.8.0 (2020-03-26)
 ==================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Unreleased
 ==========
 
+- Change `game::inter_shard_memory` functions to avoid panicking on private servers where the interface doesn't
+  exist
+- Change `game::inter_shard_memory::get_local` and `get_remote` to return `Option<String>` accounting for cases
+  where they have not been set
+
 
 0.8.0 (2020-03-26)
 ==================

--- a/src/inter_shard_memory.rs
+++ b/src/inter_shard_memory.rs
@@ -16,23 +16,26 @@
 //!
 //! [`InterShardMemory`]: https://docs.screeps.com/api/#InterShardMemory
 
-/// Returns the string contents of the current shard's data.
-pub fn get_local() -> String {
-    js_unwrap!(InterShardMemory.getLocal())
+/// Returns the string contents of the current shard's data, `None` if it hasn't
+/// been set or on a private server without the intershard memory interface
+pub fn get_local() -> Option<String> {
+    js_unwrap!(typeof(InterShardMemory) == "object" && InterShardMemory.getLocal() || null)
 }
 
-/// Replace the current shard's data with the new value.
+/// Replace the current shard's data with the new value. Maximum allowed length
+/// of 102400 bytes.
 pub fn set_local(value: &str) {
     js! {
-        InterShardMemory.setLocal(@{value});
+        typeof(InterShardMemory) == "object" && InterShardMemory.setLocal(@{value});
     }
 }
 
 /// Returns the string contents of another shard's data.
 ///
-/// Consider using [`game::cpu::shard_limits`] to retrieve shard names.
+/// Consider using [`game::cpu::shard_limits`] to retrieve shard names - invalid
+/// shard names will cause an error in the game API
 ///
 /// [`game::cpu::shard_limits`]: crate::game::cpu::shard_limits
-pub fn get_remote(shard: &str) -> String {
-    js_unwrap!(InterShardMemory.getRemote(@{shard}))
+pub fn get_remote(shard: &str) -> Option<String> {
+    js_unwrap!(typeof(InterShardMemory) == "object" && InterShardMemory.getRemote(@{shard}) || null)
 }


### PR DESCRIPTION
`InterShardMemory` - heavy sigh.

- On private servers, it doesn't exist at all.  Handle the cases where it's undefined by returning `None`
- On MMO, when you haven't set data for a segment it's undefined and can cause a panic; handle that with an `Option` wrapper