### PR TITLE
Pathfinding improvements (v2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ log = "0.4"
 num-derive = "0.2"
 num-traits = "0.2"
 parse-display = "0.1"
-scoped-tls = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = "1"
 serde_repr = "0.1"

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -118,12 +118,12 @@ pub fn find_exit_with_callback(
     let callback_type_erased: &mut (dyn FnMut(RoomName, RoomName) -> f64) =
         &mut callback_boxed;
 
-    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
-    // storage: it's now pretending to be static data. This should be entirely safe
+
+    // Overwrite lifetime of reference so it can be passed to javascript. 
+    // It's now pretending to be static data. This should be entirely safe
     // because we're only sticking it in scoped storage and we control the
     // only use of it, but it's still necessary because "some lifetime above
-    // the  current scope but otherwise unknown" is not a valid lifetime to
-    // have PF_CALLBACK have.
+    // the current scope but otherwise unknown" is not a valid lifetime.
     let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, RoomName) -> f64 =
         unsafe { mem::transmute(callback_type_erased) };
 
@@ -171,12 +171,12 @@ pub fn find_route_with_callback(
     let callback_type_erased: &mut (dyn FnMut(RoomName, RoomName) -> f64) =
         &mut callback_boxed;
 
-    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
-    // storage: it's now pretending to be static data. This should be entirely safe
+
+    // Overwrite lifetime of reference so it can be passed to javascript. 
+    // It's now pretending to be static data. This should be entirely safe
     // because we're only sticking it in scoped storage and we control the
     // only use of it, but it's still necessary because "some lifetime above
-    // the  current scope but otherwise unknown" is not a valid lifetime to
-    // have PF_CALLBACK have.
+    // the current scope but otherwise unknown" is not a valid lifetime.
     let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, RoomName) -> f64 =
         unsafe { mem::transmute(callback_type_erased) };
 

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -5,7 +5,6 @@ use std::{borrow::Cow, collections, mem, str::FromStr};
 
 use num_traits::FromPrimitive;
 use parse_display::FromStr;
-use scoped_tls::scoped_thread_local;
 use serde::{
     de::{Deserializer, Error as _, Unexpected},
     Deserialize,
@@ -106,41 +105,49 @@ pub fn find_exit(from_room: RoomName, to_room: RoomName) -> Result<ExitDirection
 pub fn find_exit_with_callback(
     from_room: RoomName,
     to_room: RoomName,
-    route_callback: impl Fn(RoomName, RoomName) -> f64,
+    route_callback: impl FnMut(RoomName, RoomName) -> f64,
 ) -> Result<ExitDirection, ReturnCode> {
-    // Actual callback
-    fn callback(room_name: String, from_room_name: String) -> f64 {
-        FR_CALLBACK.with(|callback| {
-            callback(
-                room_name.parse().expect(
-                    "expected room name passed into Game.map.findExit \
-                     callback to be a valid room name",
-                ),
-                from_room_name.parse().expect(
-                    "expected room name passed into Game.map.findExit \
-                     callback to be a valid room name",
-                ),
-            )
-        })
-    }
+    let mut raw_callback = route_callback;
 
-    let callback_type_erased: Box<dyn Fn(RoomName, RoomName) -> f64> = Box::new(route_callback);
+    let mut callback_boxed = move |to_name: RoomName, from_name: RoomName| -> f64 {
+        raw_callback(to_name, from_name).into()
+    };
 
-    let callback_lifetime_erased: Box<dyn Fn(RoomName, RoomName) -> f64 + 'static> =
+    // Type erased and boxed callback: no longer a type specific to the closure
+    // passed in, now unified as &Fn
+    let callback_type_erased: &mut (dyn FnMut(RoomName, RoomName) -> f64) =
+        &mut callback_boxed;
+
+    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
+    // storage: it's now pretending to be static data. This should be entirely safe
+    // because we're only sticking it in scoped storage and we control the
+    // only use of it, but it's still necessary because "some lifetime above
+    // the  current scope but otherwise unknown" is not a valid lifetime to
+    // have PF_CALLBACK have.
+    let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, RoomName) -> f64 =
         unsafe { mem::transmute(callback_type_erased) };
 
-    FR_CALLBACK.set(&callback_lifetime_erased, || {
-        let code: i32 = js_unwrap! {Game.map.findExit(@{from_room}, @{to_room}, @{callback})};
-        ExitDirection::from_i32(code)
-            .map(Ok)
-            .or_else(|| ReturnCode::from_i32(code).map(Err))
-            .unwrap_or_else(|| {
-                panic!(
-                    "find_exit: return value {:?} not recognized as either Exit nor ReturnCode",
-                    code
-                )
-            })
-    })
+    let code: i32 = js!(
+        let cb = @{callback_lifetime_erased};
+        
+        let res = Game.map.findExit(@{from_room}, @{to_room}, cb);
+
+        cb.drop();
+
+        return res;
+    )
+    .try_into()
+    .expect("expected int from findExit");
+
+    ExitDirection::from_i32(code)
+        .map(Ok)
+        .or_else(|| ReturnCode::from_i32(code).map(Err))
+        .unwrap_or_else(|| {
+            panic!(
+                "find_exit: return value {:?} not recognized as either Exit nor ReturnCode",
+                code
+            )
+        })
 }
 
 pub fn find_route(from_room: &str, to_room: &str) -> Result<Vec<RoomRouteStep>, ReturnCode> {
@@ -148,38 +155,42 @@ pub fn find_route(from_room: &str, to_room: &str) -> Result<Vec<RoomRouteStep>, 
     parse_find_route_returned_value(v)
 }
 
-scoped_thread_local!(static FR_CALLBACK: Box<(dyn Fn(RoomName, RoomName) -> f64)>);
-
 pub fn find_route_with_callback(
     from_room: RoomName,
     to_room: RoomName,
-    route_callback: impl Fn(RoomName, RoomName) -> f64,
+    route_callback: impl FnMut(RoomName, RoomName) -> f64,
 ) -> Result<Vec<RoomRouteStep>, ReturnCode> {
-    // Actual callback
-    fn callback(room_name: String, from_room_name: String) -> f64 {
-        FR_CALLBACK.with(|callback| {
-            callback(
-                room_name.parse().expect(
-                    "expected room name passed into Game.map.findRoute \
-                     callback to be a valid room name",
-                ),
-                from_room_name.parse().expect(
-                    "expected room name passed into Game.map.findRoute \
-                     callback to be a valid room name",
-                ),
-            )
-        })
-    }
+    let mut raw_callback = route_callback;
 
-    let callback_type_erased: Box<dyn Fn(RoomName, RoomName) -> f64> = Box::new(route_callback);
+    let mut callback_boxed = move |to_name: RoomName, from_name: RoomName| -> f64 {
+        raw_callback(to_name, from_name).into()
+    };
 
-    let callback_lifetime_erased: Box<dyn Fn(RoomName, RoomName) -> f64 + 'static> =
+    // Type erased and boxed callback: no longer a type specific to the closure
+    // passed in, now unified as &Fn
+    let callback_type_erased: &mut (dyn FnMut(RoomName, RoomName) -> f64) =
+        &mut callback_boxed;
+
+    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
+    // storage: it's now pretending to be static data. This should be entirely safe
+    // because we're only sticking it in scoped storage and we control the
+    // only use of it, but it's still necessary because "some lifetime above
+    // the  current scope but otherwise unknown" is not a valid lifetime to
+    // have PF_CALLBACK have.
+    let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, RoomName) -> f64 =
         unsafe { mem::transmute(callback_type_erased) };
 
-    FR_CALLBACK.set(&callback_lifetime_erased, || {
-        let v = js!(return Game.map.findRoute(@{from_room}, @{to_room}, @{callback}););
-        parse_find_route_returned_value(v)
-    })
+    let v = js!(
+        let cb = @{callback_lifetime_erased};
+
+        let res = Game.map.findRoute(@{from_room}, @{to_room}, { routeCallback: cb });
+
+        cb.drop();
+
+        return res;
+    );
+
+    parse_find_route_returned_value(v)
 }
 
 fn parse_find_route_returned_value(v: Value) -> Result<Vec<RoomRouteStep>, ReturnCode> {
@@ -202,6 +213,6 @@ fn parse_find_route_returned_value(v: Value) -> Result<Vec<RoomRouteStep>, Retur
 #[serde(rename_all = "camelCase")]
 pub struct RoomRouteStep {
     pub exit: ExitDirection,
-    pub room: String,
+    pub room: RoomName,
 }
 js_deserializable!(RoomRouteStep);

--- a/src/local/room_position/game_methods.rs
+++ b/src/local/room_position/game_methods.rs
@@ -4,7 +4,7 @@ use crate::{
     game,
     local::RoomName,
     objects::{FindOptions, Flag, HasPosition, LookResult, Path},
-    pathfinder::CostMatrix,
+    pathfinder::{SingleRoomCostResult, CostMatrix},
 };
 
 use super::Position;
@@ -64,18 +64,18 @@ impl Position {
         )
     }
 
-    pub fn find_path_to<'a, F, T>(self, target: &T, opts: FindOptions<'a, F>) -> Path
+    pub fn find_path_to<'a, F, T>(self, target: &T, opts: FindOptions<'a, F, SingleRoomCostResult<'a>>) -> Path
     where
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'a>) -> SingleRoomCostResult<'a> + 'a,
         T: ?Sized + HasPosition,
     {
         let self_room = game::rooms::get(self.room_name()).unwrap();
         self_room.find_path(&self, target, opts)
     }
 
-    pub fn find_path_to_xy<'a, F>(self, x: u32, y: u32, opts: FindOptions<'a, F>) -> Path
+    pub fn find_path_to_xy<'a, F>(self, x: u32, y: u32, opts: FindOptions<'a, F, SingleRoomCostResult<'a>>) -> Path
     where
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: Fn(RoomName, CostMatrix<'a>) -> SingleRoomCostResult<'a> + 'a,
     {
         let target = Position::new(x, y, self.room_name());
         self.find_path_to(&target, opts)

--- a/src/objects/creep_shared.rs
+++ b/src/objects/creep_shared.rs
@@ -1,7 +1,6 @@
 use std::{marker::PhantomData, mem};
 
-use scoped_tls::scoped_thread_local;
-use stdweb::Reference;
+use stdweb::{Value, Reference};
 
 use crate::{
     constants::{Direction, ResourceType, ReturnCode},
@@ -11,11 +10,10 @@ use crate::{
         Creep, FindOptions, HasPosition, PolyStyle, PowerCreep, Resource, RoomObjectProperties,
         Step, Transferable, Withdrawable,
     },
-    pathfinder::{CostMatrix, SearchResults},
+    pathfinder::{MultiRoomCostResult, CostMatrix, SearchResults},
     ConversionError,
+    traits::TryInto
 };
-
-scoped_thread_local!(static COST_CALLBACK: Box<dyn Fn(RoomName, Reference) -> Option<Reference>>);
 
 /// Trait for all wrappers over Screeps JavaScript objects that are creeps or
 /// power creeps
@@ -53,7 +51,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
         move_options: MoveToOptions<'a, F>,
     ) -> ReturnCode
     where
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: FnMut(RoomName, CostMatrix<'a>) -> MultiRoomCostResult<'a> + 'a,
     {
         let pos = Position::new(x, y, self.pos().room_name());
         self.move_to_with_options(&pos, move_options)
@@ -71,7 +69,7 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
     ) -> ReturnCode
     where
         T: ?Sized + HasPosition,
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: FnMut(RoomName, CostMatrix<'a>) -> MultiRoomCostResult<'a> + 'a,
     {
         let MoveToOptions {
             reuse_path,
@@ -90,74 +88,68 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
                     range,
                     plain_cost,
                     swamp_cost,
+                    ..
                 },
         } = move_options;
 
-        // This callback is the one actually passed to JavaScript.
-        fn callback(room_name: String, cost_matrix: Reference) -> Option<Reference> {
-            let room_name = room_name.parse().expect(
-                "expected room name passed into Creep.moveTo \
-                 callback to be a valid room name",
-            );
-            COST_CALLBACK.with(|callback| callback(room_name, cost_matrix))
-        }
+        let mut raw_callback = cost_callback;
 
-        // User provided callback: rust String, CostMatrix -> Option<CostMatrix>
-        let raw_callback = cost_callback;
-
-        // Wrapped user callback: rust String, Reference -> Option<Reference>
-        let callback_boxed = move |room_name, cost_matrix_ref| {
+        let mut callback_boxed = move |room_name: RoomName, cost_matrix_ref: Reference| -> Value {
             let cmatrix = CostMatrix {
                 inner: cost_matrix_ref,
                 lifetime: PhantomData,
             };
-            raw_callback(room_name, cmatrix).map(|cm| cm.inner)
+
+            raw_callback(room_name, cmatrix).into()
         };
 
         // Type erased and boxed callback: no longer a type specific to the closure
-        // passed in, now unified as Box<Fn>
-        let callback_type_erased: Box<dyn Fn(RoomName, Reference) -> Option<Reference> + 'a> =
-            Box::new(callback_boxed);
+        // passed in, now unified as &Fn
+        let callback_type_erased: &mut (dyn FnMut(RoomName, Reference) -> Value + 'a) =
+            &mut callback_boxed;
 
-        // Overwrite lifetime of box inside closure so it can be stuck in
-        // scoped_thread_local storage: now pretending to be static data so that
-        // it can be stuck in scoped_thread_local. This should be entirely safe
-        // because we're only sticking it in scoped storage and we control the only use
-        // of it, but it's still necessary because "some lifetime above the current
-        // scope but otherwise unknown" is not a valid lifetime to have
-        // PF_CALLBACK have.
-        let callback_lifetime_erased: Box<
-            dyn Fn(RoomName, Reference) -> Option<Reference> + 'static,
-        > = unsafe { mem::transmute(callback_type_erased) };
+        // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
+        // storage: it's now pretending to be static data. This should be entirely safe
+        // because we're only sticking it in scoped storage and we control the
+        // only use of it, but it's still necessary because "some lifetime above
+        // the  current scope but otherwise unknown" is not a valid lifetime to
+        // have PF_CALLBACK have.
+        let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, Reference) -> Value =
+            unsafe { mem::transmute(callback_type_erased) };
 
         // Store callback_lifetime_erased in COST_CALLBACK for the duration of the
         // PathFinder call and make the call to PathFinder.
         //
         // See https://docs.rs/scoped-tls/0.1/scoped_tls/
-        COST_CALLBACK.set(&callback_lifetime_erased, || {
-            let rp = target.pos();
-            js_unwrap! {
-                @{ self.as_ref() }.moveTo(
-                    pos_from_packed(@{rp.packed_repr()}),
-                    {
-                        reusePath: @{reuse_path},
-                        serializeMemory: @{serialize_memory},
-                        noPathFinding: @{no_path_finding},
-                        visualizePathStyle: @{visualize_path_style},
-                        ignoreCreeps: @{ignore_creeps},
-                        ignoreDestructibleStructures: @{ignore_destructible_structures},
-                        costCallback: @{callback},
-                        maxOps: @{max_ops},
-                        heuristicWeight: @{heuristic_weight},
-                        serialize: @{serialize},
-                        maxRooms: @{max_rooms},
-                        range: @{range},
-                        plainCost: @{plain_cost},
-                        swampCost: @{swamp_cost}
-                    }
-                )
-            }
-        })
+        let rp = target.pos();
+        js!(
+            let cb = @{callback_lifetime_erased};
+
+            let res = @{ self.as_ref() }.moveTo(
+                pos_from_packed(@{rp.packed_repr()}),
+                {
+                    reusePath: @{reuse_path},
+                    serializeMemory: @{serialize_memory},
+                    noPathFinding: @{no_path_finding},
+                    visualizePathStyle: @{visualize_path_style},
+                    ignoreCreeps: @{ignore_creeps},
+                    ignoreDestructibleStructures: @{ignore_destructible_structures},
+                    costCallback: cb,
+                    maxOps: @{max_ops},
+                    heuristicWeight: @{heuristic_weight},
+                    serialize: @{serialize},
+                    maxRooms: @{max_rooms},
+                    range: @{range},
+                    plainCost: @{plain_cost},
+                    swampCost: @{swamp_cost}
+                }
+            );
+            cb.drop();
+
+            return res;
+        )
+        .try_into()
+        .expect("expected return code from moveTo")
     }
 
     fn move_by_path_serialized(&self, path: &str) -> ReturnCode {
@@ -264,17 +256,17 @@ unsafe impl SharedCreepProperties for PowerCreep {}
 
 pub struct MoveToOptions<'a, F>
 where
-    F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: FnMut(RoomName, CostMatrix<'a>) -> MultiRoomCostResult<'a>,
 {
     pub(crate) reuse_path: u32,
     pub(crate) serialize_memory: bool,
     pub(crate) no_path_finding: bool,
     pub(crate) visualize_path_style: Option<PolyStyle>,
-    pub(crate) find_options: FindOptions<'a, F>,
+    pub(crate) find_options: FindOptions<'a, F, MultiRoomCostResult<'a>>,
 }
 
 impl Default
-    for MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>>
+    for MoveToOptions<'static, fn(RoomName, CostMatrix<'static>) -> MultiRoomCostResult<'static>>
 {
     fn default() -> Self {
         // TODO: should we fall back onto the game's default values, or is
@@ -289,7 +281,7 @@ impl Default
     }
 }
 
-impl MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>> {
+impl MoveToOptions<'static, fn(RoomName, CostMatrix<'static>) -> MultiRoomCostResult<'static>> {
     /// Creates default SearchOptions
     pub fn new() -> Self {
         Self::default()
@@ -298,7 +290,7 @@ impl MoveToOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'s
 
 impl<'a, F> MoveToOptions<'a, F>
 where
-    F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: FnMut(RoomName, CostMatrix<'a>) -> MultiRoomCostResult<'a>,
 {
     /// Enables caching of the calculated path. Default: 5 ticks
     pub fn reuse_path(mut self, n_ticks: u32) -> Self {
@@ -341,15 +333,17 @@ where
     /// Sets cost callback - default `|_, _| {}`.
     pub fn cost_callback<'b, F2>(self, cost_callback: F2) -> MoveToOptions<'b, F2>
     where
-        F2: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
+        F2: FnMut(RoomName, CostMatrix<'b>) -> MultiRoomCostResult<'b>,
     {
-        MoveToOptions {
+        let new_options: MoveToOptions<'b, F2> = MoveToOptions {
             reuse_path: self.reuse_path,
             serialize_memory: self.serialize_memory,
             no_path_finding: self.no_path_finding,
             visualize_path_style: self.visualize_path_style,
             find_options: self.find_options.cost_callback(cost_callback),
-        }
+        };
+
+        new_options
     }
 
     /// Sets maximum ops - default `2000`.
@@ -394,9 +388,9 @@ where
     }
 
     /// Sets options related to FindOptions. Defaults to FindOptions default.
-    pub fn find_options<'b, F2>(self, find_options: FindOptions<'b, F2>) -> MoveToOptions<'b, F2>
+    pub fn find_options<'b, F2>(self, find_options: FindOptions<'b, F2, MultiRoomCostResult<'b>>) -> MoveToOptions<'b, F2>
     where
-        F2: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
+        F2: FnMut(RoomName, CostMatrix<'b>) -> MultiRoomCostResult<'b>
     {
         MoveToOptions {
             reuse_path: self.reuse_path,

--- a/src/objects/creep_shared.rs
+++ b/src/objects/creep_shared.rs
@@ -108,19 +108,15 @@ pub unsafe trait SharedCreepProperties: RoomObjectProperties {
         let callback_type_erased: &mut (dyn FnMut(RoomName, Reference) -> Value + 'a) =
             &mut callback_boxed;
 
-        // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
-        // storage: it's now pretending to be static data. This should be entirely safe
+
+        // Overwrite lifetime of reference so it can be passed to javascript. 
+        // It's now pretending to be static data. This should be entirely safe
         // because we're only sticking it in scoped storage and we control the
         // only use of it, but it's still necessary because "some lifetime above
-        // the  current scope but otherwise unknown" is not a valid lifetime to
-        // have PF_CALLBACK have.
+        // the current scope but otherwise unknown" is not a valid lifetime.
         let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, Reference) -> Value =
             unsafe { mem::transmute(callback_type_erased) };
 
-        // Store callback_lifetime_erased in COST_CALLBACK for the duration of the
-        // PathFinder call and make the call to PathFinder.
-        //
-        // See https://docs.rs/scoped-tls/0.1/scoped_tls/
         let rp = target.pos();
         js!(
             let cb = @{callback_lifetime_erased};

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -200,12 +200,11 @@ impl Room {
         let callback_type_erased: &mut (dyn FnMut(RoomName, Reference) -> Value + 'a) =
             &mut callback_boxed;
 
-        // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
-        // storage: it's now pretending to be static data. This should be entirely safe
+        // Overwrite lifetime of reference so it can be passed to javascript. 
+        // It's now pretending to be static data. This should be entirely safe
         // because we're only sticking it in scoped storage and we control the
         // only use of it, but it's still necessary because "some lifetime above
-        // the  current scope but otherwise unknown" is not a valid lifetime to
-        // have PF_CALLBACK have.
+        // the current scope but otherwise unknown" is not a valid lifetime.
         let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, Reference) -> Value =
             unsafe { mem::transmute(callback_type_erased) };
 

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -1,7 +1,6 @@
 use std::{fmt, marker::PhantomData, mem, ops::Range};
 
 use num_traits::FromPrimitive;
-use scoped_tls::scoped_thread_local;
 use serde::{
     self,
     de::{self, Deserializer, MapAccess, Visitor},
@@ -23,7 +22,7 @@ use crate::{
         Room, RoomTerrain, RoomVisual, Ruin, Source, Structure, StructureController,
         StructureStorage, StructureTerminal, Tombstone,
     },
-    pathfinder::CostMatrix,
+    pathfinder::{RoomCostResult, SingleRoomCostResult, CostMatrix},
     traits::{TryFrom, TryInto},
     ConversionError,
 };
@@ -38,8 +37,6 @@ simple_accessors! {
         pub fn terminal() -> Option<StructureTerminal> = terminal;
     }
 }
-
-scoped_thread_local!(static COST_CALLBACK: &'static dyn Fn(RoomName, Reference) -> Option<Reference>);
 
 impl Room {
     pub fn serialize_path(&self, path: &[Step]) -> String {
@@ -178,40 +175,30 @@ impl Room {
         js_unwrap!(@{self.as_ref()}.lookAtArea(@{top}, @{left}, @{bottom}, @{right}, true))
     }
 
-    pub fn find_path<'a, O, T, F>(&self, from_pos: &O, to_pos: &T, opts: FindOptions<'a, F>) -> Path
+    pub fn find_path<'a, 's, O, T, F,>(&'s self, from_pos: &O, to_pos: &T, opts: FindOptions<'a, F, SingleRoomCostResult<'a>>) -> Path
     where
         O: ?Sized + HasPosition,
         T: ?Sized + HasPosition,
-        F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>> + 'a,
+        F: FnMut(RoomName, CostMatrix<'a>) -> SingleRoomCostResult<'a> + 'a + 's,
     {
         let from = from_pos.pos();
         let to = to_pos.pos();
 
-        // This callback is the one actually passed to JavaScript.
-        fn callback(room_name: String, cost_matrix: Reference) -> Option<Reference> {
-            let room_name = room_name.parse().expect(
-                "expected room name passed into Room.findPath \
-                 callback to be a valid room name",
-            );
-            COST_CALLBACK.with(|callback| callback(room_name, cost_matrix))
-        }
+        let mut raw_callback = opts.cost_callback;
 
-        // User provided callback: rust String, CostMatrix -> Option<CostMatrix>
-        let raw_callback = opts.cost_callback;
-
-        // Wrapped user callback: rust String, Reference -> Option<Reference>
-        let callback_boxed = move |room_name, cost_matrix_ref| {
+        let mut callback_boxed = move |room_name: RoomName, cost_matrix_ref: Reference| -> Value {
             let cmatrix = CostMatrix {
                 inner: cost_matrix_ref,
                 lifetime: PhantomData,
             };
-            raw_callback(room_name, cmatrix).map(|cm| cm.inner)
+
+            raw_callback(room_name, cmatrix).into()
         };
 
         // Type erased and boxed callback: no longer a type specific to the closure
         // passed in, now unified as &Fn
-        let callback_type_erased: &(dyn Fn(RoomName, Reference) -> Option<Reference> + 'a) =
-            &callback_boxed;
+        let callback_type_erased: &mut (dyn FnMut(RoomName, Reference) -> Value + 'a) =
+            &mut callback_boxed;
 
         // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
         // storage: it's now pretending to be static data. This should be entirely safe
@@ -219,7 +206,7 @@ impl Room {
         // only use of it, but it's still necessary because "some lifetime above
         // the  current scope but otherwise unknown" is not a valid lifetime to
         // have PF_CALLBACK have.
-        let callback_lifetime_erased: &'static dyn Fn(RoomName, Reference) -> Option<Reference> =
+        let callback_lifetime_erased: &'static mut dyn FnMut(RoomName, Reference) -> Value =
             unsafe { mem::transmute(callback_type_erased) };
 
         let FindOptions {
@@ -235,35 +222,33 @@ impl Room {
             ..
         } = opts;
 
-        // Store callback_lifetime_erased in COST_CALLBACK for the duration of the
-        // PathFinder call and make the call to PathFinder.
-        //
-        // See https://docs.rs/scoped-tls/0.1/scoped_tls/
-        COST_CALLBACK.set(&callback_lifetime_erased, || {
-            let v = js! {
-                return @{&self.as_ref()}.findPath(
-                    pos_from_packed(@{from.packed_repr()}),
-                    pos_from_packed(@{to.packed_repr()}),
-                    {
-                        ignoreCreeps: @{ignore_creeps},
-                        ignoreDestructibleStructures: @{ignore_destructible_structures},
-                        costCallback: @{callback},
-                        maxOps: @{max_ops},
-                        heuristicWeight: @{heuristic_weight},
-                        serialize: @{serialize},
-                        maxRooms: @{max_rooms},
-                        range: @{range},
-                        plainCost: @{plain_cost},
-                        swampCost: @{swamp_cost}
-                    }
-                );
-            };
-            if serialize {
-                Path::Serialized(v.try_into().unwrap())
-            } else {
-                Path::Vectorized(v.try_into().unwrap())
-            }
-        })
+        let v = js! {
+            let cb = @{callback_lifetime_erased};
+            let res = @{&self.as_ref()}.findPath(
+                pos_from_packed(@{from.packed_repr()}),
+                pos_from_packed(@{to.packed_repr()}),
+                {
+                    ignoreCreeps: @{ignore_creeps},
+                    ignoreDestructibleStructures: @{ignore_destructible_structures},
+                    costCallback: cb,
+                    maxOps: @{max_ops},
+                    heuristicWeight: @{heuristic_weight},
+                    serialize: @{serialize},
+                    maxRooms: @{max_rooms},
+                    range: @{range},
+                    plainCost: @{plain_cost},
+                    swampCost: @{swamp_cost}
+                }
+            );
+            cb.drop();
+            return res;
+        };
+
+        if serialize {
+            Path::Serialized(v.try_into().unwrap())
+        } else {
+            Path::Vectorized(v.try_into().unwrap())
+        }
     }
 
     pub fn look_for_at<T, U>(&self, ty: T, target: &U) -> Vec<T::Item>
@@ -354,9 +339,10 @@ impl PartialEq for Room {
 
 impl Eq for Room {}
 
-pub struct FindOptions<'a, F>
+pub struct FindOptions<'a, F, R>
 where
-    F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: FnMut(RoomName, CostMatrix<'a>) -> R,
+    R: RoomCostResult
 {
     pub(crate) ignore_creeps: bool,
     pub(crate) ignore_destructible_structures: bool,
@@ -368,20 +354,17 @@ where
     pub(crate) range: u32,
     pub(crate) plain_cost: u8,
     pub(crate) swamp_cost: u8,
+    pub(crate) phantom: PhantomData<&'a ()>
 }
 
-impl Default for FindOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>> {
+impl<'a, R> Default for FindOptions<'a, fn(RoomName, CostMatrix<'a>) -> R, R> where R: RoomCostResult + Default {
     fn default() -> Self {
-        fn cost_callback(_: RoomName, _: CostMatrix<'_>) -> Option<CostMatrix<'static>> {
-            None
-        }
-
         // TODO: should we fall back onto the game's default values, or is
         // it alright to copy them here?
         FindOptions {
             ignore_creeps: false,
             ignore_destructible_structures: false,
-            cost_callback,
+            cost_callback: |_, _| R::default(),
             max_ops: 2000,
             heuristic_weight: 1.2,
             serialize: false,
@@ -389,20 +372,22 @@ impl Default for FindOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<Cos
             range: 0,
             plain_cost: 1,
             swamp_cost: 5,
+            phantom: PhantomData
         }
     }
 }
 
-impl FindOptions<'static, fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'static>>> {
+impl<'a, R> FindOptions<'a, fn(RoomName, CostMatrix<'a>) -> R, R> where R: RoomCostResult + Default {
     /// Creates default SearchOptions
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<'a, F> FindOptions<'a, F>
+impl<'a, F, R> FindOptions<'a, F, R>
 where
-    F: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'a>>,
+    F: FnMut(RoomName, CostMatrix<'a>) -> R,
+    R: RoomCostResult
 {
     /// Sets whether the algorithm considers creeps as walkable. Default: False.
     pub fn ignore_creeps(mut self, ignore: bool) -> Self {
@@ -418,14 +403,14 @@ where
     }
 
     /// Sets cost callback - default `|_, _| {}`.
-    pub fn cost_callback<'b, F2>(self, cost_callback: F2) -> FindOptions<'b, F2>
+    pub fn cost_callback<'b, F2, R2>(self, cost_callback: F2) -> FindOptions<'b, F2, R2>
     where
-        F2: Fn(RoomName, CostMatrix<'_>) -> Option<CostMatrix<'b>>,
+        F2: FnMut(RoomName, CostMatrix<'b>) -> R2,
+        R2: RoomCostResult
     {
         let FindOptions {
             ignore_creeps,
             ignore_destructible_structures,
-            cost_callback: _,
             max_ops,
             heuristic_weight,
             serialize,
@@ -433,7 +418,9 @@ where
             range,
             plain_cost,
             swamp_cost,
+            ..
         } = self;
+
         FindOptions {
             ignore_creeps,
             ignore_destructible_structures,
@@ -445,6 +432,7 @@ where
             range,
             plain_cost,
             swamp_cost,
+            phantom: PhantomData
         }
     }
 

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -509,19 +509,14 @@ where
     let callback_type_erased: &mut (dyn FnMut(RoomName) -> Value + 'a) =
         &mut callback_boxed;
 
-    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
-    // storage: it's now pretending to be static data. This should be entirely safe
+    // Overwrite lifetime of reference so it can be passed to javascript. 
+    // It's now pretending to be static data. This should be entirely safe
     // because we're only sticking it in scoped storage and we control the
     // only use of it, but it's still necessary because "some lifetime above
-    // the  current scope but otherwise unknown" is not a valid lifetime to
-    // have PF_CALLBACK have.
+    // the current scope but otherwise unknown" is not a valid lifetime.
     let callback_lifetime_erased: &'static mut dyn FnMut(RoomName) -> Value =
         unsafe { mem::transmute(callback_type_erased) };
 
-    // Store callback_lifetime_erased in PF_CALLBACK for the duration of the
-    // PathFinder call and make the call to PathFinder.
-    //
-    // See https://docs.rs/scoped-tls/0.1/scoped_tls/
     let res: ::stdweb::Reference = js!(
         let cb = @{callback_lifetime_erased};
 

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -10,12 +10,11 @@
 //!
 //! [1]: crate::objects::Room::find_path
 //! [`PathFinder`]: https://docs.screeps.com/api/#PathFinder
-use std::{f64, marker::PhantomData, mem};
+use std::{f64, marker::PhantomData, mem, borrow::{Borrow}};
 
-use scoped_tls::scoped_thread_local;
-use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray};
+use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray, Value};
 
-use crate::{local::Position, objects::HasPosition, traits::TryInto};
+use crate::{local::Position, objects::HasPosition, traits::TryInto, RoomName};
 
 #[derive(Clone, Debug)]
 pub struct LocalCostMatrix {
@@ -120,6 +119,18 @@ impl Into<Vec<u8>> for LocalCostMatrix {
     }
 }
 
+impl<'a> CostMatrixSet for LocalCostMatrix {
+    fn set_multi<D, B, P, V>(&mut self, data: D) where D: IntoIterator<Item = B>, B: Borrow<(P, V)>, P: HasLocalPosition, V: Borrow<u8> {
+        let iter = data.into_iter();
+
+        for entry in iter {
+            let (pos, cost) = entry.borrow();
+            
+            self.set(pos.x(), pos.y(), *cost.borrow());
+        }
+    }
+}
+
 /// A `CostMatrix` that's valid to pass as a result from a `PathFinder.search`
 /// room callback.
 ///
@@ -139,6 +150,59 @@ impl Default for CostMatrix<'static> {
             inner: js_unwrap!(new PathFinder.CostMatrix()),
             lifetime: PhantomData,
         }
+    }
+}
+
+impl<'a> Into<MultiRoomCostResult<'a>> for CostMatrix<'a> {
+    fn into(self) -> MultiRoomCostResult<'a> {
+        MultiRoomCostResult::CostMatrix(self)
+    }
+}
+
+impl<'a> Into<SingleRoomCostResult<'a>> for CostMatrix<'a> {
+    fn into(self) -> SingleRoomCostResult<'a> {
+        SingleRoomCostResult::CostMatrix(self)
+    }
+}
+
+pub trait HasLocalPosition {
+    fn x(&self) -> u8;
+    fn y(&self) -> u8;
+}
+
+pub trait CostMatrixSet {
+    fn set<P, V>(&mut self, position: P, cost: V) where P: HasLocalPosition, V: Borrow<u8> {
+        self.set_multi(&[(position, cost)])
+    }
+
+    fn set_multi<D, B, P, V>(&mut self, data: D) where D: IntoIterator<Item = B>, B: Borrow<(P, V)>, P: HasLocalPosition, V: Borrow<u8>;
+}
+
+impl<'a> CostMatrixSet for CostMatrix<'a> {
+    fn set_multi<D, B, P, V>(&mut self, data: D) where D: IntoIterator<Item = B>, B: Borrow<(P, V)>, P: HasLocalPosition, V: Borrow<u8> {
+        let iter = data.into_iter();
+        let (minimum_size, _maximum_size) = iter.size_hint();
+        let mut storage: Vec<u8> = Vec::with_capacity(minimum_size * 3);
+
+        for entry in iter {
+            let (pos, cost) = entry.borrow();
+            storage.push(pos.x());
+            storage.push(pos.y());
+            storage.push(*cost.borrow());
+        }
+
+        let bits: TypedArray<u8> = storage.as_slice().into();
+
+        js!(
+            let matrix = @{&self.inner};
+            let raw_data = @{bits};
+
+            const element_count = raw_data.length / 3;
+
+            for (let index = 0; index < element_count; ++index) {
+                matrix.set(raw_data[index + 0], index[index + 1], index[index + 2]);
+            }
+        );
     }
 }
 
@@ -176,9 +240,57 @@ mod serde_impls {
     }
 }
 
+pub trait RoomCostResult: Into<Value> {}
+
+pub enum MultiRoomCostResult<'a> {
+    CostMatrix(CostMatrix<'a>),
+    Impassable,
+    Default
+}
+
+impl<'a> RoomCostResult for MultiRoomCostResult<'a> {}
+
+impl<'a> Default for MultiRoomCostResult<'a> {
+    fn default() -> Self {
+        MultiRoomCostResult::Default
+    }
+}
+
+impl<'a> Into<Value> for MultiRoomCostResult<'a> {
+    fn into(self) -> Value {
+        match self {
+            MultiRoomCostResult::CostMatrix(m) => m.inner.into(),
+            MultiRoomCostResult::Impassable => Value::Bool(false),
+            MultiRoomCostResult::Default => Value::Undefined
+        }
+    }
+}
+
+pub enum SingleRoomCostResult<'a> {
+    CostMatrix(CostMatrix<'a>),
+    Default
+}
+
+impl<'a> RoomCostResult for SingleRoomCostResult<'a> {}
+
+impl<'a> Default for SingleRoomCostResult<'a> {
+    fn default() -> Self {
+        SingleRoomCostResult::Default
+    }
+}
+
+impl<'a> Into<Value> for SingleRoomCostResult<'a> {
+    fn into(self) -> Value {
+        match self {
+            SingleRoomCostResult::CostMatrix(m) => m.inner.into(),
+            SingleRoomCostResult::Default => Value::Undefined
+        }
+    }
+}
+
 pub struct SearchOptions<'a, F>
 where
-    F: Fn(String) -> CostMatrix<'a>,
+    F: FnMut(RoomName) -> MultiRoomCostResult<'a>,
 {
     room_callback: F,
     plain_cost: u8,
@@ -190,10 +302,10 @@ where
     heuristic_weight: f64,
 }
 
-impl Default for SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
+impl Default for SearchOptions<'static, fn(RoomName) -> MultiRoomCostResult<'static>> {
     fn default() -> Self {
-        fn cost_matrix(_: String) -> CostMatrix<'static> {
-            CostMatrix::default()
+        fn cost_matrix(_: RoomName) -> MultiRoomCostResult<'static> {
+            MultiRoomCostResult::Default
         }
 
         // TODO: should we fall back onto the game's default values, or is
@@ -211,7 +323,7 @@ impl Default for SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
     }
 }
 
-impl SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
+impl SearchOptions<'static, fn(RoomName) -> MultiRoomCostResult<'static>> {
     /// Creates default SearchOptions
     #[inline]
     pub fn new() -> Self {
@@ -221,12 +333,12 @@ impl SearchOptions<'static, fn(String) -> CostMatrix<'static>> {
 
 impl<'a, F> SearchOptions<'a, F>
 where
-    F: Fn(String) -> CostMatrix<'a>,
+    F: FnMut(RoomName) -> MultiRoomCostResult<'a>,
 {
     /// Sets room callback - default `|_| { CostMatrix::default() }`.
     pub fn room_callback<'b, F2>(self, room_callback: F2) -> SearchOptions<'b, F2>
     where
-        F2: Fn(String) -> CostMatrix<'b>,
+        F2: FnMut(RoomName) -> MultiRoomCostResult<'b>,
     {
         let SearchOptions {
             room_callback: _,
@@ -330,7 +442,7 @@ pub fn search<'a, O, G, F>(
 where
     O: ?Sized + HasPosition,
     G: ?Sized + HasPosition,
-    F: Fn(String) -> CostMatrix<'a> + 'a,
+    F: FnMut(RoomName) -> MultiRoomCostResult<'a> + 'a,
 {
     let pos = goal.pos();
     search_real(
@@ -346,7 +458,7 @@ where
     O: HasPosition,
     G: IntoIterator<Item = (I, u32)>,
     I: HasPosition,
-    F: Fn(String) -> CostMatrix<'a> + 'a,
+    F: FnMut(RoomName) -> MultiRoomCostResult<'a> + 'a,
 {
     let goals: Vec<Object> = goal
         .into_iter()
@@ -367,43 +479,14 @@ where
     search_real(origin.pos(), &goals_js, opts)
 }
 
-scoped_thread_local!(static PF_CALLBACK: &'static dyn Fn(String) -> Reference);
-
 fn search_real<'a, F>(
     origin: Position,
     goal: &Reference,
     opts: SearchOptions<'a, F>,
 ) -> SearchResults
 where
-    F: Fn(String) -> CostMatrix<'a> + 'a,
-{
-    // TODO: should we just accept `fn()` and force the user
-    // to do this? it would... greatly simplify all of this.
-
-    // This callback is the one actually passed to JavaScript.
-    fn callback(input: String) -> Reference {
-        PF_CALLBACK.with(|callback| callback(input))
-    }
-
-    // User provided callback: rust String -> CostMatrix
-    let raw_callback = opts.room_callback;
-
-    // Wrapped user callback: rust String -> Reference
-    let callback_unboxed = move |input| raw_callback(input).inner;
-
-    // Type erased and boxed callback: no longer a type specific to the closure
-    // passed in, now unified as &Fn
-    let callback_type_erased: &(dyn Fn(String) -> Reference + 'a) = &callback_unboxed;
-
-    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
-    // storage: it's now pretending to be static data. This should be entirely safe
-    // because we're only sticking it in scoped storage and we control the only
-    // use of it, but it's still necessary because "some lifetime above the
-    // current scope but otherwise unknown" is not a valid lifetime to have
-    // PF_CALLBACK have.
-    let callback_lifetime_erased: &'static dyn Fn(String) -> Reference =
-        unsafe { mem::transmute(callback_type_erased) };
-
+    F: FnMut(RoomName) -> MultiRoomCostResult<'a> + 'a,
+{       
     let SearchOptions {
         plain_cost,
         swamp_cost,
@@ -415,29 +498,55 @@ where
         ..
     } = opts;
 
+    let mut raw_callback = opts.room_callback;
+
+    let mut callback_boxed = move |room_name: RoomName| -> Value {
+        raw_callback(room_name).into()
+    };
+
+    // Type erased and boxed callback: no longer a type specific to the closure
+    // passed in, now unified as &Fn
+    let callback_type_erased: &mut (dyn FnMut(RoomName) -> Value + 'a) =
+        &mut callback_boxed;
+
+    // Overwrite lifetime of reference so it can be stuck in scoped_thread_local
+    // storage: it's now pretending to be static data. This should be entirely safe
+    // because we're only sticking it in scoped storage and we control the
+    // only use of it, but it's still necessary because "some lifetime above
+    // the  current scope but otherwise unknown" is not a valid lifetime to
+    // have PF_CALLBACK have.
+    let callback_lifetime_erased: &'static mut dyn FnMut(RoomName) -> Value =
+        unsafe { mem::transmute(callback_type_erased) };
+
     // Store callback_lifetime_erased in PF_CALLBACK for the duration of the
     // PathFinder call and make the call to PathFinder.
     //
     // See https://docs.rs/scoped-tls/0.1/scoped_tls/
-    PF_CALLBACK.set(&callback_lifetime_erased, || {
-        let res: ::stdweb::Reference = js_unwrap! {
-            PathFinder.search(pos_from_packed(@{origin.packed_repr()}), @{goal}, {
-                roomCallback: @{callback},
-                plainCost: @{plain_cost},
-                swampCost: @{swamp_cost},
-                flee: @{flee},
-                maxOps: @{max_ops},
-                maxRooms: @{max_rooms},
-                maxCost: @{max_cost},
-                heuristicWeight: @{heuristic_weight}
-            })
-        };
+    let res: ::stdweb::Reference = js!(
+        let cb = @{callback_lifetime_erased};
 
-        SearchResults {
-            path: js_unwrap!(@{&res}.path),
-            ops: js_unwrap!(@{&res}.ops),
-            cost: js_unwrap!(@{&res}.cost),
-            incomplete: js_unwrap!(@{&res}.incomplete),
-        }
-    })
+        let res = PathFinder.search(pos_from_packed(@{origin.packed_repr()}), @{goal}, {
+            roomCallback: cb,
+            plainCost: @{plain_cost},
+            swampCost: @{swamp_cost},
+            flee: @{flee},
+            maxOps: @{max_ops},
+            maxRooms: @{max_rooms},
+            maxCost: @{max_cost},
+            heuristicWeight: @{heuristic_weight}
+        })
+        
+        cb.drop();
+
+        return res;
+    )
+    .try_into()
+    .expect("expected reference from search");
+
+    SearchResults {
+        path: js_unwrap!(@{&res}.path),
+        ops: js_unwrap!(@{&res}.ops),
+        cost: js_unwrap!(@{&res}.cost),
+        incomplete: js_unwrap!(@{&res}.incomplete),
+    }
 }


### PR DESCRIPTION
This is another pass at adding back in full cost matrix return values.

- Adds the correct return values multi-room pathfinding that allows to make a room as impassable.
- Removes complexity for pathfinding callbacks that were being stored in thread local storage that can remain on the stack.
- Fixes callback leaks on the JS side caused by not dropping the callbacks.

I'm proposing we take the breaking change as it seems like people are already using these changes as they're needed to make multi-room pathfinding work out of the box.