### PR TITLE
Fix deserializing for Power and Transfer event.

### DIFF
--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -568,6 +568,8 @@ impl<'de> Deserialize<'de> for Event {
                                         8 => Some(EventType::ReserveController(map.next_value()?)),
                                         9 => Some(EventType::UpgradeController(map.next_value()?)),
                                         10 => Some(EventType::Exit(map.next_value()?)),
+                                        11 => Some(EventType::Power(map.next_value()?)),
+                                        12 => Some(EventType::Transfer(map.next_value()?)),
                                         _ => {
                                             return Err(de::Error::custom(format!(
                                                 "Event Type Unrecognized: {}",


### PR DESCRIPTION
`Room.get_event_log()` panics when the event is either `EVENT_TRANSFER` or `EVENT_POWER`.

This seems to fix the problem for me. Please take a look. Thanks,