### PR TITLE
Fix path serialize/deserialize functions being static/not on object instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Unreleased
 ==========
 
-
+- Fixed `Room::serialize_path` and `Room::deserialize_path`, which are static methods and don't
+  exist on instances of `Room` objects themselves.
 
 0.9.0 (2021-01-23)
 ==================

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -39,12 +39,12 @@ simple_accessors! {
 }
 
 impl Room {
-    pub fn serialize_path(&self, path: &[Step]) -> String {
-        js_unwrap! {@{self.as_ref()}.serializePath(@{path})}
+    pub fn serialize_path(path: &[Step]) -> String {
+        js_unwrap! {Room.serializePath(@{path})}
     }
 
-    pub fn deserialize_path(&self, path: &str) -> Vec<Step> {
-        js_unwrap! {@{self.as_ref()}.deserializePath(@{path})}
+    pub fn deserialize_path(path: &str) -> Vec<Step> {
+        js_unwrap! {Room.deserializePath(@{path})}
     }
 
     pub fn create_construction_site<T>(&self, at: &T, ty: StructureType) -> ReturnCode


### PR DESCRIPTION
Fixes #343 - `Room` object instances don't have `serializePath` and `deserializePath`, they're only available as static methods on the class.