### PR TITLE
Traits and feature improvements

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -66,8 +66,9 @@ mod recipes;
 pub mod seasonal;
 mod small_enums;
 mod types;
+pub mod look;
 
-pub use self::{extra::*, numbers::*, recipes::FactoryRecipe, small_enums::*, types::*};
+pub use self::{extra::*, numbers::*, recipes::FactoryRecipe, small_enums::*, types::*, look::*};
 
 /// Re-export of all constants related to [`Creep`] behavior and operations.
 ///

--- a/src/constants/look.rs
+++ b/src/constants/look.rs
@@ -1,0 +1,91 @@
+use enum_iterator::IntoEnumIterator;
+use wasm_bindgen::prelude::*;
+use serde::{Deserialize, Serialize};
+use crate::objects::*;
+use crate::enums::StructureObject;
+
+/// Translates `LOOK_*` constants.
+#[wasm_bindgen]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, IntoEnumIterator)]
+pub enum Look {
+    Creeps = "creep",
+    Energy = "energy",
+    Resources = "resource",
+    Sources = "source",
+    Minerals = "mineral",
+    Structures = "structure",
+    Flags = "flag",
+    ConstructionSites = "constructionSite",
+    Nukes = "nuke",
+    Terrain = "terrain",
+    Tombstones = "tombstone",
+    PowerCreeps = "powerCreep",
+    Deposits = "deposit",
+    Ruins = "ruin",
+    // todo these seem to not work when conditionally compiled out - they're not hurting to leave
+    // in but need to figure that out
+    //#[cfg(feature = "enable-score")]
+    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
+    ScoreContainers = "scoreContainer",
+    //#[cfg(feature = "enable-score")]
+    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
+    ScoreCollectors = "scoreCollector",
+    //#[cfg(feature = "enable-symbols")]
+    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
+    SymbolContainers = "symbolContainer",
+    //#[cfg(feature = "enable-symbols")]
+    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
+    SymbolDecoders = "symbolDecoder",
+}
+
+macro_rules! typesafe_look_constants {
+    (
+        $(
+            $vis:vis struct $constant_name:ident = ($value:expr, $result:path, $conversion_method:expr);
+        )*
+    ) => (
+        $(
+            #[allow(bad_style)]
+            $vis struct $constant_name;
+            impl LookConstant for $constant_name {
+                type Item = $result;
+
+                fn convert_and_check_item(reference: JsValue) -> Self::Item {
+                    $conversion_method(reference)
+                }
+
+                #[inline]
+                fn look_code() -> Look {
+                    $value
+                }
+            }
+        )*
+    );
+}
+
+pub trait LookConstant {
+    type Item;
+
+    fn convert_and_check_item(reference: JsValue) -> Self::Item;
+
+    fn look_code() -> Look;
+}
+
+typesafe_look_constants! {
+    pub struct CREEPS = (Look::Creeps, Creep, Into::into);
+    pub struct ENERGY = (Look::Energy, Resource, Into::into);
+    pub struct RESOURCES = (Look::Resources, Resource, Into::into);
+    pub struct SOURCES = (Look::Sources, Source, Into::into);
+    pub struct MINERALS = (Look::Minerals, Mineral, Into::into);
+    pub struct DEPOSITS = (Look::Deposits, Deposit, Into::into);
+    pub struct STRUCTURES = (Look::Structures, StructureObject, Into::into);
+    pub struct FLAGS = (Look::Flags, Flag, Into::into);
+    pub struct CONSTRUCTION_SITES = (Look::ConstructionSites, ConstructionSite,
+        Into::into);
+    pub struct NUKES = (Look::Nukes, Nuke, Into::into);
+    //TODO: wiarchbe: Add back in terrain type.
+    //pub struct TERRAIN = (Look::Terrain, Terrain, TryInto::try_into);
+    pub struct TOMBSTONES = (Look::Tombstones, Tombstone, Into::into);
+    pub struct POWER_CREEPS = (Look::PowerCreeps, PowerCreep, Into::into);
+    pub struct RUINS = (Look::Ruins, Ruin, Into::into);
+}

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -1,5 +1,4 @@
 //! Various constants translated as small enums.
-// use std::{borrow::Cow, fmt, str::FromStr};
 
 use enum_iterator::IntoEnumIterator;
 use num_derive::FromPrimitive;
@@ -243,40 +242,6 @@ impl From<ExitDirection> for Direction {
             ExitDirection::Left => Direction::Left,
         }
     }
-}
-
-/// Translates `LOOK_*` constants.
-#[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, IntoEnumIterator)]
-pub enum Look {
-    Creeps = "creep",
-    Energy = "energy",
-    Resources = "resource",
-    Sources = "source",
-    Minerals = "mineral",
-    Structures = "structure",
-    Flags = "flag",
-    ConstructionSites = "constructionSite",
-    Nukes = "nuke",
-    Terrain = "terrain",
-    Tombstones = "tombstone",
-    PowerCreeps = "powerCreep",
-    Deposits = "deposit",
-    Ruins = "ruin",
-    // todo these seem to not work when conditionally compiled out - they're not hurting to leave
-    // in but need to figure that out
-    //#[cfg(feature = "enable-score")]
-    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
-    ScoreContainers = "scoreContainer",
-    //#[cfg(feature = "enable-score")]
-    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
-    ScoreCollectors = "scoreCollector",
-    //#[cfg(feature = "enable-symbols")]
-    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
-    SymbolContainers = "symbolContainer",
-    //#[cfg(feature = "enable-symbols")]
-    //#[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
-    SymbolDecoders = "symbolDecoder",
 }
 
 /// Translates `COLOR_*` constants.

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -1,7 +1,8 @@
 use enum_dispatch::enum_dispatch;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 
 use crate::objects::*;
+use crate::prelude::*;
 
 #[enum_dispatch(Attackable)]
 pub enum AttackableObject {
@@ -113,6 +114,44 @@ pub enum CooldownObject {
 
 #[enum_dispatch(HasId)]
 pub enum ObjectWithId {
+    Deposit,
+    Mineral,
+    Nuke,
+    Resource,
+    Ruin,
+    #[cfg(feature = "enable-score")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
+    ScoreCollector,
+    #[cfg(feature = "enable-score")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
+    ScoreContainer,
+    Source,
+    StructureContainer,
+    StructureController,
+    StructureExtension,
+    StructureExtractor,
+    StructureFactory,
+    StructureInvaderCore,
+    StructureKeeperLair,
+    StructureLab,
+    StructureLink,
+    StructureNuker,
+    StructureObserver,
+    StructurePortal,
+    StructurePowerBank,
+    StructurePowerSpawn,
+    StructureRampart,
+    StructureRoad,
+    StructureSpawn,
+    StructureStorage,
+    StructureTerminal,
+    StructureTower,
+    StructureWall,
+    Tombstone,
+}
+
+#[enum_dispatch(MaybeHasId)]
+pub enum ObjectWithMaybeId {
     ConstructionSite,
     Creep,
     Deposit,
@@ -295,7 +334,7 @@ pub enum MovableObject {
 
 /// Enum used for converting a [`Structure`] into a typed object of its specific
 /// structure type.
-#[enum_dispatch(StructureProperties)]
+#[enum_dispatch(StructureProperties, HasPosition)]
 pub enum StructureObject {
     StructureContainer,
     StructureController,
@@ -318,6 +357,14 @@ pub enum StructureObject {
     StructureTerminal,
     StructureTower,
     StructureWall,
+}
+
+impl From<JsValue> for StructureObject {
+    fn from(reference: JsValue) -> Self {
+        let structure: Structure = reference.unchecked_into();
+
+        structure.into()
+    }
 }
 
 impl From<Structure> for StructureObject {
@@ -347,6 +394,34 @@ impl From<Structure> for StructureObject {
             Tower => Self::StructureTower(structure.unchecked_into()),
             Wall => Self::StructureWall(structure.unchecked_into()),
             _ => panic!("unknown structure type for conversion into enum"),
+        }
+    }
+}
+
+impl StructureObject {
+    pub fn as_has_store(&self) -> Option<&dyn HasStore> {
+        match self {
+            Self::StructureSpawn(s) => Some(s),
+            Self::StructureExtension(s) => Some(s),
+            Self::StructureRoad(_) => None,
+            Self::StructureWall(_) => None,
+            Self::StructureRampart(_) => None,
+            Self::StructureKeeperLair(_) => None,
+            Self::StructurePortal(_) => None,
+            Self::StructureController(_) => None,
+            Self::StructureLink(s) => Some(s),
+            Self::StructureStorage(s) => Some(s),
+            Self::StructureTower(s) => Some(s),
+            Self::StructureObserver(_) => None,
+            Self::StructurePowerBank(_) => None,
+            Self::StructurePowerSpawn(s) => Some(s),
+            Self::StructureExtractor(_) => None,
+            Self::StructureLab(s) => Some(s),
+            Self::StructureTerminal(s) => Some(s),
+            Self::StructureContainer(s) => Some(s),
+            Self::StructureNuker(s) => Some(s),
+            Self::StructureFactory(s) => Some(s),
+            Self::StructureInvaderCore(_) => None,
         }
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -190,10 +190,9 @@ impl Game {
     where
         T: From<JsValue>,
     {
-        match Game::get_object_by_id(&id.raw) {
-            Some(object) => Some(JsValue::from(object).into()),
-            None => None,
-        }
+        Game::get_object_by_id(&id.raw)
+            .map(JsValue::from)
+            .map(Into::into)
     }
 
     /// Get the typed object represented by a given [`ObjectId`], if it's still
@@ -207,10 +206,9 @@ impl Game {
         // construct a reference to a javascript string using the id data
         let js_str = JsString::from(id.to_string());
 
-        match Game::get_object_by_id(&js_str) {
-            Some(object) => Some(JsValue::from(object).into()),
-            None => None,
-        }
+        Game::get_object_by_id(&js_str)
+            .map(JsValue::from)
+            .map(Into::into)
     }
 
     /// Get the [`RoomObject`] represented by a given [`RawObjectId`], if it's

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -28,7 +28,7 @@ mod impls;
 //mod structure;
 
 pub use self::impls::{
-    ConstructionSite, CostMatrix, Creep, Deposit, Flag, Mineral, Nuke, OwnedStructure, Owner,
+    ConstructionSite, CostMatrix, CostMatrixSet, Creep, Deposit, Flag, Mineral, Nuke, OwnedStructure, Owner,
     PowerCreep, Reservation, Resource, Room, RoomObject, RoomPosition, RoomTerrain, Ruin, Sign,
     Source, Spawning, Store, Structure, StructureContainer, StructureController,
     StructureExtension, StructureExtractor, StructureFactory, StructureInvaderCore,

--- a/src/objects/impls.rs
+++ b/src/objects/impls.rs
@@ -57,6 +57,7 @@ mod symbol_decoder;
 pub use self::{
     construction_site::ConstructionSite,
     cost_matrix::CostMatrix,
+    cost_matrix::CostMatrixSet,
     creep::Creep,
     deposit::Deposit,
     flag::Flag,

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::{ReturnCode, StructureType},
-    objects::{Owner, Room, RoomObject, RoomPosition},
+    objects::{Owner, RoomObject},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -61,22 +61,8 @@ extern "C" {
     pub fn remove(this: &ConstructionSite) -> ReturnCode;
 }
 
-impl HasId for ConstructionSite {
+impl MaybeHasId for ConstructionSite {
     fn id(&self) -> Option<JsString> {
         Self::id(self)
-    }
-}
-impl HasPosition for ConstructionSite {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for ConstructionSite {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
     }
 }

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{Direction, Part, ResourceType, ReturnCode},
     objects::{
-        ConstructionSite, Owner, Resource, Room, RoomObject, RoomPosition, Store, Structure,
+        ConstructionSite, Owner, Resource, RoomObject, Store, Structure,
         StructureController,
     },
     prelude::*,
@@ -45,8 +45,7 @@ extern "C" {
     pub fn hits_max(this: &Creep) -> u32;
 
     /// Object ID of the creep, which can be used to efficiently fetch a fresh
-    /// reference to the object on subsequent ticks.  `None` if the creep began
-    /// spawning this tick.
+    /// reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.id)
     #[wasm_bindgen(final, method, getter)]
@@ -317,7 +316,7 @@ extern "C" {
     ) -> ReturnCode;
 }
 
-impl Attackable for Creep {
+impl HasHits for Creep {
     fn hits(&self) -> u32 {
         Self::hits(self)
     }
@@ -326,28 +325,16 @@ impl Attackable for Creep {
         Self::hits_max(self)
     }
 }
-impl HasId for Creep {
+
+impl MaybeHasId for Creep {
     fn id(&self) -> Option<JsString> {
         Self::id(self)
     }
 }
-impl HasPosition for Creep {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for Creep {
     fn store(&self) -> Store {
         Self::store(self)
-    }
-}
-impl RoomObjectProperties for Creep {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
     }
 }
 

--- a/src/objects/impls/deposit.rs
+++ b/src/objects/impls/deposit.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::ResourceType,
-    objects::{Room, RoomObject, RoomPosition},
+    objects::{RoomObject},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -52,27 +52,15 @@ impl CanDecay for Deposit {
         Self::ticks_to_decay(self)
     }
 }
+
 impl HasCooldown for Deposit {
     fn cooldown(&self) -> u32 {
         Self::cooldown(self)
     }
 }
-impl HasId for Deposit {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self))
-    }
-}
-impl HasPosition for Deposit {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for Deposit {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
 
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
+impl HasId for Deposit {
+    fn id(&self) -> JsString {
+        Self::id(self)
     }
 }

--- a/src/objects/impls/flag.rs
+++ b/src/objects/impls/flag.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::Color,
-    objects::{Room, RoomObject, RoomPosition},
-    prelude::*,
+    objects::{RoomObject, RoomPosition}
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -59,19 +58,4 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Flag.setPosition)
     #[wasm_bindgen(method, js_name = setPosition)]
     pub fn set_position(this: &Flag, pos: RoomPosition);
-}
-
-impl HasPosition for Flag {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for Flag {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
 }

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::{Density, ResourceType},
-    objects::{Room, RoomObject, RoomPosition},
+    objects::{RoomObject},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -41,21 +41,7 @@ extern "C" {
 }
 
 impl HasId for Mineral {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self))
-    }
-}
-impl HasPosition for Mineral {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for Mineral {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
+    fn id(&self) -> JsString {
+        Self::id(self)
     }
 }

--- a/src/objects/impls/nuke.rs
+++ b/src/objects/impls/nuke.rs
@@ -1,8 +1,8 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition},
+    objects::{RoomObject},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -35,21 +35,7 @@ extern "C" {
 }
 
 impl HasId for Nuke {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self))
-    }
-}
-impl HasPosition for Nuke {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for Nuke {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
+    fn id(&self) -> JsString {
+        Self::id(self)
     }
 }

--- a/src/objects/impls/owned_structure.rs
+++ b/src/objects/impls/owned_structure.rs
@@ -1,8 +1,8 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Structure},
-    prelude::*,
+    objects::{RoomObject, Structure},
+    prelude::*
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -29,18 +29,13 @@ extern "C" {
     pub fn owner(this: &OwnedStructure) -> Option<Owner>;
 }
 
-impl HasPosition for OwnedStructure {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for OwnedStructure {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
+impl<T> OwnedStructureProperties for T where T: AsRef<OwnedStructure> {
+    fn my(&self) -> bool {
+        OwnedStructure::my(self.as_ref())
     }
 
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
+    fn owner(&self) -> Option<Owner> {
+        OwnedStructure::owner(self.as_ref())
     }
 }
 

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -1,12 +1,12 @@
 use crate::{
     constants::{Direction, PowerCreepClass, PowerType, ResourceType, ReturnCode},
     objects::{
-        Owner, Resource, Room, RoomObject, RoomPosition, Store, StructureController,
+        Owner, Resource, RoomObject, Store, StructureController,
         StructurePowerSpawn,
     },
     prelude::*,
 };
-use js_sys::{Array, JsString, Object};
+use js_sys::{JsString, Object};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -16,6 +16,13 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep)
     #[wasm_bindgen(extends = RoomObject)]
     pub type PowerCreep;
+
+    //TODO: wiarchbe: Come back to this... need a good 'maybe has position' implementation that doesn't conflict with base pos().
+    /// Position of the object.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#RoomObject.pos)
+    //#[wasm_bindgen(method, getter)]
+    //pub fn pos(this: &RoomObject) -> Option<RoomPosition>;
 
     /// Create a new power creep in your account. Note that it will not
     /// initially be spawned.
@@ -272,7 +279,7 @@ extern "C" {
     ) -> ReturnCode;
 }
 
-impl Attackable for PowerCreep {
+impl HasHits for PowerCreep {
     fn hits(&self) -> u32 {
         Self::hits(self)
     }
@@ -281,30 +288,38 @@ impl Attackable for PowerCreep {
         Self::hits_max(self)
     }
 }
+
+//TODO: wiarchbe: Add maybe has ID?
+
+/*
 impl HasId for PowerCreep {
+    fn id(&self) -> JsString {
+        Self::id(self)
+    }
+}
+*/
+
+impl MaybeHasId for PowerCreep {
     fn id(&self) -> Option<JsString> {
         Self::id(self)
     }
 }
-impl HasPosition for PowerCreep {
+
+//TODO: wiarchbe: Implement!
+/*
+impl MaybeHasPosition for PowerCreep {
     fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
+        PowerCreep::pos(self.as_ref())
     }
 }
+*/
+
 impl HasStore for PowerCreep {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl RoomObjectProperties for PowerCreep {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
 
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
 impl SharedCreepProperties for PowerCreep {
     fn memory(&self) -> JsValue {
         Self::memory(self)

--- a/src/objects/impls/resource.rs
+++ b/src/objects/impls/resource.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::ResourceType,
-    objects::{Room, RoomObject, RoomPosition},
+    objects::{RoomObject},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -36,21 +36,7 @@ extern "C" {
 }
 
 impl HasId for Resource {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self))
-    }
-}
-impl HasPosition for Resource {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for Resource {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
+    fn id(&self) -> JsString {
+        Self::id(self)
     }
 }

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -1,7 +1,8 @@
-//use crate::local::RoomName;
 use crate::{
+    prelude::*,
     constants::{ExitDirection, Find, Look, ReturnCode, StructureType},
-    objects::{RoomPosition, RoomTerrain, StructureController, StructureStorage},
+    objects::*,
+    constants::look::*,
 };
 
 #[cfg(not(feature = "disable-terminal"))]
@@ -184,21 +185,21 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.lookForAt)
     #[wasm_bindgen(method, js_name = lookFor)]
-    pub fn look_for_at(this: &Room, ty: Look, target: &RoomPosition) -> Option<Array>;
+    fn look_for_at_internal(this: &Room, ty: Look, target: &RoomPosition) -> Option<Array>;
 
     /// Get an array of all objects of a given type at the given coordinates, if
     /// any.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.lookForAt)
     #[wasm_bindgen(method, js_name = lookFor)]
-    pub fn look_for_at_xy(this: &Room, ty: Look, x: u8, y: u8) -> Option<Array>;
+    fn look_for_at_xy_internal(this: &Room, ty: Look, x: u8, y: u8) -> Option<Array>;
 
     /// Get an array of all objects in a certain area, in either object or array
     /// format depending on the `as_array` option.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.lookAtArea)
     #[wasm_bindgen(method, js_name = lookAtArea)]
-    pub fn look_for_at_area(
+    fn look_for_at_area_internal(
         this: &Room,
         ty: Look,
         top_y: u8,
@@ -208,6 +209,30 @@ extern "C" {
         as_array: bool,
     ) -> JsValue;
 }
+
+impl Room {
+    pub fn look_for_at<T, U>(&self, _ty: T, target: &U) -> Vec<T::Item>
+    where
+        T: LookConstant,
+        U: HasPosition,
+    {
+        let pos = target.pos();
+
+        self.look_for_at_internal(T::look_code(), &pos)
+            .map(|arr| arr.iter().map(T::convert_and_check_item).collect())
+            .unwrap_or_else(Vec::new)
+    }
+
+    pub fn look_for_at_xy<T>(&self, _ty: T, x: u8, y: u8) -> Vec<T::Item>
+    where
+        T: LookConstant,
+    {
+        self.look_for_at_xy_internal(T::look_code(), x, y)
+            .map(|arr| arr.iter().map(T::convert_and_check_item).collect())
+            .unwrap_or_else(Vec::new)
+    }
+}
+
 
 // use std::{fmt, marker::PhantomData, mem, ops::Range};
 

--- a/src/objects/impls/room_object.rs
+++ b/src/objects/impls/room_object.rs
@@ -18,12 +18,11 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn effects(this: &RoomObject) -> Array;
 
-    /// Position of the object, or `None` if the object is a power creep not
-    /// spawned on the current shard.
+    /// Position of the object.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomObject.pos)
     #[wasm_bindgen(method, getter)]
-    pub fn pos(this: &RoomObject) -> Option<RoomPosition>;
+    pub fn pos(this: &RoomObject) -> RoomPosition;
 
     /// A link to the room that the object is currently in, or `None` if the
     /// object is a power creep not spawned on the current shard, or a flag or
@@ -34,17 +33,18 @@ extern "C" {
     pub fn room(this: &RoomObject) -> Option<Room>;
 }
 
-impl HasPosition for RoomObject {
-    fn pos(&self) -> Option<RoomPosition> {
-        Self::pos(self.as_ref())
+impl<T> HasPosition for T where T: AsRef<RoomObject> {
+    fn pos(&self) -> RoomPosition {
+        RoomObject::pos(self.as_ref())
     }
 }
-impl RoomObjectProperties for RoomObject {
+
+impl<T> RoomObjectProperties for T where T: AsRef<RoomObject> {
     fn effects(&self) -> Array {
-        Self::effects(self)
+        RoomObject::effects(self.as_ref())
     }
 
     fn room(&self) -> Option<Room> {
-        Self::room(self)
+        RoomObject::room(self.as_ref())
     }
 }

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -231,11 +231,18 @@ extern "C" {
     pub fn look_for(this: &RoomPosition, ty: Look) -> Option<Array>;
 }
 
-impl HasPosition for RoomPosition {
-    fn pos(&self) -> Option<Self> {
+impl Clone for RoomPosition {
+    fn clone(&self) -> Self {
         let new_pos = RoomPosition::from(JsValue::from(Object::create(&ROOM_POSITION_PROTOTYPE)));
         new_pos.set_packed(self.packed());
-        Some(new_pos)
+        new_pos        
+    }
+}
+
+impl HasPosition for RoomPosition {
+    fn pos(&self) -> Self {
+        //TODO: Should this clone or just return self?
+        self.clone()
     }
 }
 

--- a/src/objects/impls/ruin.rs
+++ b/src/objects/impls/ruin.rs
@@ -1,8 +1,8 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -55,27 +55,15 @@ impl CanDecay for Ruin {
         Self::ticks_to_decay(self)
     }
 }
+
 impl HasId for Ruin {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self))
+    fn id(&self) -> JsString {
+        Self::id(self)
     }
 }
-impl HasPosition for Ruin {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for Ruin {
     fn store(&self) -> Store {
         Self::store(self)
-    }
-}
-impl RoomObjectProperties for Ruin {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
     }
 }

--- a/src/objects/impls/score_collector.rs
+++ b/src/objects/impls/score_collector.rs
@@ -38,22 +38,9 @@ impl HasId for ScoreCollector {
         Some(Self::id(self.as_ref()))
     }
 }
-impl HasPosition for ScoreCollector {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for ScoreCollector {
     fn store(&self) -> Store {
         Self::store(self)
-    }
-}
-impl RoomObjectProperties for ScoreCollector {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
     }
 }

--- a/src/objects/impls/score_container.rs
+++ b/src/objects/impls/score_container.rs
@@ -45,27 +45,15 @@ impl CanDecay for ScoreContainer {
         Self::ticks_to_decay(self)
     }
 }
+
 impl HasId for ScoreContainer {
     fn id(&self) -> Option<JsString> {
         Some(Self::id(self.as_ref()))
     }
 }
-impl HasPosition for ScoreContainer {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for ScoreContainer {
     fn store(&self) -> Store {
         Self::store(self)
-    }
-}
-impl RoomObjectProperties for ScoreContainer {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
     }
 }

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -1,8 +1,8 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition},
+    objects::{RoomObject},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -54,21 +54,7 @@ extern "C" {
 }
 
 impl HasId for Source {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self))
-    }
-}
-impl HasPosition for Source {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for Source {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
+    fn id(&self) -> JsString {
+        Self::id(self)
     }
 }

--- a/src/objects/impls/store.rs
+++ b/src/objects/impls/store.rs
@@ -1,6 +1,9 @@
 use crate::constants::ResourceType;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use js_sys::{Object};
 
+//TODO: wiarchbe: Need types for general purpose store and specific store. (Specific store can return undefined for missing types.)
 #[wasm_bindgen]
 extern "C" {
     /// An object that represents the cargo within an entity in the game world.
@@ -8,6 +11,9 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Store)
     #[wasm_bindgen]
     pub type Store;
+
+    #[wasm_bindgen(method, structural, indexing_getter)]
+    pub fn get(this: &Store, ty: ResourceType) -> Option<u32>;
 
     /// Get the capacity of the [`Store`] for the specified resource. If the
     /// [`Store`] can contain any resource, passing `None` as the type will get
@@ -30,4 +36,13 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Store.getUsedCapacity)
     #[wasm_bindgen(method, js_name = getUsedCapacity)]
     pub fn get_used_capacity(this: &Store, ty: Option<ResourceType>) -> u32;
+}
+
+impl Store {
+    pub fn store_types(&self) -> Vec<ResourceType> {
+        Object::keys(self.unchecked_ref())
+            .iter()
+            .filter_map(|v| ResourceType::from_js_value(&v))
+            .collect()
+    }
 }

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::{ReturnCode, StructureType},
-    objects::{Room, RoomObject, RoomPosition},
+    objects::{RoomObject},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -64,18 +64,36 @@ extern "C" {
     pub fn notify_when_attacked(this: &Structure, val: bool) -> ReturnCode;
 }
 
-impl HasPosition for Structure {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
+impl<T> HasId for T where T: AsRef<Structure> {
+    fn id(&self) -> JsString {
+        Structure::id(self.as_ref())
     }
 }
 
-impl RoomObjectProperties for Structure {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
+impl<T> HasHits for T where T: AsRef<Structure> {
+    fn hits(&self) -> u32 {
+        Structure::hits(self.as_ref())
     }
 
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
+    fn hits_max(&self) -> u32 {
+        Structure::hits_max(self.as_ref())
+    }
+}
+
+impl<T> StructureProperties for T where T: AsRef<Structure> {
+    fn structure_type(&self) -> StructureType {
+        Structure::structure_type(self.as_ref())
+    }
+
+    fn destroy(&self) -> ReturnCode {
+        Structure::destroy(self.as_ref())
+    }
+
+    fn is_active(&self) -> bool {
+        Structure::is_active(self.as_ref())
+    }
+
+    fn notify_when_attacked(&self, val: bool) -> ReturnCode {
+        Structure::notify_when_attacked(self.as_ref(), val)
     }
 }

--- a/src/objects/impls/structure_container.rs
+++ b/src/objects/impls/structure_container.rs
@@ -1,8 +1,7 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -30,42 +29,14 @@ extern "C" {
     pub fn ticks_to_decay(this: &StructureContainer) -> u32;
 }
 
-impl Attackable for StructureContainer {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl CanDecay for StructureContainer {
     fn ticks_to_decay(&self) -> u32 {
         Self::ticks_to_decay(self)
     }
 }
-impl HasId for StructureContainer {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureContainer {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for StructureContainer {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl RoomObjectProperties for StructureContainer {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureContainer {}

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::ReturnCode,
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Structure},
-    prelude::*,
+    objects::{OwnedStructure, RoomObject, Structure},
 };
-use js_sys::{Array, Date, JsString};
+use js_sys::{Date, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -107,36 +106,6 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn unclaim(this: &StructureController) -> ReturnCode;
 }
-
-impl HasId for StructureController {
-    fn id(&self) -> Option<JsString> {
-        Self::id(self.as_ref())
-    }
-}
-impl HasPosition for StructureController {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl OwnedStructureProperties for StructureController {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureController {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureController {}
 
 #[wasm_bindgen]
 extern "C" {

--- a/src/objects/impls/structure_extension.rs
+++ b/src/objects/impls/structure_extension.rs
@@ -1,8 +1,7 @@
 use crate::{
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -22,46 +21,8 @@ extern "C" {
     pub fn store(this: &StructureExtension) -> Store;
 }
 
-impl Attackable for StructureExtension {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureExtension {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureExtension {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
 impl HasStore for StructureExtension {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureExtension {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureExtension {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureExtension {}

--- a/src/objects/impls/structure_extractor.rs
+++ b/src/objects/impls/structure_extractor.rs
@@ -1,8 +1,7 @@
 use crate::{
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Structure},
+    objects::{OwnedStructure, RoomObject, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -27,46 +26,8 @@ extern "C" {
     pub fn cooldown(this: &StructureExtractor) -> u32;
 }
 
-impl Attackable for StructureExtractor {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl HasCooldown for StructureExtractor {
     fn cooldown(&self) -> u32 {
         Self::cooldown(self)
     }
 }
-impl HasId for StructureExtractor {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureExtractor {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl OwnedStructureProperties for StructureExtractor {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureExtractor {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureExtractor {}

--- a/src/objects/impls/structure_factory.rs
+++ b/src/objects/impls/structure_factory.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::{ResourceType, ReturnCode},
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -44,51 +43,14 @@ extern "C" {
     pub fn produce(this: &StructureFactory, ty: ResourceType) -> ReturnCode;
 }
 
-impl Attackable for StructureFactory {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl HasCooldown for StructureFactory {
     fn cooldown(&self) -> u32 {
         Self::cooldown(self)
     }
 }
-impl HasId for StructureFactory {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureFactory {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for StructureFactory {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureFactory {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureFactory {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureFactory {}

--- a/src/objects/impls/structure_invader_core.rs
+++ b/src/objects/impls/structure_invader_core.rs
@@ -1,8 +1,6 @@
 use crate::{
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Spawning, Structure},
-    prelude::*,
+    objects::{OwnedStructure, RoomObject, Spawning, Structure}
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -35,42 +33,3 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn spawning(this: &StructureInvaderCore) -> Option<Spawning>;
 }
-
-impl Attackable for StructureInvaderCore {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureInvaderCore {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureInvaderCore {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl OwnedStructureProperties for StructureInvaderCore {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureInvaderCore {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureInvaderCore {}

--- a/src/objects/impls/structure_keeper_lair.rs
+++ b/src/objects/impls/structure_keeper_lair.rs
@@ -1,8 +1,6 @@
 use crate::{
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Structure},
-    prelude::*,
+    objects::{OwnedStructure, RoomObject, Structure}
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -21,33 +19,3 @@ extern "C" {
     #[wasm_bindgen(method, getter = ticksToSpawn)]
     pub fn ticks_to_spawn(this: &StructureKeeperLair) -> u32;
 }
-
-impl HasId for StructureKeeperLair {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureKeeperLair {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl OwnedStructureProperties for StructureKeeperLair {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureKeeperLair {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureKeeperLair {}

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::{ResourceType, ReturnCode},
-    objects::{Creep, OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -84,52 +83,14 @@ extern "C" {
     pub fn unboost_creep(this: &StructureLab, creep: &Creep) -> ReturnCode;
 }
 
-impl Attackable for StructureLab {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl HasCooldown for StructureLab {
     fn cooldown(&self) -> u32 {
         Self::cooldown(self)
     }
 }
 
-impl HasId for StructureLab {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureLab {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
 impl HasStore for StructureLab {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureLab {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureLab {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureLab {}

--- a/src/objects/impls/structure_link.rs
+++ b/src/objects/impls/structure_link.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::ReturnCode,
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -38,52 +37,14 @@ extern "C" {
     pub fn transfer_energy(this: &StructureLink, target: &StructureLink) -> ReturnCode;
 }
 
-impl Attackable for StructureLink {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl HasCooldown for StructureLink {
     fn cooldown(&self) -> u32 {
         Self::cooldown(self)
     }
 }
 
-impl HasId for StructureLink {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureLink {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
 impl HasStore for StructureLink {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureLink {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureLink {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureLink {}

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::ReturnCode,
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, RoomPosition, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -40,51 +39,14 @@ extern "C" {
     pub fn launch_nuke(this: &StructureNuker, target: &RoomPosition) -> ReturnCode;
 }
 
-impl Attackable for StructureNuker {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl HasCooldown for StructureNuker {
     fn cooldown(&self) -> u32 {
         Self::cooldown(self)
     }
 }
-impl HasId for StructureNuker {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureNuker {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for StructureNuker {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureNuker {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureNuker {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureNuker {}

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::ReturnCode,
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Structure},
-    prelude::*,
+    objects::{OwnedStructure, RoomObject, Structure},
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -22,43 +21,3 @@ extern "C" {
     #[wasm_bindgen(method, js_name = observeRoom)]
     pub fn observe_room(this: &StructureObserver, target: &JsString) -> ReturnCode;
 }
-
-impl Attackable for StructureObserver {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureObserver {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-
-impl HasPosition for StructureObserver {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl OwnedStructureProperties for StructureObserver {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureObserver {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureObserver {}

--- a/src/objects/impls/structure_portal.rs
+++ b/src/objects/impls/structure_portal.rs
@@ -1,8 +1,7 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Structure},
+    objects::{RoomObject, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -29,27 +28,6 @@ impl CanDecay for StructurePortal {
         Self::ticks_to_decay(self)
     }
 }
-
-impl HasId for StructurePortal {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructurePortal {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructurePortal {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructurePortal {}
 
 // use serde::Deserialize;
 // use stdweb::Value;

--- a/src/objects/impls/structure_power_bank.rs
+++ b/src/objects/impls/structure_power_bank.rs
@@ -1,8 +1,7 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Structure},
+    objects::{RoomObject, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -27,38 +26,8 @@ extern "C" {
     pub fn ticks_to_decay(this: &StructurePowerBank) -> u32;
 }
 
-impl Attackable for StructurePowerBank {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl CanDecay for StructurePowerBank {
     fn ticks_to_decay(&self) -> u32 {
         Self::ticks_to_decay(self)
     }
 }
-
-impl HasId for StructurePowerBank {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructurePowerBank {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructurePowerBank {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructurePowerBank {}

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::ReturnCode,
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -32,46 +31,8 @@ extern "C" {
     pub fn process_power(this: &StructurePowerSpawn) -> ReturnCode;
 }
 
-impl Attackable for StructurePowerSpawn {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructurePowerSpawn {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructurePowerSpawn {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
 impl HasStore for StructurePowerSpawn {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructurePowerSpawn {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructurePowerSpawn {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructurePowerSpawn {}

--- a/src/objects/impls/structure_rampart.rs
+++ b/src/objects/impls/structure_rampart.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::ReturnCode,
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Structure},
+    objects::{OwnedStructure, RoomObject, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -40,48 +39,8 @@ extern "C" {
     pub fn set_public(this: &StructureRampart, val: bool) -> ReturnCode;
 }
 
-impl Attackable for StructureRampart {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl CanDecay for StructureRampart {
     fn ticks_to_decay(&self) -> u32 {
         Self::ticks_to_decay(self)
     }
 }
-
-impl HasId for StructureRampart {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-
-impl HasPosition for StructureRampart {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl OwnedStructureProperties for StructureRampart {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureRampart {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureRampart {}

--- a/src/objects/impls/structure_road.rs
+++ b/src/objects/impls/structure_road.rs
@@ -1,8 +1,7 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Structure},
+    objects::{RoomObject, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -25,37 +24,8 @@ extern "C" {
     pub fn ticks_to_decay(this: &StructureRoad) -> u32;
 }
 
-impl Attackable for StructureRoad {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
 impl CanDecay for StructureRoad {
     fn ticks_to_decay(&self) -> u32 {
         Self::ticks_to_decay(self)
     }
 }
-impl HasId for StructureRoad {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureRoad {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureRoad {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureRoad {}

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -1,6 +1,6 @@
 use crate::{
     constants::ReturnCode,
-    objects::{Creep, OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
 use js_sys::{Array, JsString, Object};
@@ -78,49 +78,11 @@ extern "C" {
     pub fn renew_creep(this: &StructureSpawn, creep: &Creep) -> ReturnCode;
 }
 
-impl Attackable for StructureSpawn {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureSpawn {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureSpawn {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
 impl HasStore for StructureSpawn {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureSpawn {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureSpawn {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureSpawn {}
 
 #[wasm_bindgen]
 extern "C" {

--- a/src/objects/impls/structure_storage.rs
+++ b/src/objects/impls/structure_storage.rs
@@ -1,8 +1,7 @@
 use crate::{
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -22,46 +21,8 @@ extern "C" {
     pub fn store(this: &StructureStorage) -> Store;
 }
 
-impl Attackable for StructureStorage {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureStorage {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureStorage {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
 impl HasStore for StructureStorage {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureStorage {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureStorage {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureStorage {}

--- a/src/objects/impls/structure_terminal.rs
+++ b/src/objects/impls/structure_terminal.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::{ResourceType, ReturnCode},
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -42,51 +42,14 @@ extern "C" {
     ) -> ReturnCode;
 }
 
-impl Attackable for StructureTerminal {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureTerminal {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
 impl HasCooldown for StructureTerminal {
     fn cooldown(&self) -> u32 {
         Self::cooldown(self)
     }
 }
-impl HasPosition for StructureTerminal {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for StructureTerminal {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureTerminal {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureTerminal {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureTerminal {}

--- a/src/objects/impls/structure_tower.rs
+++ b/src/objects/impls/structure_tower.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::ReturnCode,
-    objects::{OwnedStructure, Owner, Room, RoomObject, RoomPosition, Store, Structure},
+    objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -44,46 +43,8 @@ extern "C" {
     pub fn repair(this: &StructureTower, target: &Structure) -> ReturnCode;
 }
 
-impl Attackable for StructureTower {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureTower {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureTower {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
 impl HasStore for StructureTower {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
-impl OwnedStructureProperties for StructureTower {
-    fn my(&self) -> bool {
-        OwnedStructure::my(self.as_ref())
-    }
-
-    fn owner(&self) -> Option<Owner> {
-        OwnedStructure::owner(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureTower {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureTower {}

--- a/src/objects/impls/structure_wall.rs
+++ b/src/objects/impls/structure_wall.rs
@@ -1,8 +1,6 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Structure},
-    prelude::*,
+    objects::{RoomObject, Structure}
 };
-use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -14,33 +12,3 @@ extern "C" {
     #[wasm_bindgen(extends = RoomObject, extends = Structure)]
     pub type StructureWall;
 }
-
-impl Attackable for StructureWall {
-    fn hits(&self) -> u32 {
-        Structure::hits(self.as_ref())
-    }
-
-    fn hits_max(&self) -> u32 {
-        Structure::hits_max(self.as_ref())
-    }
-}
-impl HasId for StructureWall {
-    fn id(&self) -> Option<JsString> {
-        Some(Structure::id(self.as_ref()))
-    }
-}
-impl HasPosition for StructureWall {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
-impl RoomObjectProperties for StructureWall {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
-    }
-}
-impl StructureProperties for StructureWall {}

--- a/src/objects/impls/tombstone.rs
+++ b/src/objects/impls/tombstone.rs
@@ -1,8 +1,8 @@
 use crate::{
-    objects::{Room, RoomObject, RoomPosition, Store},
+    objects::{RoomObject, Store},
     prelude::*,
 };
-use js_sys::{Array, JsString};
+use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -54,27 +54,15 @@ impl CanDecay for Tombstone {
         Self::ticks_to_decay(self)
     }
 }
+
 impl HasId for Tombstone {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self))
+    fn id(&self) -> JsString {
+        Self::id(self)
     }
 }
-impl HasPosition for Tombstone {
-    fn pos(&self) -> Option<RoomPosition> {
-        RoomObject::pos(self.as_ref())
-    }
-}
+
 impl HasStore for Tombstone {
     fn store(&self) -> Store {
         Self::store(self)
-    }
-}
-impl RoomObjectProperties for Tombstone {
-    fn effects(&self) -> Array {
-        RoomObject::effects(self.as_ref())
-    }
-
-    fn room(&self) -> Option<Room> {
-        RoomObject::room(self.as_ref())
     }
 }

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -109,7 +109,6 @@ extern "C" {
     pub fn incomplete(this: &SearchResults) -> bool;
 }
 
-
 // use std::{f64, marker::PhantomData, mem, borrow::{Borrow}};
 
 // use stdweb::{web::TypedArray, Array, Object, Reference, UnsafeTypedArray, Value};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 use crate::{constants::*, enums::*, objects::*};
 
 #[enum_dispatch]
-pub trait Attackable {
+pub trait HasHits {
     /// Retrieve the current hits of this object.
     fn hits(&self) -> u32;
 
@@ -28,13 +28,32 @@ pub trait HasCooldown {
 #[enum_dispatch]
 pub trait HasId {
     /// Object ID of the object, which can be used to efficiently fetch a
+    /// fresh reference to the object on subsequent ticks.
+    fn id(&self) -> JsString;
+}
+
+#[enum_dispatch]
+pub trait MaybeHasId {
+    /// Object ID of the object, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks, or `None` if the
     /// object doesn't currently have an id.
     fn id(&self) -> Option<JsString>;
 }
 
+impl<T> MaybeHasId for T where T: HasId {
+    fn id(&self) -> Option<JsString> {
+        Some(self.id())
+    }
+}
+
 #[enum_dispatch]
 pub trait HasPosition {
+    /// Position of the object.
+    fn pos(&self) -> RoomPosition;
+}
+
+#[enum_dispatch]
+pub trait MaybeHasPosition {
     /// Position of the object, or `None` if the object is a power creep not
     /// spawned on the current shard.
     fn pos(&self) -> Option<RoomPosition>;
@@ -146,4 +165,12 @@ pub trait SharedCreepProperties {
 }
 
 #[enum_dispatch]
-pub trait StructureProperties {}
+pub trait StructureProperties {
+    fn structure_type(&self) -> StructureType;
+
+    fn destroy(&self) -> ReturnCode;
+
+    fn is_active(&self) -> bool;
+
+    fn notify_when_attacked(&self, val: bool) -> ReturnCode;
+}


### PR DESCRIPTION
- Remove duplicated code for structure types - use traits with blanket implementations where possible.
- Add typed 'find' constants and fix minimum set of functions.
- Add back in some old 'Structure' enumeration implementations like 'as_has_store'.
- Add 'maybe' traits for 'pos' and 'id' so that common cases (just getting pos) are much simpler in 99% cases.