### PR TITLE
LocalCostMatrix improvements

### DIFF
--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -1,5 +1,7 @@
-use crate::objects::CostMatrix;
 use std::convert::TryInto;
+use std::ops::{Index, IndexMut};
+
+use crate::objects::CostMatrix;
 
 #[derive(Clone, Debug)]
 pub struct LocalCostMatrix {
@@ -114,6 +116,24 @@ impl From<CostMatrix> for LocalCostMatrix {
         LocalCostMatrix {
             bits: array.to_vec().try_into().expect("JS CostMatrix was not length 2500."),
         }
+    }
+}
+
+impl Index<(u8, u8)> for LocalCostMatrix {
+    type Output = u8;
+
+    fn index(&self, idx: (u8, u8)) -> &Self::Output {
+        assert!(idx.0 < 50, "out of bounds x: {}", idx.0);
+        assert!(idx.1 < 50, "out of bounds y: {}", idx.1);
+        &self.bits[pos_as_idx(idx.0, idx.1)]
+    }
+}
+
+impl IndexMut<(u8, u8)> for LocalCostMatrix {
+    fn index_mut(&mut self, idx: (u8, u8)) -> &mut Self::Output {
+        assert!(idx.0 < 50, "out of bounds x: {}", idx.0);
+        assert!(idx.1 < 50, "out of bounds y: {}", idx.1);
+        &mut self.bits[pos_as_idx(idx.0, idx.1)]
     }
 }
 

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -29,12 +29,18 @@ impl LocalCostMatrix {
 
     #[inline]
     pub fn set(&mut self, x: u8, y: u8, val: u8) {
-        self.bits[pos_as_idx(x, y)] = val;
+        assert!(x < 50, "out of bounds x: {}", x);
+        assert!(y < 50, "out of bounds y: {}", y);
+        // SAFETY: 0 <= x < 50, 0 <= y < 50, 0 <=pos_as_idx(x, y) < 2500
+        unsafe { *self.bits.get_unchecked_mut(pos_as_idx(x, y)) = val; }
     }
 
     #[inline]
     pub fn get(&self, x: u8, y: u8) -> u8 {
-        self.bits[pos_as_idx(x, y)]
+        assert!(x < 50, "out of bounds x: {}", x);
+        assert!(y < 50, "out of bounds y: {}", y);
+        // SAFETY: 0 <= x < 50, 0 <= y < 50, 0 <=pos_as_idx(x, y) < 2500
+        unsafe { *self.bits.get_unchecked(pos_as_idx(x, y)) }
     }
 
     // # Safety

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -37,6 +37,24 @@ impl LocalCostMatrix {
         self.bits[pos_as_idx(x, y)]
     }
 
+    // # Safety
+    // Calling this method with x >= 50 or y >= 50 is undefined behaviour.
+    #[inline]
+    pub unsafe fn get_unchecked(&self, x: u8, y: u8) -> u8 {
+        debug_assert!(x < 50, "out of bounds x: {}", x);
+        debug_assert!(y < 50, "out of bounds y: {}", y);
+        *self.bits.get_unchecked(pos_as_idx(x,y))
+    }
+
+    // # Safety
+    // Calling this method with x >= 50 or y >= 50 is undefined behaviour.
+    #[inline]
+    pub unsafe fn set_unchecked(&mut self, x: u8, y: u8, val: u8) {
+        debug_assert!(x < 50, "out of bounds x: {}", x);
+        debug_assert!(y < 50, "out of bounds y: {}", y);
+        *self.bits.get_unchecked_mut(pos_as_idx(x, y)) = val;
+    }
+
     pub fn get_bits(&self) -> &[u8; 2500] {
         &self.bits
     }

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -31,18 +31,12 @@ impl LocalCostMatrix {
 
     #[inline]
     pub fn set(&mut self, x: u8, y: u8, val: u8) {
-        assert!(x < 50, "out of bounds x: {}", x);
-        assert!(y < 50, "out of bounds y: {}", y);
-        // SAFETY: 0 <= x < 50, 0 <= y < 50, 0 <=pos_as_idx(x, y) < 2500
-        unsafe { *self.bits.get_unchecked_mut(pos_as_idx(x, y)) = val; }
+        self[(x, y)] = val;
     }
 
     #[inline]
     pub fn get(&self, x: u8, y: u8) -> u8 {
-        assert!(x < 50, "out of bounds x: {}", x);
-        assert!(y < 50, "out of bounds y: {}", y);
-        // SAFETY: 0 <= x < 50, 0 <= y < 50, 0 <=pos_as_idx(x, y) < 2500
-        unsafe { *self.bits.get_unchecked(pos_as_idx(x, y)) }
+        self[(x, y)]
     }
 
     // # Safety
@@ -151,7 +145,8 @@ impl Index<(u8, u8)> for LocalCostMatrix {
     fn index(&self, idx: (u8, u8)) -> &Self::Output {
         assert!(idx.0 < 50, "out of bounds x: {}", idx.0);
         assert!(idx.1 < 50, "out of bounds y: {}", idx.1);
-        &self.bits[pos_as_idx(idx.0, idx.1)]
+        // SAFETY: Just did bounds checking above.
+        unsafe { self.bits.get_unchecked(pos_as_idx(idx.0, idx.1)) }
     }
 }
 
@@ -159,7 +154,8 @@ impl IndexMut<(u8, u8)> for LocalCostMatrix {
     fn index_mut(&mut self, idx: (u8, u8)) -> &mut Self::Output {
         assert!(idx.0 < 50, "out of bounds x: {}", idx.0);
         assert!(idx.1 < 50, "out of bounds y: {}", idx.1);
-        &mut self.bits[pos_as_idx(idx.0, idx.1)]
+        // SAFETY: Just did bounds checking above.
+        unsafe { self.bits.get_unchecked_mut(pos_as_idx(idx.0, idx.1)) }
     }
 }
 

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -3,6 +3,8 @@ use std::ops::{Index, IndexMut};
 
 use crate::objects::CostMatrix;
 
+use super::Position;
+
 #[derive(Clone, Debug)]
 pub struct LocalCostMatrix {
     bits: [u8; 2500],
@@ -161,6 +163,22 @@ impl IndexMut<(u8, u8)> for LocalCostMatrix {
     }
 }
 
+// TODO: Remove the casts when #346 is merged.
+impl Index<Position> for LocalCostMatrix {
+    type Output = u8;
+
+    fn index(&self,  idx: Position) -> &Self::Output {
+        // SAFETY: Position always gives a valid in-room coordinate.
+        unsafe { self.bits.get_unchecked(pos_as_idx(idx.x() as u8, idx.y() as u8)) }
+    }
+}
+
+impl IndexMut<Position> for LocalCostMatrix {
+    fn index_mut(&mut self, idx: Position) -> &mut Self::Output {
+        // SAFETY: Position always gives a valid in-room coordinate.
+        unsafe { self.bits.get_unchecked_mut(pos_as_idx(idx.x() as u8, idx.y() as u8)) }
+    }
+}
 
 // impl<'a> CostMatrixSet for LocalCostMatrix {
 //     fn set_multi<D, B, P, V>(&mut self, data: D) where D: IntoIterator<Item = B>, B: Borrow<(P, V)>, P: HasLocalPosition, V: Borrow<u8> {


### PR DESCRIPTION
Some improvements to LocalCostMatrix that should increase performance, make it more usable, and cover a missing bounds check.

Making `bits` a [u8; 2500] does mean that a LocalCostMatrix has a size of 2.5kB instead of whatever small size the Vec has, so users may want to use a Box<LocalCostMatrix> wherever a LocalCostMatrix was used before.