### PR TITLE
RoomCoordinate and RoomXY wrapper types

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -6,6 +6,7 @@ mod js_object_id;
 mod object_id;
 mod room_name;
 mod room_position;
+mod room_coordinate;
 
 /// Represents two constants related to room names.
 ///
@@ -20,4 +21,4 @@ const HALF_WORLD_SIZE: i32 = 128;
 /// Valid room name coordinates.
 const VALID_ROOM_NAME_COORDINATES: Range<i32> = -HALF_WORLD_SIZE..HALF_WORLD_SIZE;
 
-pub use self::{cost_matrix::*, js_object_id::*, object_id::*, room_name::*, room_position::*};
+pub use self::{cost_matrix::*, js_object_id::*, object_id::*, room_name::*, room_position::*, room_coordinate::*};

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -7,7 +7,7 @@ use serde::{Serialize, Deserialize};
 
 use crate::objects::CostMatrix;
 
-use super::{Position, xy_to_linear_index, linear_index_to_xy, RoomCoordinate, RoomXY, ROOM_AREA};
+use super::{Position, xy_to_linear_index, linear_index_to_xy, RoomXY, ROOM_AREA};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -30,36 +30,20 @@ impl LocalCostMatrix {
         }
     }
 
+    // # Notes
+    // This method does no bounds checking for the passed-in `RoomXY`, you may use
+    // `RoomXY::unchecked_new` to skip all bounds checking.
     #[inline]
     pub fn set(&mut self, xy: RoomXY, val: u8) {
         self[xy] = val;
     }
 
+    // # Notes
+    // This method does no bounds checking for the passed-in `RoomXY`, you may use
+    // `RoomXY::unchecked_new` to skip all bounds checking.
     #[inline]
     pub fn get(&self, xy: RoomXY) -> u8 {
         self[xy]
-    }
-
-    // # Safety
-    // Calling this method with x >= super::ROOM_SIZE or y >= super::ROOM_SIZE is undefined behaviour.
-    #[inline]
-    pub unsafe fn get_unchecked(&self, x: u8, y: u8) -> u8 {
-        let xy = RoomXY {
-            x: RoomCoordinate::unchecked_new(x),
-            y: RoomCoordinate::unchecked_new(y)
-        };
-        self[xy]
-    }
-
-    // # Safety
-    // Calling this method with x >= super::ROOM_SIZE or y >= super::ROOM_SIZE is undefined behaviour.
-    #[inline]
-    pub unsafe fn set_unchecked(&mut self, x: u8, y: u8, val: u8) {
-        let xy = RoomXY {
-            x: RoomCoordinate::unchecked_new(x),
-            y: RoomCoordinate::unchecked_new(y)
-        };
-        self[xy] = val;
     }
 
     pub fn get_bits(&self) -> &[u8; ROOM_AREA] {
@@ -248,7 +232,7 @@ impl From<&CostMatrix> for SparseCostMatrix {
 impl From<&LocalCostMatrix> for SparseCostMatrix {
     fn from(lcm: &LocalCostMatrix) -> Self {
         SparseCostMatrix {
-            inner: lcm.iter().filter_map(|(xy, val)| { 
+            inner: lcm.iter().filter_map(|(xy, val)| {
                 if val > 0 {
                     Some((xy, val))
                 } else {

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -10,6 +10,7 @@ use crate::objects::CostMatrix;
 use super::{Position, xy_to_linear_index, linear_index_to_xy, RoomCoordinate, RoomXY, ROOM_AREA};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct LocalCostMatrix {
     #[serde(with = "serde_impls")]
     bits: [u8; ROOM_AREA],

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -9,7 +9,7 @@ use crate::objects::CostMatrix;
 
 use super::{Position, xy_to_linear_index, linear_index_to_xy, RoomCoordinate, RoomXY, ROOM_AREA};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LocalCostMatrix {
     #[serde(with = "serde_impls")]
     bits: [u8; ROOM_AREA],
@@ -146,7 +146,7 @@ impl IndexMut<Position> for LocalCostMatrix {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SparseCostMatrix {
     inner: HashMap<RoomXY, u8>
 }

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -41,7 +41,7 @@ impl LocalCostMatrix {
     }
 
     // # Safety
-    // Calling this method with x >= 50 or y >= 50 is undefined behaviour.
+    // Calling this method with x >= super::ROOM_SIZE or y >= super::ROOM_SIZE is undefined behaviour.
     #[inline]
     pub unsafe fn get_unchecked(&self, x: u8, y: u8) -> u8 {
         let xy = RoomXY {
@@ -52,7 +52,7 @@ impl LocalCostMatrix {
     }
 
     // # Safety
-    // Calling this method with x >= 50 or y >= 50 is undefined behaviour.
+    // Calling this method with x >= super::ROOM_SIZE or y >= super::ROOM_SIZE is undefined behaviour.
     #[inline]
     pub unsafe fn set_unchecked(&mut self, x: u8, y: u8, val: u8) {
         let xy = RoomXY {

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -106,8 +106,14 @@ impl From<LocalCostMatrix> for Vec<u8> {
     }
 }
 
-impl From<CostMatrix> for LocalCostMatrix {
-    fn from(js_matrix: CostMatrix) -> Self {
+impl From<&LocalCostMatrix> for Vec<u8> {
+    fn from(lcm: &LocalCostMatrix) -> Vec<u8> {
+        lcm.bits.clone().into()
+    }
+}
+
+impl From<&CostMatrix> for LocalCostMatrix {
+    fn from(js_matrix: &CostMatrix) -> Self {
         let array = js_matrix.get_bits();
 
         LocalCostMatrix {
@@ -202,6 +208,12 @@ impl SparseCostMatrix {
     }
 }
 
+impl From<HashMap<RoomXY, u8>> for SparseCostMatrix {
+    fn from(inner: HashMap<RoomXY, u8>) -> Self {
+        SparseCostMatrix { inner }
+    }
+}
+
 impl From<&HashMap<RoomXY, u8>> for SparseCostMatrix {
     fn from(map: &HashMap<RoomXY, u8>) -> Self {
         SparseCostMatrix { inner: map.clone() }
@@ -214,8 +226,8 @@ impl From<&HashMap<Position, u8>> for SparseCostMatrix {
     }
 }
 
-impl From<CostMatrix> for SparseCostMatrix {
-    fn from(js_matrix: CostMatrix) -> Self {
+impl From<&CostMatrix> for SparseCostMatrix {
+    fn from(js_matrix: &CostMatrix) -> Self {
         let vals: Vec<u8> = js_matrix.get_bits().to_vec();
         assert!(vals.len() == ROOM_AREA, "JS CostMatrix had length {} instead of {}.", vals.len(), ROOM_AREA);
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -130,7 +130,7 @@ impl<'de> Deserialize<'de> for RoomCoordinate {
         let val = u8::deserialize(deserializer)?;
         RoomCoordinate::try_from(val).map_err(|_| {
             de::Error::invalid_value(de::Unexpected::Unsigned(val as u64),
-                                     &"a non-negative integer less-than 50")
+                                     &format!("a non-negative integer less-than {}", ROOM_SIZE).as_str())
         })
     }
 }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -2,6 +2,7 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
 pub const ROOM_SIZE: u8 = 50;
+pub const ROOM_AREA: usize = (ROOM_SIZE as usize) * (ROOM_SIZE as usize);
 
 #[derive(Debug, Clone, Copy)]
 pub struct OutOfBoundsError(u8);
@@ -41,14 +42,10 @@ impl fmt::Display for RoomXY {
 }
 
 impl RoomCoordinate {
+    // # Safety
+    // Calling this method with `coord >= 50` can result in undefined behaviour when used.
     #[inline]
-    pub fn new(coord: u8) -> Self {
-        assert!(coord < ROOM_SIZE, "Out of bounds coordinate: {}", coord);
-        RoomCoordinate(coord)
-    }
-
-    #[inline]
-    pub(crate) fn unchecked_new(coord: u8) -> Self {
+    pub unsafe fn unchecked_new(coord: u8) -> Self {
         debug_assert!(coord < ROOM_SIZE, "Out of bounds unchecked coordinate: {}", coord);
         RoomCoordinate(coord)
     }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -31,6 +31,7 @@ pub fn linear_index_to_xy(idx: usize) -> RoomXY {
 }
 
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(try_from = "u8", into = "u8")]
 pub struct RoomCoordinate(u8);
 
 #[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
@@ -105,28 +106,6 @@ impl From<(RoomCoordinate, RoomCoordinate)> for RoomXY {
 impl From<RoomXY> for (RoomCoordinate, RoomCoordinate) {
     fn from(xy: RoomXY) -> (RoomCoordinate, RoomCoordinate) {
         (xy.x, xy.y)
-    }
-}
-
-impl Serialize for RoomCoordinate {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u8(self.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for RoomCoordinate {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let val = u8::deserialize(deserializer)?;
-        RoomCoordinate::try_from(val).map_err(|_| {
-            de::Error::invalid_value(de::Unexpected::Unsigned(val as u64),
-                                     &format!("a non-negative integer less-than {}", ROOM_SIZE).as_str())
-        })
     }
 }
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -30,7 +30,7 @@ pub fn linear_index_to_xy(idx: usize) -> RoomXY {
     }
 }
 
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(try_from = "u8", into = "u8")]
 pub struct RoomCoordinate(u8);
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -1,0 +1,113 @@
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
+
+pub const ROOM_SIZE: u8 = 50;
+
+#[derive(Debug, Clone, Copy)]
+pub struct OutOfBoundsError(u8);
+
+impl fmt::Display for OutOfBoundsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Out of bounds coordinate: {}", self.0)
+    }
+}
+
+#[inline]
+pub fn xy_to_linear_index(xy: RoomXY) -> usize {
+    ((xy.x.0 as usize) * (ROOM_SIZE as usize)) + (xy.y.0 as usize)
+}
+
+#[inline]
+pub fn linear_index_to_xy(idx: usize) -> RoomXY {
+    RoomXY {
+        x: RoomCoordinate::new((idx / (ROOM_SIZE as usize)) as u8),
+        y: RoomCoordinate::new((idx % (ROOM_SIZE as usize)) as u8)
+    }
+}
+
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RoomCoordinate(u8);
+
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+pub struct RoomXY {
+    pub x: RoomCoordinate,
+    pub y: RoomCoordinate
+}
+
+impl fmt::Display for RoomXY {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({}, {})", self.x, self.y)
+    }
+}
+
+impl RoomCoordinate {
+    #[inline]
+    pub fn new(coord: u8) -> Self {
+        assert!(coord < ROOM_SIZE, "Out of bounds coordinate: {}", coord);
+        RoomCoordinate(coord)
+    }
+
+    #[inline]
+    pub(crate) fn unchecked_new(coord: u8) -> Self {
+        debug_assert!(coord < ROOM_SIZE, "Out of bounds unchecked coordinate: {}", coord);
+        RoomCoordinate(coord)
+    }
+
+    #[inline]
+    pub fn val(self) -> u8 {
+        self.0
+    }
+}
+
+impl fmt::Display for RoomCoordinate {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<RoomCoordinate> for u8 {
+    fn from(coord: RoomCoordinate) -> u8 {
+        coord.0
+    }
+}
+
+impl TryFrom<u8> for RoomCoordinate {
+    type Error = OutOfBoundsError;
+
+    fn try_from(coord: u8) -> Result<Self, Self::Error> {
+        if coord < ROOM_SIZE {
+            Ok(RoomCoordinate(coord))
+        } else {
+            Err(OutOfBoundsError(coord))
+        }
+    }
+}
+
+impl From<RoomXY> for (u8, u8) {
+    fn from(xy: RoomXY) -> (u8, u8) {
+        (xy.x.0, xy.y.0)
+    }
+}
+
+impl TryFrom<(u8, u8)> for RoomXY {
+    type Error = OutOfBoundsError;
+
+    fn try_from(xy: (u8, u8)) -> Result<RoomXY, OutOfBoundsError> {
+        Ok(RoomXY {
+            x: xy.0.try_into()?,
+            y: xy.1.try_into()?
+        })
+    }
+}
+
+impl From<(RoomCoordinate, RoomCoordinate)> for RoomXY {
+    fn from(xy: (RoomCoordinate, RoomCoordinate)) -> RoomXY {
+        RoomXY { x: xy.0, y: xy.1 }
+    }
+}
+
+impl From<RoomXY> for (RoomCoordinate, RoomCoordinate) {
+    fn from(xy: RoomXY) -> (RoomCoordinate, RoomCoordinate) {
+        (xy.x, xy.y)
+    }
+}

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -130,7 +130,7 @@ impl<'de> Deserialize<'de> for RoomCoordinate {
         let val = u8::deserialize(deserializer)?;
         RoomCoordinate::try_from(val).map_err(|_| {
             de::Error::invalid_value(de::Unexpected::Unsigned(val as u64),
-                                     &" non-negative integer less-than 50")
+                                     &"a non-negative integer less-than 50")
         })
     }
 }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -20,9 +20,11 @@ pub fn xy_to_linear_index(xy: RoomXY) -> usize {
 
 #[inline]
 pub fn linear_index_to_xy(idx: usize) -> RoomXY {
+    assert!(idx < ROOM_AREA, "Out of bounds index: {}", idx);
+    // SAFETY: bounds checking above ensures both are within range.
     RoomXY {
-        x: RoomCoordinate::new((idx / (ROOM_SIZE as usize)) as u8),
-        y: RoomCoordinate::new((idx % (ROOM_SIZE as usize)) as u8)
+        x: unsafe { RoomCoordinate::unchecked_new((idx / (ROOM_SIZE as usize)) as u8) },
+        y: unsafe { RoomCoordinate::unchecked_new((idx % (ROOM_SIZE as usize)) as u8) }
     }
 }
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -34,21 +34,10 @@ pub fn linear_index_to_xy(idx: usize) -> RoomXY {
 #[serde(try_from = "u8", into = "u8")]
 pub struct RoomCoordinate(u8);
 
-#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
-pub struct RoomXY {
-    pub x: RoomCoordinate,
-    pub y: RoomCoordinate
-}
-
-impl fmt::Display for RoomXY {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({}, {})", self.x, self.y)
-    }
-}
-
 impl RoomCoordinate {
     // # Safety
-    // Calling this method with `coord >= 50` can result in undefined behaviour when used.
+    // Calling this method with `coord >= ROOM_SIZE` can result in undefined behaviour when the
+    // resulting `RoomCoordinate` is used.
     #[inline]
     pub unsafe fn unchecked_new(coord: u8) -> Self {
         debug_assert!(coord < ROOM_SIZE, "Out of bounds unchecked coordinate: {}", coord);
@@ -59,6 +48,31 @@ impl RoomCoordinate {
 impl fmt::Display for RoomCoordinate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Hash, Clone, Copy, PartialEq, Eq)]
+pub struct RoomXY {
+    pub x: RoomCoordinate,
+    pub y: RoomCoordinate
+}
+
+impl RoomXY {
+    // # Safety
+    // Calling this method with `x >= ROOM_SIZE` or `y >= ROOM_SIZE` can result in undefined
+    // behaviour when the resulting `RoomXY` is used.
+    #[inline]
+    pub unsafe fn unchecked_new(x: u8, y: u8) -> Self {
+        RoomXY {
+            x: RoomCoordinate::unchecked_new(x),
+            y: RoomCoordinate::unchecked_new(y)
+        }
+    }
+}
+
+impl fmt::Display for RoomXY {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({}, {})", self.x, self.y)
     }
 }
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::fmt;
 
 pub const ROOM_SIZE: u8 = 50;
@@ -93,8 +93,8 @@ impl TryFrom<(u8, u8)> for RoomXY {
 
     fn try_from(xy: (u8, u8)) -> Result<RoomXY, OutOfBoundsError> {
         Ok(RoomXY {
-            x: xy.0.try_into()?,
-            y: xy.1.try_into()?
+            x: RoomCoordinate::try_from(xy.0)?,
+            y: RoomCoordinate::try_from(xy.1)?
         })
     }
 }

--- a/src/local/room_position.rs
+++ b/src/local/room_position.rs
@@ -226,7 +226,7 @@ impl Position {
     /// outside of the range `E127N127 - W127S127`.
     #[inline]
     pub fn new(x: RoomCoordinate, y: RoomCoordinate, room_name: RoomName) -> Self {
-        Self::from_coords_adjusted_and_room_packed(x.val(), y.val(), room_name.packed_repr())
+        Self::from_coords_adjusted_and_room_packed(x.into(), y.into(), room_name.packed_repr())
     }
 
     /// Creates a `Position` from x,y coordinates and room coordinates
@@ -300,12 +300,12 @@ impl Position {
 
     #[inline]
     pub fn set_x(&mut self, x: RoomCoordinate) {
-        self.packed = (self.packed & !(0xFF << 8)) | ((x.val() as u32) << 8);
+        self.packed = (self.packed & !(0xFF << 8)) | ((u8::from(x) as u32) << 8);
     }
 
     #[inline]
     pub fn set_y(&mut self, y: RoomCoordinate) {
-        self.packed = (self.packed & !0xFF) | (y.val() as u32);
+        self.packed = (self.packed & !0xFF) | (u8::from(y) as u32);
     }
 
     #[inline]

--- a/src/local/room_position.rs
+++ b/src/local/room_position.rs
@@ -8,7 +8,7 @@ use std::{
     fmt,
 };
 
-use super::{RoomName, HALF_WORLD_SIZE};
+use super::{RoomName, RoomCoordinate, ROOM_SIZE, HALF_WORLD_SIZE};
 
 use crate::{HasPosition, objects::RoomPosition};
 
@@ -225,11 +225,8 @@ impl Position {
     /// Will panic if either `x` or `y` is larger than 49, or if `room_name` is
     /// outside of the range `E127N127 - W127S127`.
     #[inline]
-    pub fn new(x: u8, y: u8, room_name: RoomName) -> Self {
-        assert!(x < 50, "out of bounds x: {}", x);
-        assert!(y < 50, "out of bounds y: {}", y);
-
-        Self::from_coords_adjusted_and_room_packed(x, y, room_name.packed_repr())
+    pub fn new(x: RoomCoordinate, y: RoomCoordinate, room_name: RoomName) -> Self {
+        Self::from_coords_adjusted_and_room_packed(x.val(), y.val(), room_name.packed_repr())
     }
 
     /// Creates a `Position` from x,y coordinates and room coordinates
@@ -263,8 +260,8 @@ impl Position {
     pub fn from_packed(packed: i32) -> Self {
         let x = packed >> 8 & 0xFF;
         let y = packed & 0xFF;
-        assert!(x < 50, "out of bounds x: {}", x);
-        assert!(y < 50, "out of bounds y: {}", y);
+        assert!(x < ROOM_SIZE as i32, "out of bounds x: {}", x);
+        assert!(y < ROOM_SIZE as i32, "out of bounds y: {}", y);
         Position {
             packed: packed as u32,
         }
@@ -284,14 +281,16 @@ impl Position {
 
     /// Gets this position's in-room x coordinate.
     #[inline]
-    pub fn x(self) -> u8 {
-        (self.packed >> 8 & 0xFF) as u8
+    pub fn x(self) -> RoomCoordinate {
+        // SAFETY: packed always contains a valid x coordinate
+        unsafe { RoomCoordinate::unchecked_new((self.packed >> 8 & 0xFF) as u8) }
     }
 
     /// Gets this position's in-room y coordinate.
     #[inline]
-    pub fn y(self) -> u8 {
-        (self.packed & 0xFF) as u8
+    pub fn y(self) -> RoomCoordinate {
+        // SAFETY: packed always contains a valid y coordinate
+        unsafe { RoomCoordinate::unchecked_new((self.packed & 0xFF) as u8) }
     }
 
     #[inline]
@@ -300,15 +299,13 @@ impl Position {
     }
 
     #[inline]
-    pub fn set_x(&mut self, x: u8) {
-        assert!(x < 50, "out of bounds x: {}", x);
-        self.packed = (self.packed & !(0xFF << 8)) | ((x as u32) << 8);
+    pub fn set_x(&mut self, x: RoomCoordinate) {
+        self.packed = (self.packed & !(0xFF << 8)) | ((x.val() as u32) << 8);
     }
 
     #[inline]
-    pub fn set_y(&mut self, y: u8) {
-        assert!(y < 50, "out of bounds y: {}", y);
-        self.packed = (self.packed & !0xFF) | (y as u32);
+    pub fn set_y(&mut self, y: RoomCoordinate) {
+        self.packed = (self.packed & !0xFF) | (y.val() as u32);
     }
 
     #[inline]
@@ -318,13 +315,13 @@ impl Position {
     }
 
     #[inline]
-    pub fn with_x(mut self, x: u8) -> Self {
+    pub fn with_x(mut self, x: RoomCoordinate) -> Self {
         self.set_x(x);
         self
     }
 
     #[inline]
-    pub fn with_y(mut self, y: u8) -> Self {
+    pub fn with_y(mut self, y: RoomCoordinate) -> Self {
         self.set_y(y);
         self
     }
@@ -372,14 +369,14 @@ impl From<&RoomPosition> for Position {
 mod serde {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    use super::{Position, RoomName};
+    use super::{Position, RoomName, RoomCoordinate};
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct ReadableFormat {
         room_name: RoomName,
-        x: u8,
-        y: u8,
+        x: RoomCoordinate,
+        y: RoomCoordinate,
     }
 
     impl From<ReadableFormat> for Position {
@@ -427,17 +424,17 @@ mod serde {
 
 #[cfg(test)]
 mod test {
-    use super::Position;
+    use super::{Position, RoomCoordinate};
 
-    const TEST_POSITIONS: &[(i32, (u8, u8, &str))] = &[
-        (-2122440404i32, (33, 44, "E1N1")),
-        (-1803615720i32, (2, 24, "E20N0")),
-        (2139029504i32, (0, 0, "W0N0")),
-        (-2139160576i32, (0, 0, "E0N0")),
-        (2139095040i32, (0, 0, "W0S0")),
-        (-2139095040i32, (0, 0, "E0S0")),
-        (1285i32, (5, 5, "sim")),
-    ];
+    const TEST_POSITIONS: &[(i32, (RoomCoordinate, RoomCoordinate, &str))] = unsafe { &[
+        (-2122440404i32, (RoomCoordinate::unchecked_new(33), RoomCoordinate::unchecked_new(44), "E1N1")),
+        (-1803615720i32, (RoomCoordinate::unchecked_new(2), RoomCoordinate::unchecked_new(24), "E20N0")),
+        (2139029504i32, (RoomCoordinate::unchecked_new(0), RoomCoordinate::unchecked_new(0), "W0N0")),
+        (-2139160576i32, (RoomCoordinate::unchecked_new(0), RoomCoordinate::unchecked_new(0), "E0N0")),
+        (2139095040i32, (RoomCoordinate::unchecked_new(0), RoomCoordinate::unchecked_new(0), "W0S0")),
+        (-2139095040i32, (RoomCoordinate::unchecked_new(0), RoomCoordinate::unchecked_new(0), "E0S0")),
+        (1285i32, (RoomCoordinate::unchecked_new(5), RoomCoordinate::unchecked_new(5), "sim")),
+    ] };
 
     #[test]
     fn from_i32_accurate() {

--- a/src/local/room_position/approximate_offsets.rs
+++ b/src/local/room_position/approximate_offsets.rs
@@ -46,6 +46,8 @@ impl Position {
 
 #[cfg(test)]
 mod test {
+    use std::convert::TryInto;
+
     use super::Position;
     use crate::RoomName;
 
@@ -56,7 +58,7 @@ mod test {
     }
 
     fn pos(room: RoomName, x: u8, y: u8) -> Position {
-        Position::new(x, y, room)
+        Position::new(x.try_into().unwrap(), y.try_into().unwrap(), room)
     }
 
     #[test]

--- a/src/local/room_position/game_math.rs
+++ b/src/local/room_position/game_math.rs
@@ -78,8 +78,8 @@ impl Position {
     #[inline]
     pub fn is_near_to(self, target: Position) -> bool {
         self.room_name() == target.room_name()
-            && (self.x() as i32 - target.x() as i32).abs() <= 1
-            && (self.y() as i32 - target.y() as i32).abs() <= 1
+            && (self.x().val() as i32 - target.x().val() as i32).abs() <= 1
+            && (self.y().val() as i32 - target.y().val() as i32).abs() <= 1
     }
 }
 

--- a/src/local/room_position/game_math.rs
+++ b/src/local/room_position/game_math.rs
@@ -78,8 +78,8 @@ impl Position {
     #[inline]
     pub fn is_near_to(self, target: Position) -> bool {
         self.room_name() == target.room_name()
-            && (self.x().val() as i32 - target.x().val() as i32).abs() <= 1
-            && (self.y().val() as i32 - target.y().val() as i32).abs() <= 1
+            && (u8::from(self.x()) as i32 - u8::from(target.x()) as i32).abs() <= 1
+            && (u8::from(self.y()) as i32 - u8::from(target.y()) as i32).abs() <= 1
     }
 }
 

--- a/src/local/room_position/pair_utils.rs
+++ b/src/local/room_position/pair_utils.rs
@@ -2,91 +2,32 @@
 use super::Position;
 use crate::local::RoomXY;
 
+macro_rules! int_pair_from_position {
+    ($($num_type:ty),+) => {$(
+            impl From<Position> for ($num_type, $num_type) {
+                #[inline]
+                fn from(pos: Position) -> Self {
+                    (u8::from(pos.x()) as $num_type, u8::from(pos.y()) as $num_type)
+                }
+            }
+    )+}
+}
+
+int_pair_from_position!(u8, u16, u32, u64, i8, i16, i32, i64);
+
 impl Position {
     /// Returns this position's in-room coordinates as a pair of unsigned
     /// integers.
     #[inline]
     pub fn coords(&self) -> (u8, u8) {
-        (self.x().val(), self.y().val())
+        (self.x().into(), self.y().into())
     }
 
     /// Returns this position's in-room coordinates as a pair of signed
     /// integers.
     #[inline]
     pub fn coords_signed(&self) -> (i8, i8) {
-        (self.x().val() as i8, self.y().val() as i8)
-    }
-}
-
-// Note: we would usually implement `From<Position> for (u8, u8)`, but this
-// implementation is not allowed as it'd be implementing it on a nested type,
-// and both the outer type (`(T, T)`), and the inner ones (`u8`) are from an
-// external crate.
-// TODO: We can do stuff like impl From<LocalCostMatrix> for Vec<u8>, so maybe
-// we can do the same here for more idiomatic code?
-
-impl Into<(u8, u8)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `u8` values.
-    #[inline]
-    fn into(self) -> (u8, u8) {
-        (self.x().val(), self.y().val())
-    }
-}
-
-impl Into<(u16, u16)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `u16` values.
-    #[inline]
-    fn into(self) -> (u16, u16) {
-        (self.x().val() as u16, self.y().val() as u16)
-    }
-}
-
-impl Into<(u32, u32)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `u32` values.
-    #[inline]
-    fn into(self) -> (u32, u32) {
-        (self.x().val() as u32, self.y().val() as u32)
-    }
-}
-
-impl Into<(u64, u64)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `u64` values.
-    #[inline]
-    fn into(self) -> (u64, u64) {
-        (self.x().val() as u64, self.y().val() as u64)
-    }
-}
-
-// khoover: Is this even safe? When Arena releases, 200 > 127.
-impl Into<(i8, i8)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `i8` values.
-    #[inline]
-    fn into(self) -> (i8, i8) {
-        (self.x().val() as i8, self.y().val() as i8)
-    }
-}
-
-impl Into<(i16, i16)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `i16` values.
-    #[inline]
-    fn into(self) -> (i16, i16) {
-        (self.x().val() as i16, self.y().val() as i16)
-    }
-}
-
-impl Into<(i32, i32)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `i32` values.
-    #[inline]
-    fn into(self) -> (i32, i32) {
-        (self.x().val() as i32, self.y().val() as i32)
-    }
-}
-
-impl Into<(i64, i64)> for Position {
-    /// Turns this positions's in-room coordinates into a pair of `i64` values.
-    #[inline]
-    fn into(self) -> (i64, i64) {
-        (self.x().val() as i64, self.y().val() as i64)
+        (u8::from(self.x()) as i8, u8::from(self.y()) as i8)
     }
 }
 

--- a/src/local/room_position/pair_utils.rs
+++ b/src/local/room_position/pair_utils.rs
@@ -1,19 +1,20 @@
 //! Utilities for working with Position and coordinate pairs
 use super::Position;
+use crate::local::RoomXY;
 
 impl Position {
     /// Returns this position's in-room coordinates as a pair of unsigned
     /// integers.
     #[inline]
     pub fn coords(&self) -> (u8, u8) {
-        (self.x(), self.y())
+        (self.x().val(), self.y().val())
     }
 
     /// Returns this position's in-room coordinates as a pair of signed
     /// integers.
     #[inline]
     pub fn coords_signed(&self) -> (i8, i8) {
-        (self.x() as i8, self.y() as i8)
+        (self.x().val() as i8, self.y().val() as i8)
     }
 }
 
@@ -28,7 +29,7 @@ impl Into<(u8, u8)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `u8` values.
     #[inline]
     fn into(self) -> (u8, u8) {
-        (self.x(), self.y())
+        (self.x().val(), self.y().val())
     }
 }
 
@@ -36,7 +37,7 @@ impl Into<(u16, u16)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `u16` values.
     #[inline]
     fn into(self) -> (u16, u16) {
-        (self.x() as u16, self.y() as u16)
+        (self.x().val() as u16, self.y().val() as u16)
     }
 }
 
@@ -44,7 +45,7 @@ impl Into<(u32, u32)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `u32` values.
     #[inline]
     fn into(self) -> (u32, u32) {
-        (self.x() as u32, self.y() as u32)
+        (self.x().val() as u32, self.y().val() as u32)
     }
 }
 
@@ -52,15 +53,16 @@ impl Into<(u64, u64)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `u64` values.
     #[inline]
     fn into(self) -> (u64, u64) {
-        (self.x() as u64, self.y() as u64)
+        (self.x().val() as u64, self.y().val() as u64)
     }
 }
 
+// khoover: Is this even safe? When Arena releases, 200 > 127.
 impl Into<(i8, i8)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `i8` values.
     #[inline]
     fn into(self) -> (i8, i8) {
-        (self.x() as i8, self.y() as i8)
+        (self.x().val() as i8, self.y().val() as i8)
     }
 }
 
@@ -68,7 +70,7 @@ impl Into<(i16, i16)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `i16` values.
     #[inline]
     fn into(self) -> (i16, i16) {
-        (self.x() as i16, self.y() as i16)
+        (self.x().val() as i16, self.y().val() as i16)
     }
 }
 
@@ -76,7 +78,7 @@ impl Into<(i32, i32)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `i32` values.
     #[inline]
     fn into(self) -> (i32, i32) {
-        (self.x() as i32, self.y() as i32)
+        (self.x().val() as i32, self.y().val() as i32)
     }
 }
 
@@ -84,6 +86,13 @@ impl Into<(i64, i64)> for Position {
     /// Turns this positions's in-room coordinates into a pair of `i64` values.
     #[inline]
     fn into(self) -> (i64, i64) {
-        (self.x() as i64, self.y() as i64)
+        (self.x().val() as i64, self.y().val() as i64)
+    }
+}
+
+impl From<Position> for RoomXY {
+    #[inline]
+    fn from(pos: Position) -> RoomXY {
+        RoomXY { x: pos.x(), y: pos.y() }
     }
 }

--- a/src/local/room_position/world_utils.rs
+++ b/src/local/room_position/world_utils.rs
@@ -7,7 +7,7 @@ impl Position {
     /// `room_x = -xx - 1` for `Wxx` rooms and as `room_x = xx` for `Exx` rooms.
     #[inline]
     pub fn world_x(self) -> i32 {
-        self.room_x() * 50 + (self.x() as i32)
+        self.room_x() * 50 + (self.x().val() as i32)
     }
 
     /// Returns this position's vertical "world coordinate".
@@ -16,7 +16,7 @@ impl Position {
     /// `room_y = -yy - 1` for `Nyy` rooms and as `room_y = yy` for `Syy` rooms.
     #[inline]
     pub fn world_y(self) -> i32 {
-        self.room_y() * 50 + (self.y() as i32)
+        self.room_y() * 50 + (self.y().val() as i32)
     }
 
     /// Returns this position's "world coordinates".
@@ -79,7 +79,10 @@ mod test {
         "E1N1", "E20N0", "W0N0", "E0N0", "W0S0", "E0S0", "W0N0", "E0N0", "W0S0", "E0S0", "W50S20",
         "W127S127", "W127N127", "E127S127", "E127N127",
     ];
-    const TEST_COORDS: &[u8] = &[0, 21, 44, 49];
+    const TEST_COORDS: &[RoomCoordinate] = unsafe {
+        &[RoomCoordinate::unchecked_new(0), RoomCoordinate::unchecked_new(21),
+          RoomCoordinate::unchecked_new(44), RoomCoordinate::unchecked_new(49)]
+    };
 
     #[test]
     fn world_coords_round_trip() {

--- a/src/local/room_position/world_utils.rs
+++ b/src/local/room_position/world_utils.rs
@@ -7,7 +7,7 @@ impl Position {
     /// `room_x = -xx - 1` for `Wxx` rooms and as `room_x = xx` for `Exx` rooms.
     #[inline]
     pub fn world_x(self) -> i32 {
-        self.room_x() * 50 + (self.x().val() as i32)
+        self.room_x() * 50 + (u8::from(self.x()) as i32)
     }
 
     /// Returns this position's vertical "world coordinate".
@@ -16,7 +16,7 @@ impl Position {
     /// `room_y = -yy - 1` for `Nyy` rooms and as `room_y = yy` for `Syy` rooms.
     #[inline]
     pub fn world_y(self) -> i32 {
-        self.room_y() * 50 + (self.y().val() as i32)
+        self.room_y() * 50 + (u8::from(self.y()) as i32)
     }
 
     /// Returns this position's "world coordinates".


### PR DESCRIPTION
This is meant to be Position for room-agnostic coordinates (e.g. cost-matrix cells). Puts all of the bounds checking into a single place.