### PR TITLE
Lots of changes to bring bindgen API closer to parity with stdweb implementation.

### DIFF
--- a/src/constants/numbers.rs
+++ b/src/constants/numbers.rs
@@ -284,7 +284,7 @@ pub fn controller_levels(current_rcl: u32) -> Option<u32> {
 /// [`StructureController::ticks_to_downgrade`]:
 /// crate::objects::StructureController::ticks_to_downgrade
 #[inline]
-pub fn controller_downgrade(rcl: u32) -> Option<u32> {
+pub fn controller_downgrade(rcl: u8) -> Option<u32> {
     match rcl {
         1 => Some(20_000),
         2 => Some(10_000),

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -4,9 +4,8 @@ use enum_iterator::IntoEnumIterator;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::{convert::TryFrom, fmt};
+use std::{convert::{Infallible, TryFrom}, fmt, str::FromStr};
 use wasm_bindgen::prelude::*;
-// use parse_display::FromStr;
 use serde::{Deserialize, Serialize};
 use crate::constants::find::Find;
 
@@ -294,6 +293,24 @@ impl Part {
     //         )
     //     })
     // }
+}
+
+impl FromStr for Part {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "move" => Ok(Part::Move),
+            "work" => Ok(Part::Work),
+            "carry" => Ok(Part::Carry),
+            "attack" => Ok(Part::Attack),
+            "ranged_attack" => Ok(Part::RangedAttack),
+            "tough" => Ok(Part::Tough),
+            "heal" => Ok(Part::Heal),
+            "claim" => Ok(Part::Claim),
+            _ => panic!("unknown part type")
+        }
+    }
 }
 
 /// Translates the `DENSITY_*` constants.

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -1,0 +1,155 @@
+//! The main interface to objects in the Screeps game world.
+//!
+//! This contains all functionality from the [`Game`] object in Screeps. That
+//! generally means all state which is true this tick throughout the world.
+//!
+//! [Screeps documentation](http://docs.screeps.com/api/#Game)
+
+use std::marker::PhantomData;
+
+use js_sys::{Array, JsString, Object};
+
+use wasm_bindgen::{
+    JsCast,
+    prelude::*
+};
+
+pub trait JsContainerIntoValue {
+    fn into_value(self) -> JsValue;
+}
+
+pub trait JsContainerFromValue {
+    fn from_value(val: JsValue) -> Self;
+}
+
+pub struct JsHashMap<K, V> {
+    map: Object,
+    _phantom: PhantomData<(K, V)>
+}
+
+impl<K, V> JsHashMap<K, V> where K: JsContainerFromValue {
+    pub fn keys(&self) -> impl Iterator<Item = K> {
+        let array = Object::keys(self.map.unchecked_ref());
+
+        OwnedArrayIter::new(array)
+    }  
+}
+
+impl<K, V> JsHashMap<K, V> where V: JsContainerFromValue {
+    pub fn values(&self) -> impl Iterator<Item = V> {
+        let array = Object::values(self.map.unchecked_ref());
+
+        OwnedArrayIter::new(array)
+    }  
+}
+
+impl<K, V> JsHashMap<K, V> where K: JsContainerIntoValue, V: JsContainerFromValue {
+    pub fn get(&self, key: K) -> Option<V> {
+        let key = key.into_value();
+        let val = js_sys::Reflect::get(&self.map, &key).ok()?;
+        let val = V::from_value(val);
+
+        Some(val)
+    }    
+}
+
+impl<K, V> JsHashMap<K, V> where K: JsContainerIntoValue, V: JsContainerIntoValue {
+    pub fn set(&self, key: K, value: V) {
+        let key = key.into_value();
+        let value = value.into_value();
+        js_sys::Reflect::set(&self.map, &key, &value).expect("expected to set js value");
+    }
+}
+
+impl<K, V> From<Object> for JsHashMap<K, V> {
+    fn from(map: Object) -> Self {
+        Self {
+            map,
+            _phantom: Default::default()
+        }
+    }
+}
+
+impl<K, V> From<JsValue> for JsHashMap<K, V> {
+    fn from(val: JsValue) -> Self {
+        Self {
+            map: val.into(),
+            _phantom: Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OwnedArrayIter<T> {
+    range: std::ops::Range<u32>,
+    array: Array,
+    _phantom: PhantomData<T>
+}
+
+impl<T> OwnedArrayIter<T> {
+    pub fn new(array: Array) -> Self {
+        OwnedArrayIter {
+            range: 0..array.length(),
+            array: array,
+            _phantom: Default::default()
+        }
+    }
+}
+
+impl<T> std::iter::Iterator for OwnedArrayIter<T> where T: JsContainerFromValue {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let index = self.range.next()?;
+        let val = self.array.get(index);
+        Some(T::from_value(val))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.range.size_hint()
+    }
+}
+
+impl<T> std::iter::DoubleEndedIterator for OwnedArrayIter<T> where T: JsContainerFromValue {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let index = self.range.next_back()?;
+        let val = self.array.get(index);
+        let val = T::from_value(val);
+        Some(val)
+    }
+}
+
+impl<T> std::iter::FusedIterator for OwnedArrayIter<T> where T: JsContainerFromValue {}
+
+impl<T> std::iter::ExactSizeIterator for OwnedArrayIter<T> where T: JsContainerFromValue {}
+
+//
+// Utility conversions for containers.
+//
+
+impl JsContainerIntoValue for String {
+    fn into_value(self) -> JsValue {
+        self.into()
+    }
+}
+
+impl JsContainerFromValue for String {
+    fn from_value(val: JsValue) -> String {
+        let val: JsString = val.unchecked_into();
+        
+        val.into()
+    }
+}
+
+impl JsContainerIntoValue for u8 {
+    fn into_value(self) -> JsValue {
+        JsValue::from_f64(self as f64)
+    }
+}
+
+impl JsContainerFromValue for u8 {
+    fn from_value(val: JsValue) -> u8 {
+        val.as_f64().expect("expected number value") as u8
+    }
+}

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -335,6 +335,7 @@ pub enum MovableObject {
 /// Enum used for converting a [`Structure`] into a typed object of its specific
 /// structure type.
 #[enum_dispatch(StructureProperties, HasPosition)]
+#[derive(Clone)]
 pub enum StructureObject {
     StructureContainer,
     StructureController,
@@ -399,6 +400,58 @@ impl From<Structure> for StructureObject {
 }
 
 impl StructureObject {
+    pub fn as_structure(&self) -> &Structure {
+        match self {
+            Self::StructureSpawn(s) => s.as_ref(),
+            Self::StructureExtension(s) => s.as_ref(),
+            Self::StructureRoad(s) => s.as_ref(),
+            Self::StructureWall(s) => s.as_ref(),
+            Self::StructureRampart(s) => s.as_ref(),
+            Self::StructureKeeperLair(s) => s.as_ref(),
+            Self::StructurePortal(s) => s.as_ref(),
+            Self::StructureController(s) => s.as_ref(),
+            Self::StructureLink(s) => s.as_ref(),
+            Self::StructureStorage(s) => s.as_ref(),
+            Self::StructureTower(s) => s.as_ref(),
+            Self::StructureObserver(s) => s.as_ref(),
+            Self::StructurePowerBank(s) => s.as_ref(),
+            Self::StructurePowerSpawn(s) => s.as_ref(),
+            Self::StructureExtractor(s) => s.as_ref(),
+            Self::StructureLab(s) => s.as_ref(),
+            Self::StructureTerminal(s) => s.as_ref(),
+            Self::StructureContainer(s) => s.as_ref(),
+            Self::StructureNuker(s) => s.as_ref(),
+            Self::StructureFactory(s) => s.as_ref(),
+            Self::StructureInvaderCore(s) => s.as_ref(),
+        }
+    }
+
+    pub fn as_owned(&self) -> Option<&dyn OwnedStructureProperties> {
+        match self {
+            Self::StructureSpawn(s) => Some(s),
+            Self::StructureExtension(s) => Some(s),
+            Self::StructureRoad(_) => None,
+            Self::StructureWall(_) => None,
+            Self::StructureRampart(s) => Some(s),
+            Self::StructureKeeperLair(s) => Some(s),
+            Self::StructurePortal(_) => None,
+            Self::StructureController(s) => Some(s),
+            Self::StructureLink(s) => Some(s),
+            Self::StructureStorage(s) => Some(s),
+            Self::StructureTower(s) => Some(s),
+            Self::StructureObserver(s) => Some(s),
+            Self::StructurePowerBank(_) => None,
+            Self::StructurePowerSpawn(s) => Some(s),
+            Self::StructureExtractor(s) => Some(s),
+            Self::StructureLab(s) => Some(s),
+            Self::StructureTerminal(s) => Some(s),
+            Self::StructureContainer(_) => None,
+            Self::StructureNuker(s) => Some(s),
+            Self::StructureFactory(s) => Some(s),
+            Self::StructureInvaderCore(s) => Some(s),
+        }
+    }
+
     pub fn as_has_store(&self) -> Option<&dyn HasStore> {
         match self {
             Self::StructureSpawn(s) => Some(s),
@@ -424,9 +477,7 @@ impl StructureObject {
             Self::StructureInvaderCore(_) => None,
         }
     }
-}
 
-impl StructureObject {
     pub fn as_transferable(&self) -> Option<&dyn Transferable> {
         match self {
             Self::StructureSpawn(s) => Some(s),
@@ -452,9 +503,7 @@ impl StructureObject {
             Self::StructureInvaderCore(_) => None,
         }
     }
-}
 
-impl StructureObject {
     pub fn as_withdrawable(&self) -> Option<&dyn Withdrawable> {
         match self {
             Self::StructureSpawn(s) => Some(s),
@@ -480,9 +529,7 @@ impl StructureObject {
             Self::StructureInvaderCore(_) => None,
         }
     }
-}
 
-impl StructureObject {
     pub fn as_attackable(&self) -> Option<&dyn Attackable> {
         match self {
             Self::StructureSpawn(s) => Some(s),
@@ -506,6 +553,32 @@ impl StructureObject {
             Self::StructureNuker(s) => Some(s),
             Self::StructureFactory(s) => Some(s),
             Self::StructureInvaderCore(s) => Some(s),
+        }
+    }
+
+    pub fn as_dismantleable(&self) -> Option<&dyn Dismantleable> {
+        match self {
+            Self::StructureSpawn(s) => Some(s),
+            Self::StructureExtension(s) => Some(s),
+            Self::StructureRoad(s) => Some(s),
+            Self::StructureWall(s) => Some(s),
+            Self::StructureRampart(s) => Some(s),
+            Self::StructureKeeperLair(_) => None,
+            Self::StructurePortal(_) => None,
+            Self::StructureController(_) => None,
+            Self::StructureLink(s) => Some(s),
+            Self::StructureStorage(s) => Some(s),
+            Self::StructureTower(s) => Some(s),
+            Self::StructureObserver(s) => Some(s),
+            Self::StructurePowerBank(s) => Some(s),
+            Self::StructurePowerSpawn(s) => Some(s),
+            Self::StructureExtractor(s) => Some(s),
+            Self::StructureLab(s) => Some(s),
+            Self::StructureTerminal(s) => Some(s),
+            Self::StructureContainer(s) => Some(s),
+            Self::StructureNuker(s) => Some(s),
+            Self::StructureFactory(s) => Some(s),
+            Self::StructureInvaderCore(_) => None,
         }
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -9,7 +9,7 @@ use js_sys::{JsString, Object};
 
 use wasm_bindgen::prelude::*;
 
-use crate::{Creep, RoomName, containers::JsHashMap, local::{JsObjectId, ObjectId, RawObjectId}};
+use crate::{ConstructionSite, Creep, Flag, PowerCreep, RoomName, StructureObject, StructureSpawn, containers::JsHashMap, local::{JsObjectId, ObjectId, RawObjectId}};
 
 pub mod cpu;
 pub mod gcl;
@@ -23,14 +23,16 @@ use crate::objects::RoomObject;
 
 #[wasm_bindgen]
 extern "C" {
+    pub type Game;
+
     /// Get an [`Object`] with all of your construction sites, which contains
     /// object ids in [`JsString`] form as keys and [`ConstructionSite`] values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.constructionSites)
     ///
     /// [`ConstructionSite`]: crate::objects::ConstructionSite
-    #[wasm_bindgen(js_namespace = Game, getter = constructionSites)]
-    pub fn construction_sites() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = constructionSites)]
+    fn construction_sites() -> Object;
 
     /// Get an [`Object`] with all of your creeps, which contains creep names in
     /// [`JsString`] form as keys and [`Creep`] objects as values. Note that
@@ -40,8 +42,8 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.creeps)
     ///
     /// [`Creep`]: crate::objects::Creep
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    fn creeps_internal() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = creeps)]
+    fn creeps() -> Object;
 
     /// Get an [`Object`] with all of your flags, which contains flag names in
     /// [`JsString`] form as keys and [`Flag`] objects as values.
@@ -49,8 +51,8 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.flags)
     ///
     /// [`Flag`]: crate::objects::Flag
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    pub fn flags() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = flags)]
+    fn flags() -> Object;
 
     /// Get an [`Object`] with all of your power creeps, which contains creep
     /// names in [`JsString`] form as keys and [`PowerCreep`] objects as values.
@@ -60,15 +62,15 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.powerCreeps)
     ///
     /// [`PowerCreep`]: crate::objects::PowerCreep
-    #[wasm_bindgen(js_namespace = Game, getter = powerCreeps)]
-    pub fn power_creeps() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = powerCreeps)]
+    fn power_creeps() -> Object;
 
     /// Get an [`Object`] with all of your account resources, with
     /// [`IntershardResourceType`] keys and integer values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.resources)
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    pub fn resources() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = resources)]
+    fn resources() -> Object;
 
     /// Get an [`Object`] with the rooms visible for the current tick, which
     /// contains room names in [`JsString`] form as keys and [`Room`] objects as
@@ -77,8 +79,8 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.rooms)
     ///
     /// [`Room`]: crate::objects::Room
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    fn rooms_internal() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = rooms)]
+    fn rooms() -> Object;
 
     /// Get an [`Object`] with all of your spawns, which contains spawn names in
     /// [`JsString`] form as keys and [`StructureSpawn`] objects as values.
@@ -86,8 +88,8 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.spawns)
     ///
     /// [`StructureSpawn`]: crate::objects::StructureSpawn
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    pub fn spawns() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = spawns)]
+    fn spawns() -> Object;
 
     /// Get an [`Object`] with all of your owned structures, which contains
     /// object IDs in [`JsString`] form as keys and [`Structure`] objects as
@@ -96,23 +98,22 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.spawns)
     ///
     /// [`Structure`]: crate::objects::Structure
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    pub fn structures() -> Object;
+    #[wasm_bindgen(static_method_of = Game, getter = structures)]
+    fn structures() -> Object;
 
-    //TODO: wiarchbe: This doesn't work.
     /// Get the current time, the number of ticks the game has been running.
     ///
     /// [Screeps documentation](http://docs.screeps.com/api/#Game.time)
-    #[wasm_bindgen(structural, js_namespace = Game, getter)]
-    pub fn time() -> u32;
+    #[wasm_bindgen(static_method_of = Game, getter = time)]
+    fn time() -> u32;
 
     /// Your current score, as determined by the symbols you have decoded.
     ///
     /// [Screeps documentation](https://docs-season.screeps.com/api/#Game.score)
     #[cfg(feature = "enable-symbols")]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    pub fn score() -> u32;
+    #[wasm_bindgen(static_method_of = Game, getter = score)]
+    fn score() -> u32;
 
     /// The symbols you've decoded after multiplier adjustments, used to
     /// determine your score.
@@ -120,22 +121,26 @@ extern "C" {
     /// [Screeps documentation](https://docs-season.screeps.com/api/#Game.symbols)
     #[cfg(feature = "enable-symbols")]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
-    #[wasm_bindgen(js_namespace = Game, getter)]
-    pub fn symbols() -> HashMap<ResourceType, u32>;
+    #[wasm_bindgen(static_method_of = Game, getter = symbols)]
+    fn symbols() -> HashMap<ResourceType, u32>;
 
     /// Get the [`RoomObject`] represented by a given object ID, if it is still
     /// alive and visible.
     ///
     /// [Screeps documentation](http://docs.screeps.com/api/#Game.getObjectById)
-    #[wasm_bindgen(js_namespace = Game, js_name = getObjectById)]
-    pub fn get_object_by_id(id: &JsString) -> Option<RoomObject>;
+    #[wasm_bindgen(static_method_of = Game, js_name = getObjectById)]
+    fn get_object_by_id(id: &JsString) -> Option<RoomObject>;
 
     /// Send an email message to yourself with a given message. Set a group
     /// interval to only send messages every `group_interval` minutes.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.notify)
-    #[wasm_bindgen(js_namespace = Game)]
-    pub fn notify(message: &JsString, group_interval: Option<u32>);
+    #[wasm_bindgen(static_method_of = Game, js_name = notify)]
+    fn notify(message: &JsString, group_interval: Option<u32>);
+}
+
+pub fn time() -> u32 {
+    Game::time()
 }
 
 /// Get the typed object represented by a given [`JsObjectId`], if it's
@@ -146,7 +151,7 @@ pub fn get_object_by_js_id_typed<T>(id: &JsObjectId<T>) -> Option<T>
 where
     T: From<JsValue>,
 {
-    get_object_by_id(&id.raw)
+    Game::get_object_by_id(&id.raw)
         .map(JsValue::from)
         .map(Into::into)
 }
@@ -162,7 +167,7 @@ where
     // construct a reference to a javascript string using the id data
     let js_str = JsString::from(id.to_string());
 
-    get_object_by_id(&js_str)
+    Game::get_object_by_id(&js_str)
         .map(JsValue::from)
         .map(Into::into)
 }
@@ -175,8 +180,34 @@ pub fn get_object_by_id_erased(id: &RawObjectId) -> Option<RoomObject> {
     // construct a reference to a javascript string using the id data
     let js_str = JsString::from(id.to_string());
 
-    get_object_by_id(&js_str)
+    Game::get_object_by_id(&js_str)
 }
+
+pub fn construction_sites() -> JsHashMap<RawObjectId, ConstructionSite> {
+    Game::construction_sites().into()
+}
+
+/// Get an [`JsHashMap<String, Creep>`] with all of your creeps, which contains 
+//  creep names in [`String`] form as keys and [`Creep`] objects as values. Note that
+/// newly spawned creeps are immediately added to the hash, but will not
+/// have an id until the following tick.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#Game.creeps)
+///
+/// [`Creep`]: crate::objects::Creep
+pub fn creeps() -> JsHashMap<String, Creep> {
+    Game::creeps().into()
+}
+
+pub fn flags() -> JsHashMap<String, Flag> {
+    Game::flags().into()
+}
+
+pub fn power_creeps() -> JsHashMap<String, PowerCreep> {
+    Game::power_creeps().into()
+}
+
+//TODO: wiarchbe: Add resource map - needs intershard/market resource types.
 
 /// Get an [`JsHashMap<RoomName, Room>`] with the rooms visible for the current tick, which
 /// contains room names in [`RoomName`] form as keys and [`Room`] objects as
@@ -186,19 +217,21 @@ pub fn get_object_by_id_erased(id: &RawObjectId) -> Option<RoomObject> {
 ///
 /// [`Room`]: crate::objects::Room
 pub fn rooms() -> JsHashMap<RoomName, Room> {
-    rooms_internal().into()
+    Game::rooms().into()
 }
 
-/// Get an [`JsHashMap<String, Creep>`] with all of your creeps, which contains 
-//  creep names in [`JsString`] form as keys and [`Creep`] objects as values. Note that
-/// newly spawned creeps are immediately added to the hash, but will not
-/// have an id until the following tick.
-///
-/// [Screeps documentation](https://docs.screeps.com/api/#Game.creeps)
-///
-/// [`Creep`]: crate::objects::Creep
-pub fn creeps() -> JsHashMap<String, Creep> {
-    creeps_internal().into()
+pub fn spawns() -> JsHashMap<String, StructureSpawn> {
+    Game::spawns().into()
+}
+
+pub fn structures() -> JsHashMap<RawObjectId, StructureObject> {
+    Game::structures().into()
+}
+
+pub fn notify(message: &str, group_interval: Option<u32>) {
+    let message: JsString = message.into();
+
+    Game::notify(&message, group_interval)
 }
 
 // pub fn get_object_typed<T>(id: ObjectId<T>) -> Result<Option<T>,

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -1,85 +1,76 @@
 //! Information about, and functions to manage, your code's resource utilization
 //!
 //! [Screeps documentation](http://docs.screeps.com/api/#Game.cpu)
-use js_sys::Object;
+use js_sys::{JsString, Object};
 use wasm_bindgen::prelude::*;
 
-use crate::constants::ReturnCode;
+use crate::{constants::ReturnCode, containers::JsHashMap};
 
 #[wasm_bindgen]
 extern "C" {
-    /// Object with info about your CPU allocations and limits from
-    /// [`Game::cpu`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu)
-    ///
-    /// [`Game::cpu`]: crate::game::Game::cpu
-    #[wasm_bindgen]
-    pub type CpuInfo;
-
     /// Your assigned CPU for the current shard.
-    #[wasm_bindgen(method, getter)]
-    pub fn limit(this: &CpuInfo) -> u32;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = limit)]
+    pub fn limit() -> u32;
 
     /// The amount of CPU available for execution this tick, which consists of
     /// your [`CpuInfo::limit`] and [`CpuInfo::bucket`] up to a maximum of 500
     /// ([`CPU_TICK_LIMIT_MAX`]), or [`f64::INFINITY`] on sim.
     ///
     /// [`CPU_TICK_LIMIT_MAX`]: crate::constants::extra::CPU_TICK_LIMIT_MAX
-    #[wasm_bindgen(method, getter = tickLimit)]
-    pub fn tick_limit(this: &CpuInfo) -> f64;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = tickLimit)]
+    pub fn tick_limit() -> f64;
 
     /// The amount of CPU that has accumulated in your bucket.
-    #[wasm_bindgen(method, getter)]
-    pub fn bucket(this: &CpuInfo) -> i32;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = bucket)]
+    pub fn bucket() -> i32;
 
     /// Your assigned CPU limits for each shard in an [`Object`], with shard
     /// names in [`JsString`] form as keys and numbers as values. This is the
     /// same format accepted by [`CpuInfo::set_shard_limits`].
-    #[wasm_bindgen(method, getter = shardLimits)]
-    pub fn shard_limits(this: &CpuInfo) -> Object;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = shardLimits)]
+    pub fn shard_limits_internal() -> Object;
 
     /// Whether your account is unlocked to have full CPU.
-    #[wasm_bindgen(method, getter)]
-    pub fn unlocked(this: &CpuInfo) -> bool;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = unlocked)]
+    pub fn unlocked() -> bool;
 
     /// If your account has been unlocked for a limited time, contains the time
     /// it's unlocked until in milliseconds since epoch.
-    #[wasm_bindgen(method, getter = unlockedTime)]
-    pub fn unlocked_time(this: &CpuInfo) -> Option<u64>;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = unlockedTime)]
+    pub fn unlocked_time() -> Option<u64>;
 
     /// Get information about your script's memory heap usage.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.getHeapStatistics)
-    #[wasm_bindgen(method, js_name = getHeapStatistics)]
-    pub fn get_heap_statistics(this: &CpuInfo) -> HeapStatistics;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = getHeapStatistics)]
+    pub fn get_heap_statistics() -> HeapStatistics;
 
     /// Get the amount of CPU time used for execution so far this tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.getUsed)
-    #[wasm_bindgen(method, js_name = getUsed)]
-    pub fn get_used(this: &CpuInfo) -> f64;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = getUsed)]
+    pub fn get_used() -> f64;
 
     /// Stop execution of your script, starting with a fresh environment next
     /// tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.halt)
-    #[wasm_bindgen(method)]
-    pub fn halt(this: &CpuInfo);
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = halt)]
+    pub fn halt();
 
     /// Sets new shard limits for your script in an [`Object`], with shard names
     /// in [`JsString`] form as keys and numbers as values. This is the same
     /// format accepted by [`CpuInfo::shard_limits`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.setShardLimits)
-    #[wasm_bindgen(method, js_name = setShardLimits)]
-    pub fn set_shard_limits(this: &CpuInfo, limits: &Object) -> ReturnCode;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = setShardLimits)]
+    pub fn set_shard_limits(limits: &Object) -> ReturnCode;
 
     /// Consume a [`CpuUnlock`] to unlock your full CPU for 24 hours.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.unlock)
-    #[wasm_bindgen(method)]
-    pub fn unlock(this: &CpuInfo) -> ReturnCode;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = unlock)]
+    pub fn unlock() -> ReturnCode;
 
     /// Generate a [`Pixel`], consuming [`PIXEL_COST`] CPU from your bucket.
     ///
@@ -89,8 +80,12 @@ extern "C" {
     /// [`PIXEL_COST`]: crate::constants::PIXEL_COST
     #[cfg(feature = "enable-generate-pixel")]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-generate-pixel")))]
-    #[wasm_bindgen(method, js_name = generatePixel)]
-    pub fn generate_pixel(this: &CpuInfo) -> ReturnCode;
+    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = generatePixel)]
+    pub fn generate_pixel() -> ReturnCode;
+}
+
+pub fn shard_limits() -> JsHashMap<JsString, u32> {
+    shard_limits_internal().into()
 }
 
 #[wasm_bindgen]

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -8,8 +8,11 @@ use crate::{constants::ReturnCode, containers::JsHashMap};
 
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(js_name = "cpu")]
+    pub type Cpu;
+
     /// Your assigned CPU for the current shard.
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = limit)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = limit)]
     pub fn limit() -> u32;
 
     /// The amount of CPU available for execution this tick, which consists of
@@ -17,45 +20,45 @@ extern "C" {
     /// ([`CPU_TICK_LIMIT_MAX`]), or [`f64::INFINITY`] on sim.
     ///
     /// [`CPU_TICK_LIMIT_MAX`]: crate::constants::extra::CPU_TICK_LIMIT_MAX
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = tickLimit)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = tickLimit)]
     pub fn tick_limit() -> f64;
 
     /// The amount of CPU that has accumulated in your bucket.
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = bucket)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = bucket)]
     pub fn bucket() -> i32;
 
     /// Your assigned CPU limits for each shard in an [`Object`], with shard
     /// names in [`JsString`] form as keys and numbers as values. This is the
     /// same format accepted by [`CpuInfo::set_shard_limits`].
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = shardLimits)]
-    pub fn shard_limits_internal() -> Object;
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = shardLimits)]
+    pub fn shard_limits() -> Object;
 
     /// Whether your account is unlocked to have full CPU.
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = unlocked)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = unlocked)]
     pub fn unlocked() -> bool;
 
     /// If your account has been unlocked for a limited time, contains the time
     /// it's unlocked until in milliseconds since epoch.
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], getter = unlockedTime)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = unlockedTime)]
     pub fn unlocked_time() -> Option<u64>;
 
     /// Get information about your script's memory heap usage.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.getHeapStatistics)
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = getHeapStatistics)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = getHeapStatistics)]
     pub fn get_heap_statistics() -> HeapStatistics;
 
     /// Get the amount of CPU time used for execution so far this tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.getUsed)
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = getUsed)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = getUsed)]
     pub fn get_used() -> f64;
 
     /// Stop execution of your script, starting with a fresh environment next
     /// tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.halt)
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = halt)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = halt)]
     pub fn halt();
 
     /// Sets new shard limits for your script in an [`Object`], with shard names
@@ -63,13 +66,13 @@ extern "C" {
     /// format accepted by [`CpuInfo::shard_limits`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.setShardLimits)
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = setShardLimits)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = setShardLimits)]
     pub fn set_shard_limits(limits: &Object) -> ReturnCode;
 
     /// Consume a [`CpuUnlock`] to unlock your full CPU for 24 hours.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.unlock)
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = unlock)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = unlock)]
     pub fn unlock() -> ReturnCode;
 
     /// Generate a [`Pixel`], consuming [`PIXEL_COST`] CPU from your bucket.
@@ -80,12 +83,58 @@ extern "C" {
     /// [`PIXEL_COST`]: crate::constants::PIXEL_COST
     #[cfg(feature = "enable-generate-pixel")]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-generate-pixel")))]
-    #[wasm_bindgen(js_namespace = ["Game", "cpu"], js_name = generatePixel)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = generatePixel)]
     pub fn generate_pixel() -> ReturnCode;
 }
 
+pub fn limit() -> u32 {
+    Cpu::limit()
+}
+
+pub fn tick_limit() -> f64 {
+    Cpu::tick_limit()
+}
+
+pub fn bucket() -> i32 {
+    Cpu::bucket()
+}
+
 pub fn shard_limits() -> JsHashMap<JsString, u32> {
-    shard_limits_internal().into()
+    Cpu::shard_limits().into()
+}
+
+pub fn unlocked() -> bool {
+    Cpu::unlocked()
+}
+
+pub fn unlocked_time() -> Option<u64> {
+    Cpu::unlocked_time()
+}
+
+pub fn get_heap_statistics() -> HeapStatistics {
+    Cpu::get_heap_statistics()
+}
+
+pub fn get_used() -> f64 {
+    Cpu::get_used()
+}
+
+pub fn halt() {
+    Cpu::halt()
+}
+
+pub fn set_shard_limits(limits: &Object) -> ReturnCode {
+    Cpu::set_shard_limits(limits)
+}
+
+pub fn unlock() -> ReturnCode {
+    Cpu::unlock()
+}
+
+#[cfg(feature = "enable-generate-pixel")]
+#[cfg_attr(docsrs, doc(cfg(feature = "enable-generate-pixel")))]
+pub fn generate_pixel() -> ReturnCode {
+    Cpu::generate_pixel()
 }
 
 #[wasm_bindgen]

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -7,26 +7,18 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    /// Object with info about your Global Control Level from [`Game::gcl`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Game.gcl)
-    ///
-    /// [`Game::gcl`]: crate::game::Game::gcl
-    #[wasm_bindgen]
-    pub type GclInfo;
-
     /// Your current Global Control Level, which determines the number of rooms
     /// you are allowed to claim.
-    #[wasm_bindgen(method, getter)]
-    pub fn level(this: &GclInfo) -> u32;
+    #[wasm_bindgen(js_namespace = ["Game", "gcl"], getter)]
+    pub fn level() -> u32;
 
     /// Your progress toward the next Global Control Level.
-    #[wasm_bindgen(method, getter)]
-    pub fn progress(this: &GclInfo) -> f64;
+    #[wasm_bindgen(js_namespace = ["Game", "gcl"], getter)]
+    pub fn progress() -> f64;
 
     /// Total progress needed to reach the next Global Control Level.
-    #[wasm_bindgen(method, getter = progressTotal)]
-    pub fn progress_total(this: &GclInfo) -> f64;
+    #[wasm_bindgen(js_namespace = ["Game", "gcl"], getter = progressTotal)]
+    pub fn progress_total() -> f64;
 }
 
 /// Provides the total number of control points needed to achieve each level of

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -7,18 +7,34 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(js_name = "gcl")]
+    pub type Gcl;
+
     /// Your current Global Control Level, which determines the number of rooms
     /// you are allowed to claim.
-    #[wasm_bindgen(js_namespace = ["Game", "gcl"], getter)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "gcl", static_method_of = Gcl, getter, js_name = level)]
     pub fn level() -> u32;
 
     /// Your progress toward the next Global Control Level.
-    #[wasm_bindgen(js_namespace = ["Game", "gcl"], getter)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "gcl", static_method_of = Gcl, getter, js_name = progress)]
     pub fn progress() -> f64;
 
     /// Total progress needed to reach the next Global Control Level.
-    #[wasm_bindgen(js_namespace = ["Game", "gcl"], getter = progressTotal)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "gcl", static_method_of = Gcl, getter, js_name = progressTotal)]
     pub fn progress_total() -> f64;
+}
+
+pub fn level() -> u32 {
+    Gcl::level()
+}
+
+pub fn progress() -> f64 {
+    Gcl::progress()
+}
+
+
+pub fn progress_total() -> f64 {
+    Gcl::progress_total()
 }
 
 /// Provides the total number of control points needed to achieve each level of

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -7,18 +7,32 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    /// Your current Global Power Level, which determines the number of rooms
-    /// you are allowed to claim.
-    #[wasm_bindgen(js_namespace = ["Game", "gpl"], getter)]
+    #[wasm_bindgen(js_name = "gpl")]
+    pub type Gpl;
+
+    /// Your current Global Power Level, which determines power creep development.
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "gpl", static_method_of = Gpl, getter, js_name = level)]
     pub fn level() -> u32;
 
     /// Your progress toward the next Global Power Level.
-    #[wasm_bindgen(js_namespace = ["Game", "gpl"], getter)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "gpl", static_method_of = Gpl, getter, js_name = progress)]
     pub fn progress() -> f64;
 
     /// Total progress needed to reach the next Global Power Level.
-    #[wasm_bindgen(js_namespace = ["Game", "gpl"], getter = progressTotal)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "gpl", static_method_of = Gpl, getter, js_name = progressTotal)]
     pub fn progress_total() -> f64;
+}
+
+pub fn level() -> u32 {
+    Gpl::level()
+}
+
+pub fn progress() -> f64 {
+    Gpl::progress()
+}
+
+pub fn progress_total() -> f64 {
+    Gpl::progress_total()
 }
 
 /// Provides the total number of processed power needed to achieve each level

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -7,26 +7,18 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    /// Object with info about your Global Power Level from [`Game::gpl`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Game.gpl)
-    ///
-    /// [`Game::gpl`]: crate::game::Game::gpl
-    #[wasm_bindgen]
-    pub type GplInfo;
-
     /// Your current Global Power Level, which determines the number of rooms
     /// you are allowed to claim.
-    #[wasm_bindgen(method, getter)]
-    pub fn level(this: &GplInfo) -> u32;
+    #[wasm_bindgen(js_namespace = ["Game", "gpl"], getter)]
+    pub fn level() -> u32;
 
     /// Your progress toward the next Global Power Level.
-    #[wasm_bindgen(method, getter)]
-    pub fn progress(this: &GplInfo) -> f64;
+    #[wasm_bindgen(js_namespace = ["Game", "gpl"], getter)]
+    pub fn progress() -> f64;
 
     /// Total progress needed to reach the next Global Power Level.
-    #[wasm_bindgen(method, getter = progressTotal)]
-    pub fn progress_total(this: &GplInfo) -> f64;
+    #[wasm_bindgen(js_namespace = ["Game", "gpl"], getter = progressTotal)]
+    pub fn progress_total() -> f64;
 }
 
 /// Provides the total number of processed power needed to achieve each level

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -9,7 +9,7 @@ use num_traits::*;
 
 use wasm_bindgen::{prelude::*, JsCast};
 
-use crate::{ReturnCode, RoomName, constants::ExitDirection, objects::RoomTerrain};
+use crate::{Direction, ReturnCode, RoomName, constants::ExitDirection, containers::JsHashMap, objects::RoomTerrain};
 
 #[wasm_bindgen]
 extern "C" {
@@ -18,15 +18,15 @@ extern "C" {
     /// room names as values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.describeExits)
-    #[wasm_bindgen(js_namespace = ["game", "map"], js_name = describeExits)]
-    pub fn describe_exits(room_name: &JsString) -> Object;
+    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = describeExits)]
+    fn describe_exits_internal(room_name: &JsString) -> Object;
 
     /// Get the exit direction from a given room leading toward a destination
     /// room, with an optional [`FindRouteOptions`] parameter allowing control
     /// over the costs to enter rooms.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.findExit)
-    #[wasm_bindgen(js_namespace = ["game", "map"], js_name = findExit)]
+    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = findExit)]
     fn find_exit_internal(
         from_room: &JsString,
         to_room: &JsString,
@@ -42,7 +42,7 @@ extern "C" {
     /// as a [`JsString`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.findRoute)
-    #[wasm_bindgen(js_namespace = ["game", "map"], js_name = findRoute)]
+    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = findRoute)]
     fn find_route_internal(
         from_room: &JsString,
         to_room: &JsString,
@@ -54,24 +54,24 @@ extern "C" {
     /// wrap around, which is used for terminal calculations.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getRoomLinearDistance)
-    #[wasm_bindgen(js_namespace = ["game", "map"], js_name = getRoomLinearDistance)]
-    pub fn get_room_linear_distance(
+    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getRoomLinearDistance)]
+    fn get_room_linear_distance_internal(
         room_1: &JsString,
         room_2: &JsString,
         continuous: bool,
-    ) -> Array;
+    ) -> u32;
 
     /// Get the [`RoomTerrain`] object for any room, even one you don't have
     /// vision in.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getRoomTerrain)
-    #[wasm_bindgen(js_namespace = ["game", "map"], js_name = getRoomTerrain)]
+    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getRoomTerrain)]
     fn get_room_terrain_internal(room_name: &JsString) -> RoomTerrain;
 
     /// Get the size of the world map.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getWorldSize)
-    #[wasm_bindgen(js_namespace = ["game", "map"], js_name = getWorldSize)]
+    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getWorldSize)]
     pub fn get_world_size() -> u32;
 
     // todo MapRoomStatus return val
@@ -79,7 +79,7 @@ extern "C" {
     /// area or currently inaccessible.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getRoomStatus)
-    #[wasm_bindgen(js_namespace = ["game", "map"], js_name = getRoomStatus)]
+    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getRoomStatus)]
     fn get_room_status_internal(room_name: &JsString) -> RoomStatusResult;
 
     // todo
@@ -88,6 +88,19 @@ extern "C" {
     // /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.visual)
     // #[wasm_bindgen(method, getter)]
     // pub fn visual(this: &MapInfo) -> MapVisual;
+}
+
+pub fn describe_exits(room_name: RoomName) -> JsHashMap<Direction, RoomName> {
+    let room_name = room_name.into();
+
+    describe_exits_internal(&room_name).into()
+}
+
+pub fn get_room_linear_distance(from_room: RoomName, to_room: RoomName, continuous: bool) -> u32 {
+    let from_room = from_room.into();
+    let to_room = to_room.into();
+
+    get_room_linear_distance_internal(&from_room, &to_room, continuous)
 }
 
 #[wasm_bindgen]

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -13,21 +13,24 @@ use crate::{Direction, ReturnCode, RoomName, constants::ExitDirection, container
 
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(js_name = "map")]
+    pub type Map;
+
     /// Get an object with information about the exits from a given room, with
     /// [`JsString`] versions of direction integers as keys and [`JsString`]
     /// room names as values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.describeExits)
-    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = describeExits)]
-    fn describe_exits_internal(room_name: &JsString) -> Object;
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = describeExits)]
+    fn describe_exits(room_name: &JsString) -> Object;
 
     /// Get the exit direction from a given room leading toward a destination
     /// room, with an optional [`FindRouteOptions`] parameter allowing control
     /// over the costs to enter rooms.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.findExit)
-    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = findExit)]
-    fn find_exit_internal(
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = findExit)]
+    fn find_exit(
         from_room: &JsString,
         to_room: &JsString,
         options: &JsValue,
@@ -42,8 +45,8 @@ extern "C" {
     /// as a [`JsString`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.findRoute)
-    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = findRoute)]
-    fn find_route_internal(
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = findRoute)]
+    fn find_route(
         from_room: &JsString,
         to_room: &JsString,
         options: &JsValue,
@@ -54,8 +57,8 @@ extern "C" {
     /// wrap around, which is used for terminal calculations.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getRoomLinearDistance)
-    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getRoomLinearDistance)]
-    fn get_room_linear_distance_internal(
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = getRoomLinearDistance)]
+    fn get_room_linear_distance(
         room_1: &JsString,
         room_2: &JsString,
         continuous: bool,
@@ -65,22 +68,22 @@ extern "C" {
     /// vision in.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getRoomTerrain)
-    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getRoomTerrain)]
-    fn get_room_terrain_internal(room_name: &JsString) -> RoomTerrain;
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = getRoomTerrain)]
+    fn get_room_terrain(room_name: &JsString) -> RoomTerrain;
 
     /// Get the size of the world map.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getWorldSize)
-    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getWorldSize)]
-    pub fn get_world_size() -> u32;
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = getWorldSize)]
+    fn get_world_size() -> u32;
 
     // todo MapRoomStatus return val
     /// Get the status of a given room, determining whether it's in a special
     /// area or currently inaccessible.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.map.getRoomStatus)
-    #[wasm_bindgen(js_namespace = ["Game", "map"], js_name = getRoomStatus)]
-    fn get_room_status_internal(room_name: &JsString) -> RoomStatusResult;
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = getRoomStatus, catch)]
+    fn get_room_status(room_name: &JsString) -> Result<JsRoomStatusResult, JsValue>;
 
     // todo
     // /// Get a [`MapVisual`] object, allowing rendering visual indicators on the
@@ -93,26 +96,59 @@ extern "C" {
 pub fn describe_exits(room_name: RoomName) -> JsHashMap<Direction, RoomName> {
     let room_name = room_name.into();
 
-    describe_exits_internal(&room_name).into()
+    Map::describe_exits(&room_name).into()
 }
 
 pub fn get_room_linear_distance(from_room: RoomName, to_room: RoomName, continuous: bool) -> u32 {
     let from_room = from_room.into();
     let to_room = to_room.into();
 
-    get_room_linear_distance_internal(&from_room, &to_room, continuous)
+    Map::get_room_linear_distance(&from_room, &to_room, continuous)
 }
 
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen]
-    pub type RoomStatusResult;
+    pub type JsRoomStatusResult;
 
     #[wasm_bindgen(method, getter = status)]
-    pub fn status(this: &RoomStatusResult) -> RoomStatus;
+    pub fn status(this: &JsRoomStatusResult) -> RoomStatus;
 
     #[wasm_bindgen(method, getter = timestamp)]
-    pub fn timestamp(this: &RoomStatusResult) -> Option<u64>;
+    pub fn timestamp(this: &JsRoomStatusResult) -> Option<u64>;
+}
+
+pub struct RoomStatusResult {
+    status: RoomStatus,
+    timestamp: Option<u64>
+}
+
+impl RoomStatusResult {
+    pub fn status(&self) -> RoomStatus {
+        self.status
+    }
+
+    pub fn timestamp(&self) -> Option<u64> {
+        self.timestamp
+    }
+}
+
+impl Default for RoomStatusResult {
+    fn default() -> Self {
+        RoomStatusResult {
+            status: RoomStatus::Normal,
+            timestamp: None
+        }
+    }
+}
+
+impl From<JsRoomStatusResult> for RoomStatusResult {
+    fn from(val: JsRoomStatusResult) -> Self {
+        RoomStatusResult {
+            status: val.status(),
+            timestamp: val.timestamp(),
+        }
+    }
 }
 
 #[wasm_bindgen]
@@ -127,13 +163,17 @@ pub enum RoomStatus {
 pub fn get_room_terrain(room_name: RoomName) -> RoomTerrain {
     let name = room_name.into();
 
-    get_room_terrain_internal( &name)
+    Map::get_room_terrain(&name)
+}
+
+pub fn get_world_size() -> u32 {
+    Map::get_world_size()
 }
 
 pub fn get_room_status(room_name: RoomName) -> RoomStatusResult {
     let name = room_name.into();
 
-    get_room_status_internal( &name)
+    Map::get_room_status(&name).ok().map(RoomStatusResult::from).unwrap_or_default()
 }
 
 #[wasm_bindgen]
@@ -258,10 +298,10 @@ pub fn find_route<F>(from: RoomName, to: RoomName, options: Option<FindRouteOpti
 
     let result = if let Some(options) = options {
         options.as_js_options(|js_options| {
-            find_route_internal(&from, &to, js_options)
+            Map::find_route(&from, &to, js_options)
         })
     } else {
-        find_route_internal(&from, &to, &JsValue::UNDEFINED)
+        Map::find_route(&from, &to, &JsValue::UNDEFINED)
     };
 
     if result.is_object() {
@@ -286,10 +326,10 @@ pub fn find_exit<F>(from: RoomName, to: RoomName, options: Option<FindRouteOptio
 
     let result = if let Some(options) = options {
         options.as_js_options(|js_options| {
-            find_exit_internal(&from, &to, js_options)
+            Map::find_exit(&from, &to, js_options)
         })
     } else {
-        find_exit_internal(&from, &to, &JsValue::UNDEFINED)
+        Map::find_exit(&from, &to, &JsValue::UNDEFINED)
     };
 
     if result >= 0 {

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -10,30 +10,33 @@ use crate::{constants::{MarketResourceType, OrderType, ResourceType, ReturnCode}
 
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(js_name = "market")]
+    pub type Market;
+
     /// Your current credit balance.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.credits)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], getter = credits)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, getter, js_name = credits)]
     pub fn credits() -> f64;
 
     /// An [`Array`] of the last 100 [`Transaction`]s sent to your terminals.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.incomingTransactions)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], getter = incomingTransactions)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, getter, js_name = incomingTransactions)]
     pub fn incoming_transactions() -> Array;
 
     /// An [`Array`] of the last 100 [`Transaction`]s sent from your terminals.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.outgoingTransactions)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], getter = outgoingTransactions)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, getter, js_name = outgoingTransactions)]
     pub fn outgoing_transactions() -> Array;
 
     /// An [`Object`] with your current buy and sell orders on the market, with
     /// order ID [`JsString`] keys and [`MyOrder`] values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.orders)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], getter = orders)]
-    fn orders_internal() -> Object;
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, getter, js_name = orders)]
+    fn orders() -> Object;
 
     // todo maybe just implement a native version of this instead?
     /// Get the amount of energy required to send a given amount of any resource
@@ -43,7 +46,7 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.calcTransactionCost)
     ///
     /// [`TERMINAL_SEND_COST_SCALE`]: crate::constants::TERMINAL_SEND_COST_SCALE
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = calcTransactionCost)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = calcTransactionCost)]
     pub fn calc_transaction_cost(
         amount: u32,
         room_1: &JsString,
@@ -54,14 +57,14 @@ extern "C" {
     /// associated fees.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.cancelOrder)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = cancelOrder)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = cancelOrder)]
     pub fn cancel_order(order_id: &JsString) -> ReturnCode;
 
     /// Cancel one of your existing orders on the market, without refunding
     /// associated fees.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.changeOrderPrice)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = changeOrderPrice)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = changeOrderPrice)]
     pub fn change_order_price(order_id: &JsString, new_price: f64)
         -> ReturnCode;
 
@@ -69,7 +72,7 @@ extern "C" {
     /// Create a new order on the market.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.createOrder)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = createOrder)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = createOrder)]
     pub fn create_order(order_parameters: &Object) -> ReturnCode;
 
     /// Execute a trade on an order on the market. Name of a room with a
@@ -77,7 +80,7 @@ extern "C" {
     /// order is for an account resource.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.deal)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = deal)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = deal)]
     pub fn deal(
         order_id: &JsString,
         amount: u32,
@@ -88,7 +91,7 @@ extern "C" {
     /// requesting more of the resource and incurring additional fees.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.extendOrder)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = extendOrder)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = extendOrder)]
     pub fn extend_order(order_id: &JsString, add_amount: u32) -> ReturnCode;
 
     // todo type to serialize call options into - special efficient behavior when
@@ -101,7 +104,7 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.getAllOrders)
     ///
     /// [source]: https://github.com/screeps/engine/blob/f7a09e637c20689084fcf4eb43eacdfd51d31476/src/game/market.js#L37
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = getAllOrders)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = getAllOrders)]
     pub fn get_all_orders(filter: &Object) -> Array;
 
     // todo this is probably breaking in an interesting way on private servers due to the {} return https://github.com/screeps/engine/pull/131 - maybe catch?
@@ -112,19 +115,69 @@ extern "C" {
     /// the type is recommended before use if the market might be empty.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.getHistory)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = getHistory)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = getHistory)]
     pub fn get_history(resource: Option<ResourceType>) -> JsValue;
 
     /// Get an object with information about a specific order, in the same
     /// format as returned by [`MarketInfo::get_all_orders`]
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.getOrderById)
-    #[wasm_bindgen(js_namespace = ["Game", "market"], js_name = getOrderById)]
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = getOrderById)]
     pub fn get_order_by_id(order_id: &JsString) -> Option<Order>;
 }
 
+pub fn credits() -> f64 {
+    Market::credits()
+}
+
+pub fn incoming_transactions() -> Array {
+    Market::incoming_transactions()
+}
+
+pub fn outgoing_transactions() -> Array {
+    Market::outgoing_transactions()
+}
+
 pub fn orders() -> JsHashMap<String, MyOrder> {
-    orders_internal().into()
+    Market::orders().into()
+}
+
+pub fn calc_transaction_cost(amount: u32, room_1: &JsString, room_2: &JsString) -> u32 {
+    Market::calc_transaction_cost(amount, room_1, room_2)
+}
+
+pub fn cancel_order(order_id: &JsString) -> ReturnCode {
+    Market::cancel_order(order_id)
+}
+
+pub fn change_order_price(order_id: &JsString, new_price: f64) -> ReturnCode {
+    Market::change_order_price(order_id, new_price)
+}
+
+pub fn create_order(order_parameters: &Object) -> ReturnCode {
+    Market::create_order(order_parameters)
+}
+
+pub fn deal(order_id: &JsString, amount: u32, room_name: Option<&JsString>) -> ReturnCode {
+    Market::deal(order_id, amount, room_name)
+}
+
+pub fn extend_order(order_id: &JsString, add_amount: u32) -> ReturnCode {
+    Market::extend_order(order_id, add_amount)
+}
+
+pub fn get_all_orders(filter: &Object) -> Array {
+    Market::get_all_orders(filter)
+}
+
+pub fn get_history(resource: Option<ResourceType>) -> JsValue {
+    Market::get_history(resource)
+}
+
+pub fn get_order_by_id(order_id: &str) -> Option<Order> {
+    let order_id: JsString = order_id.into();
+
+    Market::get_order_by_id(&order_id)
 }
 
 #[wasm_bindgen]

--- a/src/game/shard.rs
+++ b/src/game/shard.rs
@@ -7,24 +7,30 @@ use js_sys::JsString;
 
 #[wasm_bindgen]
 extern "C" {
-    /// Your current Global Control Level, which determines the number of rooms
-    /// you are allowed to claim.
-    #[wasm_bindgen(js_namespace = ["Game", "shard"], getter = name)]
-    fn name_internal() -> JsString;
+    #[wasm_bindgen(js_name = "shard")]
+    pub type Shard;
 
-    /// Your progress toward the next Global Control Level.
-    #[wasm_bindgen(js_namespace = ["Game", "shard"], getter = type)]
-    fn type_internal() -> JsString;
+    /// Current shard name.
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "shard", static_method_of = Shard, getter, js_name = name)]
+    fn name() -> JsString;
 
-    /// Total progress needed to reach the next Global Control Level.
-    #[wasm_bindgen(js_namespace = ["Game", "shard"], getter = ptr)]
+    /// Shard type.
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "shard", static_method_of = Shard, getter, js_name = type)]
+    fn shard_type() -> JsString;
+
+    /// Flag for if this is a public test server or not.
+    #[wasm_bindgen(js_namespace = ["Game"], js_class = "shard", static_method_of = Shard, getter, js_name = ptr)]
     pub fn ptr() -> bool;
 }
 
 pub fn name() -> String {
-    name_internal().into()
+    Shard::name().into()
 }
 
 pub fn shard_type() -> String {
-    type_internal().into()
+    Shard::shard_type().into()
+}
+
+pub fn ptr() -> bool {
+    Shard::ptr()
 }

--- a/src/game/shard.rs
+++ b/src/game/shard.rs
@@ -1,0 +1,30 @@
+//! Shard information.
+//!
+/// [Screeps documentation](https://docs.screeps.com/api/#Game.shard)
+
+use wasm_bindgen::prelude::*;
+use js_sys::JsString;
+
+#[wasm_bindgen]
+extern "C" {
+    /// Your current Global Control Level, which determines the number of rooms
+    /// you are allowed to claim.
+    #[wasm_bindgen(js_namespace = ["Game", "shard"], getter = name)]
+    fn name_internal() -> JsString;
+
+    /// Your progress toward the next Global Control Level.
+    #[wasm_bindgen(js_namespace = ["Game", "shard"], getter = type)]
+    fn type_internal() -> JsString;
+
+    /// Total progress needed to reach the next Global Control Level.
+    #[wasm_bindgen(js_namespace = ["Game", "shard"], getter = ptr)]
+    pub fn ptr() -> bool;
+}
+
+pub fn name() -> String {
+    name_internal().into()
+}
+
+pub fn shard_type() -> String {
+    type_internal().into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,12 +51,12 @@ pub use crate::inter_shard_memory::*;
 ///
 /// ```no_run
 /// use js_sys::{JsString, Reflect};
-/// use screeps::{prelude::*, Creep, Game};
+/// use screeps::{prelude::*, Creep, game};
 ///
-/// let c = Game::creeps().get(&JsString::from("Bob")).unwrap();
+/// let c = game::creeps().get(String::from("Bob")).unwrap();
 ///
 /// // `HasId` trait brought in from prelude
-/// let id = c.id();
+/// let id = c.try_id().unwrap();
 /// ```
 ///
 /// This module contains all base functionality traits, and no structures.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub mod pathfinder;
 pub mod prototypes;
 pub mod raw_memory;
 pub mod traits;
+pub mod containers;
 
 pub use crate::{
     constants::*, enums::*, game::*, local::*, objects::*, pathfinder::*, raw_memory::*, traits::*,

--- a/src/local/js_object_id.rs
+++ b/src/local/js_object_id.rs
@@ -5,9 +5,8 @@ use std::{
 };
 
 use js_sys::JsString;
-use wasm_bindgen::prelude::*;
 
-use crate::game::Game;
+use crate::{Resolvable, game::*};
 
 /// Represents a reference to an Object ID string held on the javascript heap
 /// and a type that the ID points to.
@@ -105,9 +104,9 @@ impl<T> JsObjectId<T> {
     /// don't have vision for.
     pub fn resolve(&self) -> Option<T>
     where
-        T: From<JsValue>,
+        T: Resolvable,
     {
-        Game::get_object_by_js_id_typed(self)
+        get_object_by_js_id_typed(self)
     }
 }
 

--- a/src/local/object_id.rs
+++ b/src/local/object_id.rs
@@ -7,9 +7,7 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use wasm_bindgen::prelude::*;
-
-use crate::game::Game;
+use crate::{Resolvable, game::*};
 
 // use crate::{
 //     objects::{HasId, SizedRoomObject},
@@ -277,9 +275,9 @@ impl<T> ObjectId<T> {
     /// don't have vision for.
     pub fn resolve(self) -> Option<T>
     where
-        T: From<JsValue>,
+        T: Resolvable,
     {
-        Game::get_object_by_id_typed(&self)
+        get_object_by_id_typed(&self)
     }
 
     // /// Resolves this ID into an object, panicking on type mismatch.

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -4,6 +4,8 @@ use arrayvec::ArrayString;
 use wasm_bindgen::{JsCast, JsValue};
 use js_sys::JsString;
 
+use crate::containers::{JsContainerFromValue, JsContainerIntoValue};
+
 use super::{HALF_WORLD_SIZE, VALID_ROOM_NAME_COORDINATES};
 
 /// A structure representing a room name.
@@ -205,6 +207,8 @@ impl fmt::Display for RoomNameConversionError {
     }
 }
 
+//TODO: Infallible version 'From' is needed in many places for interop.
+/*
 impl TryFrom<JsValue> for RoomName {
     type Error = RoomNameConversionError;
 
@@ -216,6 +220,7 @@ impl TryFrom<JsValue> for RoomName {
         RoomName::from_str(&val).map_err(|err| RoomNameConversionError::ParseError { err })
     }    
 }
+*/
 
 impl TryFrom<JsString> for RoomName {
     type Error = <RoomName as FromStr>::Err;
@@ -224,6 +229,27 @@ impl TryFrom<JsString> for RoomName {
         let val: String = val.into();
 
         RoomName::from_str(&val)
+    }
+}
+
+impl From<JsValue> for RoomName {
+    fn from(val: JsValue) -> Self {
+        let val: JsString = val.unchecked_into();
+        let val: String = val.into();
+
+        RoomName::from_str(&val).expect("expected parseable room name")
+    }
+}
+
+impl JsContainerIntoValue for RoomName {
+    fn into_value(self) -> JsValue {
+        self.into()
+    }
+}
+
+impl JsContainerFromValue for RoomName {
+    fn from_value(val: JsValue) -> Self {
+        val.into()
     }
 }
 

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -207,8 +207,6 @@ impl fmt::Display for RoomNameConversionError {
     }
 }
 
-//TODO: Infallible version 'From' is needed in many places for interop.
-/*
 impl TryFrom<JsValue> for RoomName {
     type Error = RoomNameConversionError;
 
@@ -220,7 +218,6 @@ impl TryFrom<JsValue> for RoomName {
         RoomName::from_str(&val).map_err(|err| RoomNameConversionError::ParseError { err })
     }    
 }
-*/
 
 impl TryFrom<JsString> for RoomName {
     type Error = <RoomName as FromStr>::Err;
@@ -232,15 +229,6 @@ impl TryFrom<JsString> for RoomName {
     }
 }
 
-impl From<JsValue> for RoomName {
-    fn from(val: JsValue) -> Self {
-        let val: JsString = val.unchecked_into();
-        let val: String = val.into();
-
-        RoomName::from_str(&val).expect("expected parseable room name")
-    }
-}
-
 impl JsContainerIntoValue for RoomName {
     fn into_value(self) -> JsValue {
         self.into()
@@ -249,7 +237,10 @@ impl JsContainerIntoValue for RoomName {
 
 impl JsContainerFromValue for RoomName {
     fn from_value(val: JsValue) -> Self {
-        val.into()
+        let val: JsString = val.unchecked_into();
+        let val: String = val.into();
+
+        RoomName::from_str(&val).expect("expected parseable room name")
     }
 }
 

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -1,8 +1,4 @@
-use crate::{
-    constants::{ReturnCode, StructureType},
-    objects::{Owner, RoomObject},
-    prelude::*,
-};
+use crate::{constants::{ReturnCode, StructureType}, objects::{Owner, RoomObject}, prelude::*};
 use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
@@ -13,14 +9,15 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type ConstructionSite;
 
     /// The Object ID of the [`ConstructionSite`], or `None` if it was created
     /// this tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &ConstructionSite) -> Option<JsString>;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &ConstructionSite) -> Option<JsString>;
 
     /// Whether you own the [`ConstructionSite`].
     ///
@@ -61,8 +58,8 @@ extern "C" {
     pub fn remove(this: &ConstructionSite) -> ReturnCode;
 }
 
-impl MaybeHasId for ConstructionSite {
-    fn id(&self) -> Option<JsString> {
-        Self::id(self)
+impl MaybeHasNativeId for ConstructionSite {
+    fn native_id(&self) -> Option<JsString> {
+        Self::id_internal(self)
     }
 }

--- a/src/objects/impls/cost_matrix.rs
+++ b/src/objects/impls/cost_matrix.rs
@@ -135,7 +135,7 @@ impl CostMatrixSet for CostMatrix {
         for entry in data.into_iter() {
             let (pos, cost) = entry.borrow();
 
-            let offset = pos_as_idx(pos.y(), pos.y());
+            let offset = pos_as_idx(pos.x(), pos.y());
 
             matrix_buffer.set_index(offset as u32, *cost.borrow());
         }

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -18,76 +18,76 @@ extern "C" {
     /// and boosts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.body)
-    #[wasm_bindgen(final, method, getter = body)]
+    #[wasm_bindgen(method, getter = body)]
     fn body_internal(this: &Creep) -> Array;
 
     /// The amount of fatigue the creep has. If greater than 0, it cannot move
     /// this tick without being pulled.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.fatigue)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn fatigue(this: &Creep) -> u32;
 
     /// Retrieve the current hits of this creep.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.hits)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn hits(this: &Creep) -> u32;
 
     /// Retrieve the maximum hits of this creep, which generally equals 50 per
     /// body part.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.hitsMax)
-    #[wasm_bindgen(final, method, getter = hitsMax)]
+    #[wasm_bindgen(method, getter = hitsMax)]
     pub fn hits_max(this: &Creep) -> u32;
 
     /// Object ID of the creep, which can be used to efficiently fetch a fresh
     /// reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.id)
-    #[wasm_bindgen(final, method, getter = id)]
-    fn id_internal(this: &Creep) -> Option<JsString>;
+    #[wasm_bindgen(method, getter = id)]
+    pub fn id_internal(this: &Creep) -> Option<JsString>;
 
     /// A shortcut to `Memory.creeps[creep.name]`.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.memory)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn memory(this: &Creep) -> JsValue;
 
     /// Sets a new value to `Memory.creeps[creep.name]`.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.memory)
-    #[wasm_bindgen(final, method, setter)]
+    #[wasm_bindgen(method, setter)]
     pub fn set_memory(this: &Creep, val: &JsValue);
 
     /// Whether this creep is owned by the player.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.my)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn my(this: &Creep) -> bool;
 
     /// The creep's name as an owned reference to a [`JsString`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.name)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter = name)]
     fn name_internal(this: &Creep) -> JsString;
 
     /// The [`Owner`] of this creep that contains the owner's username.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.owner)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn owner(this: &Creep) -> Owner;
 
     /// What the creep said last tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.saying)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn saying(this: &Creep) -> Option<JsString>;
 
     /// Whether the creep is still spawning.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.spawning)
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn spawning(this: &Creep) -> bool;
 
     /// The [`Store`] of the creep, which contains information about what
@@ -100,7 +100,7 @@ extern "C" {
     /// The number of ticks the creep has left to live
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.ticksToLive)
-    #[wasm_bindgen(final, method, getter = ticksToLive)]
+    #[wasm_bindgen(method, getter = ticksToLive)]
     pub fn ticks_to_live(this: &Creep) -> u32;
 
     /// Attack a target in melee range using a creep's attack parts.
@@ -145,7 +145,7 @@ extern "C" {
     /// of structure that can be constructed.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.dismantle)
-    #[wasm_bindgen(final, method)]
+    #[wasm_bindgen(final, method, js_name = dismantle)]
     fn dismantle_internal(this: &Creep, target: &Structure) -> ReturnCode;
 
     /// Drop a resource on the ground from the creep's [`Store`].
@@ -321,13 +321,13 @@ extern "C" {
     #[wasm_bindgen]
     pub type BodyPart;
 
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn boost(this: &BodyPart) -> ResourceType;
 
-    #[wasm_bindgen(final, method, getter = type)]   
+    #[wasm_bindgen(method, getter = type)]   
     pub fn part(this: &BodyPart) -> Part;
 
-    #[wasm_bindgen(final, method, getter)]
+    #[wasm_bindgen(method, getter)]
     pub fn hits(this: &BodyPart) -> u32;
 }
 

--- a/src/objects/impls/deposit.rs
+++ b/src/objects/impls/deposit.rs
@@ -1,8 +1,4 @@
-use crate::{
-    constants::ResourceType,
-    objects::{RoomObject},
-    prelude::*,
-};
+use crate::{constants::ResourceType, objects::{RoomObject}, prelude::*};
 use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
@@ -12,6 +8,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Deposit)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Deposit;
 
     /// Ticks until the deposit can be harvested again.
@@ -30,8 +27,8 @@ extern "C" {
     /// reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Deposit.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Deposit) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Deposit) -> JsString;
 
     /// The cooldown caused by the most recent harvest action for this deposit.
     ///
@@ -59,8 +56,8 @@ impl HasCooldown for Deposit {
     }
 }
 
-impl HasId for Deposit {
-    fn id(&self) -> JsString {
-        Self::id(self)
+impl HasNativeId for Deposit {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }

--- a/src/objects/impls/flag.rs
+++ b/src/objects/impls/flag.rs
@@ -15,6 +15,7 @@ extern "C" {
     ///
     /// [`FLAGS_LIMIT`]: crate::constants::FLAGS_LIMIT
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Flag;
 
     /// Primary color of the flag.

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Mineral)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Mineral;
 
     /// The density of the mineral on the next refill after it's depleted.
@@ -19,6 +20,12 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Mineral.density)
     #[wasm_bindgen(method, getter)]
     pub fn density(this: &Mineral) -> Density;
+
+    /// Type of resource contained in this mineral.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Mineral.mineralType)
+    #[wasm_bindgen(method, getter = mineralAmount)]
+    pub fn mineral_amount(this: &Mineral) -> u32;
 
     /// Type of resource contained in this mineral.
     ///
@@ -31,7 +38,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Mineral.id)
     #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Mineral) -> JsString;
+    fn id_internal(this: &Mineral) -> JsString;
 
     /// The number of ticks until this mineral regenerates from depletion.
     ///
@@ -40,8 +47,8 @@ extern "C" {
     pub fn ticks_to_regeneration(this: &Mineral) -> u32;
 }
 
-impl HasId for Mineral {
-    fn id(&self) -> JsString {
-        Self::id(self)
+impl HasNativeId for Mineral {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -37,8 +37,8 @@ extern "C" {
     /// reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Mineral.id)
-    #[wasm_bindgen(method, getter)]
-    fn id_internal(this: &Mineral) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id(this: &Mineral) -> JsString;
 
     /// The number of ticks until this mineral regenerates from depletion.
     ///
@@ -49,6 +49,6 @@ extern "C" {
 
 impl HasNativeId for Mineral {
     fn native_id(&self) -> JsString {
-        Self::id_internal(self)
+        Self::id(self)
     }
 }

--- a/src/objects/impls/nuke.rs
+++ b/src/objects/impls/nuke.rs
@@ -12,14 +12,15 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Nuke)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Nuke;
 
     /// Object ID of the Nuke, which can be used to efficiently fetch a fresh
     /// reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Nuke.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Nuke) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Nuke) -> JsString;
 
     /// The name of the room the nuke was fired from.
     ///
@@ -34,8 +35,8 @@ extern "C" {
     pub fn time_to_land(this: &Nuke) -> u32;
 }
 
-impl HasId for Nuke {
-    fn id(&self) -> JsString {
-        Self::id(self)
+impl HasNativeId for Nuke {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }

--- a/src/objects/impls/owned_structure.rs
+++ b/src/objects/impls/owned_structure.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#OwnedStructure)
     #[wasm_bindgen(extends = RoomObject, extends = Structure)]
+    #[derive(Clone)]
     pub type OwnedStructure;
 
     /// Whether this structure is owned by the player.
@@ -46,6 +47,12 @@ extern "C" {
     pub type Owner;
 
     /// The name of the player that owns this structure as a [`JsString`].
-    #[wasm_bindgen(method, getter)]
-    pub fn username(this: &Owner) -> JsString;
+    #[wasm_bindgen(method, getter = username)]
+    pub fn username_internal(this: &Owner) -> JsString;
+}
+
+impl Owner {
+    pub fn username(&self) -> String {
+        Self::username_internal(self).into()
+    }
 }

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -89,7 +89,7 @@ extern "C" {
     /// The power creep's name as an owned reference to a [`JsString`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.name)
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(method, getter = name)]
     fn name_internal(this: &PowerCreep) -> JsString;
 
     /// The [`Owner`] of this power creep that contains the owner's username.

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -13,7 +13,7 @@ extern "C" {
     #[wasm_bindgen(extends = RoomObject)]
     pub type PowerCreep;
 
-    //TODO: wiarchbe: Come back to this... need a good 'maybe has position' implementation that doesn't conflict with base pos().
+    //TODO: wiarchbe: Come back to this... need a good 'maybe has position' implementation that doesn't conflict with base pos() on RoomObject.
     /// Position of the object.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomObject.pos)
@@ -58,8 +58,8 @@ extern "C" {
     /// spawned on the current shard.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &PowerCreep) -> Option<JsString>;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &PowerCreep) -> Option<JsString>;
 
     /// Current level of the power creep, which can be increased with
     /// [`PowerCreep::upgrade`] if you have unspent GPL.
@@ -90,7 +90,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.name)
     #[wasm_bindgen(method, getter)]
-    pub fn name(this: &PowerCreep) -> JsString;
+    fn name_internal(this: &PowerCreep) -> JsString;
 
     /// The [`Owner`] of this power creep that contains the owner's username.
     ///
@@ -220,7 +220,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.say)
     #[wasm_bindgen(method)]
-    pub fn say(this: &PowerCreep, message: &JsString, public: bool) -> ReturnCode;
+    pub fn say(this: &PowerCreep, message: &str, public: bool) -> ReturnCode;
 
     /// Spawn the power creep at a [`StructurePowerSpawn`].
     ///
@@ -285,19 +285,9 @@ impl HasHits for PowerCreep {
     }
 }
 
-//TODO: wiarchbe: Add maybe has ID?
-
-/*
-impl HasId for PowerCreep {
-    fn id(&self) -> JsString {
-        Self::id(self)
-    }
-}
-*/
-
-impl MaybeHasId for PowerCreep {
-    fn id(&self) -> Option<JsString> {
-        Self::id(self)
+impl MaybeHasNativeId for PowerCreep {
+    fn native_id(&self) -> Option<JsString> {
+        Self::id_internal(self)
     }
 }
 
@@ -329,8 +319,8 @@ impl SharedCreepProperties for PowerCreep {
         Self::my(self)
     }
 
-    fn name(&self) -> JsString {
-        Self::name(self)
+    fn name(&self) -> String {
+        Self::name_internal(self).into()
     }
 
     fn owner(&self) -> Owner {
@@ -381,7 +371,7 @@ impl SharedCreepProperties for PowerCreep {
         Self::pickup(self, target)
     }
 
-    fn say(&self, message: &JsString, public: bool) -> ReturnCode {
+    fn say(&self, message: &str, public: bool) -> ReturnCode {
         Self::say(self, message, public)
     }
 

--- a/src/objects/impls/resource.rs
+++ b/src/objects/impls/resource.rs
@@ -13,6 +13,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Resource)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Resource;
 
     /// Amount of resource this contains.
@@ -25,8 +26,8 @@ extern "C" {
     /// fresh reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Resource.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Resource) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Resource) -> JsString;
 
     /// The type of resource this contains.
     ///
@@ -35,8 +36,8 @@ extern "C" {
     pub fn resource_type(this: &Resource) -> ResourceType;
 }
 
-impl HasId for Resource {
-    fn id(&self) -> JsString {
-        Self::id(self)
+impl HasNativeId for Resource {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -113,7 +113,7 @@ extern "C" {
     /// converted into the type of object you searched for.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.find)
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = find)]
     //TODO: wiarchbe: Find options!    
     fn find_internal(this: &Room, ty: Find, options: Option<&Object>) -> Array;
 
@@ -182,21 +182,21 @@ extern "C" {
     /// Get an array of all objects of a given type at this position, if any.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.lookForAt)
-    #[wasm_bindgen(method, js_name = lookFor)]
+    #[wasm_bindgen(method, js_name = lookForAt)]
     fn look_for_at_internal(this: &Room, ty: Look, target: &RoomPosition) -> Option<Array>;
 
     /// Get an array of all objects of a given type at the given coordinates, if
     /// any.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.lookForAt)
-    #[wasm_bindgen(method, js_name = lookFor)]
+    #[wasm_bindgen(method, js_name = lookForAt)]
     fn look_for_at_xy_internal(this: &Room, ty: Look, x: u8, y: u8) -> Option<Array>;
 
     /// Get an array of all objects in a certain area, in either object or array
     /// format depending on the `as_array` option.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.lookAtArea)
-    #[wasm_bindgen(method, js_name = lookAtArea)]
+    #[wasm_bindgen(method, js_name = lookForAtArea)]
     fn look_for_at_area_internal(
         this: &Room,
         ty: Look,

--- a/src/objects/impls/room_object.rs
+++ b/src/objects/impls/room_object.rs
@@ -7,6 +7,7 @@ extern "C" {
     /// Parent class for all objects in rooms in the game world.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room)
+    #[derive(Clone)]
     pub type RoomObject;
 
     /// Effects applied to the object.

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -1,9 +1,6 @@
-use crate::{
-    constants::{Color, Direction, Look, ReturnCode, StructureType},
-    local::Position,
-    prelude::*,
-    prototypes::ROOM_POSITION_PROTOTYPE,
-};
+use std::convert::TryInto;
+
+use crate::{RoomName, constants::{Color, Direction, Look, ReturnCode, StructureType}, local::Position, prelude::*, prototypes::ROOM_POSITION_PROTOTYPE};
 use js_sys::{Array, JsString, Object};
 use wasm_bindgen::prelude::*;
 
@@ -19,14 +16,14 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.constructor)
     #[wasm_bindgen(constructor)]
-    pub fn new(x: u8, y: u8, room_name: &JsString) -> RoomPosition;
+    fn new_internal(x: u8, y: u8, room_name: &JsString) -> RoomPosition;
 
     /// Name of the room the position is in, as an owned [`JsString`] reference
     /// to a string in Javascript memory.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.roomName)
     #[wasm_bindgen(method, getter = roomName)]
-    pub fn room_name(this: &RoomPosition) -> JsString;
+    fn room_name_internal(this: &RoomPosition) -> JsString;
 
     /// Change the room the position refers to; must be a valid room name.
     ///
@@ -229,6 +226,18 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.lookFor)
     #[wasm_bindgen(method, js_name = lookFor)]
     pub fn look_for(this: &RoomPosition, ty: Look) -> Option<Array>;
+}
+
+impl RoomPosition {
+    pub fn new(x: u8, y: u8, room_name: RoomName) -> RoomPosition {
+        let room_name = room_name.into();
+
+        Self::new_internal(x, y, &room_name)
+    }
+
+    pub fn room_name(&self) -> RoomName {
+        Self::room_name_internal(self).try_into().expect("expected parseable room name")
+    }
 }
 
 impl Clone for RoomPosition {

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -24,13 +24,15 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn get(this: &RoomTerrain, x: u8, y: u8) -> u8;
 
+    //TODO: wiarchbe: Need to handle return code?
     /// Get a copy of the underlying Uint8Array with the data about the room's
     /// terrain.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer)
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = getRawBuffer)]
     pub fn get_raw_buffer(this: &RoomTerrain) -> Uint8Array;
 
+    //TODO: wiarchbe: Need to handle return code?
     /// Copy the data about the room's terrain into an existing [`Uint8Array`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer)

--- a/src/objects/impls/ruin.rs
+++ b/src/objects/impls/ruin.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Ruin)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Ruin;
 
     /// The tick that the structure was destroyed
@@ -24,8 +25,8 @@ extern "C" {
     /// reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Ruin.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Ruin) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Ruin) -> JsString;
 
     /// The [`Store`] of the ruin, which contains any resources in the ruin.
     ///
@@ -56,9 +57,9 @@ impl CanDecay for Ruin {
     }
 }
 
-impl HasId for Ruin {
-    fn id(&self) -> JsString {
-        Self::id(self)
+impl HasNativeId for Ruin {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }
 

--- a/src/objects/impls/score_collector.rs
+++ b/src/objects/impls/score_collector.rs
@@ -16,14 +16,15 @@ extern "C" {
     /// [`ResourceType::Score`]: crate::constants::ResourceType::Score
     #[wasm_bindgen(extends = RoomObject)]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
+    #[derive(Clone)]
     pub type ScoreCollector;
 
     /// Object ID of the collector, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs-season.screeps.com/api/#ScoreCollector.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &ScoreCollector) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &ScoreCollector) -> JsString;
 
     /// The [`Store`] of the container, which contains information about what
     /// resources it is it holding.
@@ -33,9 +34,9 @@ extern "C" {
     pub fn store(this: &ScoreCollector) -> Store;
 }
 
-impl HasId for ScoreCollector {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self.as_ref()))
+impl HasNativeId for ScoreCollector {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }
 

--- a/src/objects/impls/score_container.rs
+++ b/src/objects/impls/score_container.rs
@@ -16,14 +16,15 @@ extern "C" {
     /// [`ResourceType::Score`]: crate::constants::ResourceType::Score
     #[wasm_bindgen(extends = RoomObject)]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-score")))]
+    #[derive(Clone)]
     pub type ScoreContainer;
 
     /// Object ID of the collector, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs-season.screeps.com/api/#ScoreContainer.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &ScoreContainer) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &ScoreContainer) -> JsString;
 
     /// The [`Store`] of the container, which contains information about what
     /// resources it is it holding.
@@ -46,9 +47,9 @@ impl CanDecay for ScoreContainer {
     }
 }
 
-impl HasId for ScoreContainer {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self.as_ref()))
+impl HasNativeId for Nuke {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }
 

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -11,6 +11,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Source)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Source;
 
     /// Amount of energy available to be harvested from the source.
@@ -42,8 +43,8 @@ extern "C" {
     /// reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Source.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Source) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Source) -> JsString;
 
     /// The number of ticks until this source regenerates to its
     /// [`Source::energy_capacity`], or 0 if the timer has not started yet.
@@ -53,8 +54,8 @@ extern "C" {
     pub fn ticks_to_regeneration(this: &Source) -> u32;
 }
 
-impl HasId for Source {
-    fn id(&self) -> JsString {
-        Self::id(self)
+impl HasNativeId for Source {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }

--- a/src/objects/impls/store.rs
+++ b/src/objects/impls/store.rs
@@ -27,7 +27,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Store.getFreeCapacity)
     #[wasm_bindgen(method, js_name = getFreeCapacity)]
-    pub fn get_free_capacity(this: &Store, ty: Option<ResourceType>) -> u32;
+    pub fn get_free_capacity(this: &Store, ty: Option<ResourceType>) -> i32;
 
     /// Return the used capacity of the [`Store`] for the specified resource. If
     /// the [`Store`] can contain any resource, passing `None` as the type will

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -13,6 +13,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Structure;
 
     /// Retrieve the current hits of this structure, or `0` if this structure is
@@ -35,8 +36,8 @@ extern "C" {
     /// fresh reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Structure) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Structure) -> JsString;
 
     /// The type of structure this is.
     ///
@@ -64,9 +65,9 @@ extern "C" {
     pub fn notify_when_attacked(this: &Structure, val: bool) -> ReturnCode;
 }
 
-impl<T> HasId for T where T: AsRef<Structure> {
-    fn id(&self) -> JsString {
-        Structure::id(self.as_ref())
+impl<T> HasNativeId for T where T: AsRef<Structure> {
+    fn native_id(&self) -> JsString {
+        Structure::id_internal(self.as_ref())
     }
 }
 

--- a/src/objects/impls/structure_container.rs
+++ b/src/objects/impls/structure_container.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureContainer)
     #[wasm_bindgen(extends = RoomObject, extends = Structure)]
+    #[derive(Clone)]
     pub type StructureContainer;
 
     /// The [`Store`] of the container, which contains information about what

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -11,6 +11,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureController;
 
     /// Whether power is enabled in the room, allowing power creeps to use
@@ -117,13 +118,20 @@ extern "C" {
 
     /// The name of the player that has reserved this controller as a
     /// [`JsString`].
-    #[wasm_bindgen(method, getter)]
-    pub fn username(this: &Reservation) -> JsString;
+    #[wasm_bindgen(method, getter = username)]
+    pub fn username_internal(this: &Reservation) -> JsString;
 
     /// The number of ticks until the reservation expires.
     #[wasm_bindgen(method, getter = ticksToEnd)]
     pub fn ticks_to_end(this: &Reservation) -> u32;
 }
+
+impl Reservation {
+    pub fn username(&self) -> String {
+        Self::username_internal(self).into()
+    } 
+}
+
 
 #[wasm_bindgen]
 extern "C" {
@@ -135,12 +143,12 @@ extern "C" {
 
     /// The name of the player that has reserved this controller as a
     /// [`JsString`].
-    #[wasm_bindgen(method, getter)]
-    pub fn username(this: &Sign) -> JsString;
+    #[wasm_bindgen(method, getter = username)]
+    pub fn username_internal(this: &Sign) -> JsString;
 
     /// The text of the sign on this controller as a [`JsString`].
-    #[wasm_bindgen(method, getter)]
-    pub fn text(this: &Sign) -> JsString;
+    #[wasm_bindgen(method, getter = text)]
+    pub fn text_internal(this: &Sign) -> JsString;
 
     /// The tick when this sign was written.
     #[wasm_bindgen(method, getter)]
@@ -149,4 +157,14 @@ extern "C" {
     /// The timestamp of when this sign was written.
     #[wasm_bindgen(method, getter)]
     pub fn datetime(this: &Sign) -> Date;
+}
+
+impl Sign {
+    pub fn username(&self) -> String {
+        Self::username_internal(self).into()
+    }
+
+    pub fn text(&self) -> String {
+        Self::text_internal(self).into()
+    }    
 }

--- a/src/objects/impls/structure_extension.rs
+++ b/src/objects/impls/structure_extension.rs
@@ -11,6 +11,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureExtension)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureExtension;
 
     /// The [`Store`] of the extension, which contains information about the

--- a/src/objects/impls/structure_extractor.rs
+++ b/src/objects/impls/structure_extractor.rs
@@ -13,6 +13,7 @@ extern "C" {
     ///
     /// [`Mineral`]: crate::objects::Mineral
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureExtractor;
 
     /// Ticks until this extractor can be used to [`Creep::harvest`] its

--- a/src/objects/impls/structure_factory.rs
+++ b/src/objects/impls/structure_factory.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureFactory)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureFactory;
 
     /// Ticks until [`StructureFactory::produce`] can be used again.

--- a/src/objects/impls/structure_invader_core.rs
+++ b/src/objects/impls/structure_invader_core.rs
@@ -10,6 +10,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureInvaderCore)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureInvaderCore;
 
     /// The level of the [`StructureInvaderCore`]; 0 is a lesser invader core

--- a/src/objects/impls/structure_keeper_lair.rs
+++ b/src/objects/impls/structure_keeper_lair.rs
@@ -10,6 +10,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureKeeperLair)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureKeeperLair;
 
     /// The number of ticks until the [`StructureKeeperLair`] will spawn a new

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureLab;
 
     /// The number of ticks until the [`StructureLab`] can use

--- a/src/objects/impls/structure_link.rs
+++ b/src/objects/impls/structure_link.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLink)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureLink;
 
     /// The number of ticks until the [`StructureLink`] can use
@@ -34,7 +35,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLink.transferEnergy)
     #[wasm_bindgen(method, js_name = transferEnergy)]
-    pub fn transfer_energy(this: &StructureLink, target: &StructureLink) -> ReturnCode;
+    pub fn transfer_energy(this: &StructureLink, target: &StructureLink, amount: Option<u32>) -> ReturnCode;
 }
 
 impl HasCooldown for StructureLink {

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -14,6 +14,7 @@ extern "C" {
     ///
     /// [`Nuke`]: crate::objects::Nuke
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureNuker;
 
     /// The number of ticks until the [`StructureNuker`] can use

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -1,7 +1,4 @@
-use crate::{
-    constants::ReturnCode,
-    objects::{OwnedStructure, RoomObject, Structure},
-};
+use crate::{RoomName, constants::ReturnCode, objects::{OwnedStructure, RoomObject, Structure}};
 use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
@@ -12,6 +9,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureObserver)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureObserver;
 
     /// Set the [`StructureObserver`] to provide vision of a target room next
@@ -19,5 +17,13 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureObserver.observeRoom)
     #[wasm_bindgen(method, js_name = observeRoom)]
-    pub fn observe_room(this: &StructureObserver, target: &JsString) -> ReturnCode;
+    fn observe_room_internal(this: &StructureObserver, target: &JsString) -> ReturnCode;
+}
+
+impl StructureObserver {
+    pub fn observe_room(&self, target: RoomName) -> ReturnCode {
+        let target = target.into();
+
+        Self::observe_room_internal(self, &target)
+    }
 }

--- a/src/objects/impls/structure_portal.rs
+++ b/src/objects/impls/structure_portal.rs
@@ -11,6 +11,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructurePortal)
     #[wasm_bindgen(extends = RoomObject, extends = Structure)]
+    #[derive(Clone)]
     pub type StructurePortal;
 
     // todo: destination

--- a/src/objects/impls/structure_power_bank.rs
+++ b/src/objects/impls/structure_power_bank.rs
@@ -11,6 +11,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructurePowerBank)
     #[wasm_bindgen(extends = RoomObject, extends = Structure)]
+    #[derive(Clone)]
     pub type StructurePowerBank;
 
     /// The amount of power contained within the [`StructurePowerBank`].

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructurePowerSpawn)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructurePowerSpawn;
 
     /// The [`Store`] of the power spawn, which can contain power and energy.

--- a/src/objects/impls/structure_rampart.rs
+++ b/src/objects/impls/structure_rampart.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureRampart)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureRampart;
 
     /// Whether the [`StructureRampart`] is set to be public, allowing hostile

--- a/src/objects/impls/structure_road.rs
+++ b/src/objects/impls/structure_road.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureRoad)
     #[wasm_bindgen(extends = RoomObject, extends = Structure)]
+    #[derive(Clone)]
     pub type StructureRoad;
 
     /// The number of ticks until the road will decay, losing

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -1,8 +1,4 @@
-use crate::{
-    constants::ReturnCode,
-    objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
-    prelude::*,
-};
+use crate::{Part, constants::ReturnCode, objects::{Creep, OwnedStructure, RoomObject, Store, Structure}, prelude::*};
 use js_sys::{Array, JsString, Object};
 use wasm_bindgen::prelude::*;
 
@@ -12,6 +8,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureSpawn;
 
     /// A shortcut to `Memory.spawns[spawn.name]`.
@@ -55,10 +52,10 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.spawnCreep)
     #[wasm_bindgen(method, js_name = spawnCreep)]
-    pub fn spawn_creep(
+    fn spawn_creep_internal(
         this: &StructureSpawn,
         body: &Array,
-        name: &JsString,
+        name: &str,
         options: Option<&Object>,
     ) -> ReturnCode;
 
@@ -76,6 +73,15 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.renewCreep)
     #[wasm_bindgen(method, js_name = renewCreep)]
     pub fn renew_creep(this: &StructureSpawn, creep: &Creep) -> ReturnCode;
+}
+
+impl StructureSpawn {
+    pub fn spawn_creep(&self, body: &[Part], name: &str) -> ReturnCode {
+        let body = body.iter().cloned().map(JsValue::from).collect();
+
+        //TODO: wiarchbe: Support options.        
+        Self::spawn_creep_internal(self, &body, name, None)
+    }
 }
 
 impl HasStore for StructureSpawn {

--- a/src/objects/impls/structure_storage.rs
+++ b/src/objects/impls/structure_storage.rs
@@ -11,6 +11,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureStorage)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureStorage;
 
     /// The [`Store`] of the storage, which contains information about what

--- a/src/objects/impls/structure_terminal.rs
+++ b/src/objects/impls/structure_terminal.rs
@@ -1,8 +1,4 @@
-use crate::{
-    constants::{ResourceType, ReturnCode},
-    objects::{OwnedStructure, RoomObject, Store, Structure},
-    prelude::*,
-};
+use crate::{RoomName, constants::{ResourceType, ReturnCode}, objects::{OwnedStructure, RoomObject, Store, Structure}, prelude::*};
 use js_sys::{JsString};
 use wasm_bindgen::prelude::*;
 
@@ -13,6 +9,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureTerminal)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureTerminal;
 
     /// The number of ticks until the [`StructureTerminal`] can use
@@ -32,14 +29,29 @@ extern "C" {
     /// Send resources to another room's terminal.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureTerminal.send)
-    #[wasm_bindgen(method)]
-    pub fn send(
+    #[wasm_bindgen(method, js_name = send)]
+    pub fn send_internal(
         this: &StructureTerminal,
         resource_type: ResourceType,
         amount: u32,
         destination: &JsString,
         description: Option<&JsString>,
     ) -> ReturnCode;
+}
+
+impl StructureTerminal {
+    pub fn send(
+        &self,
+        resource_type: ResourceType,
+        amount: u32,
+        destination: RoomName,
+        description: Option<&str>,
+    ) -> ReturnCode {
+        let desination = destination.into();
+        let description = description.map(JsString::from);
+
+        Self::send_internal(self, resource_type, amount, &desination, description.as_ref())
+    }
 }
 
 impl HasCooldown for StructureTerminal {

--- a/src/objects/impls/structure_tower.rs
+++ b/src/objects/impls/structure_tower.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureTower)
     #[wasm_bindgen(extends = RoomObject, extends = Structure, extends = OwnedStructure)]
+    #[derive(Clone)]
     pub type StructureTower;
 
     /// The [`Store`] of the tower, which contains energy which is consumed when
@@ -44,11 +45,11 @@ extern "C" {
 }
 
 impl StructureTower {
-    pub fn attack<T>(&self, target: T) -> ReturnCode where T: Attackable {
+    pub fn attack<T>(&self, target: &T) -> ReturnCode where T: ?Sized + Attackable {
         Self::attack_internal(&self, target.as_ref())
     }
 
-    pub fn heal<T>(&self, target: T) -> ReturnCode where T: Healable {
+    pub fn heal<T>(&self, target: &T) -> ReturnCode where T: ?Sized + Healable {
         Self::heal_internal(&self, target.as_ref())
     }
 }

--- a/src/objects/impls/structure_wall.rs
+++ b/src/objects/impls/structure_wall.rs
@@ -10,5 +10,6 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureWall)
     #[wasm_bindgen(extends = RoomObject, extends = Structure)]
+    #[derive(Clone)]
     pub type StructureWall;
 }

--- a/src/objects/impls/symbol_container.rs
+++ b/src/objects/impls/symbol_container.rs
@@ -17,14 +17,15 @@ extern "C" {
     /// [`ResourceType::Score`]: crate::constants::ResourceType::Score
     #[wasm_bindgen(extends = RoomObject)]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
+    #[derive(Clone)]
     pub type SymbolContainer;
 
     /// Object ID of the collector, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs-season.screeps.com/api/#SymbolContainer.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &SymbolContainer) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &SymbolContainer) -> JsString;
 
     /// The [`Store`] of the container, which contains information about what
     /// resources it is it holding.
@@ -54,21 +55,25 @@ impl CanDecay for SymbolContainer {
         Self::ticks_to_decay(self)
     }
 }
-impl HasId for SymbolContainer {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self.as_ref()))
+
+impl HasNativeId for SymbolContainer {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }
+
 impl HasPosition for SymbolContainer {
     fn pos(&self) -> Option<RoomPosition> {
         RoomObject::pos(self.as_ref())
     }
 }
+
 impl HasStore for SymbolContainer {
     fn store(&self) -> Store {
         Self::store(self)
     }
 }
+
 impl RoomObjectProperties for SymbolContainer {
     fn effects(&self) -> Array {
         RoomObject::effects(self.as_ref())

--- a/src/objects/impls/symbol_decoder.rs
+++ b/src/objects/impls/symbol_decoder.rs
@@ -16,14 +16,15 @@ extern "C" {
     /// [`ResourceType::Score`]: crate::constants::ResourceType::Score
     #[wasm_bindgen(extends = RoomObject)]
     #[cfg_attr(docsrs, doc(cfg(feature = "enable-symbols")))]
+    #[derive(Clone)]
     pub type SymbolDecoder;
 
     /// Object ID of the collector, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs-season.screeps.com/api/#SymbolDecoder.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &SymbolDecoder) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &SymbolDecoder) -> JsString;
 
     /// The [`ResourceType`] allowed to be transferred to this [`SymbolDecoder`]
     /// to score points.
@@ -40,16 +41,18 @@ extern "C" {
     pub fn score_multiplier(this: &SymbolDecoder) -> u32;
 }
 
-impl HasId for SymbolDecoder {
-    fn id(&self) -> Option<JsString> {
-        Some(Self::id(self.as_ref()))
+impl HasNativeId for SymbolDecoder {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }
+
 impl HasPosition for SymbolDecoder {
     fn pos(&self) -> Option<RoomPosition> {
         RoomObject::pos(self.as_ref())
     }
 }
+
 impl RoomObjectProperties for SymbolDecoder {
     fn effects(&self) -> Array {
         RoomObject::effects(self.as_ref())

--- a/src/objects/impls/tombstone.rs
+++ b/src/objects/impls/tombstone.rs
@@ -12,6 +12,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Tombstone)
     #[wasm_bindgen(extends = RoomObject)]
+    #[derive(Clone)]
     pub type Tombstone;
 
     /// The dead [`Creep`] or [`PowerCreep`] that this tombstone represents.
@@ -32,8 +33,8 @@ extern "C" {
     /// fresh reference to the object on subsequent ticks.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Tombstone.id)
-    #[wasm_bindgen(method, getter)]
-    pub fn id(this: &Tombstone) -> JsString;
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Tombstone) -> JsString;
 
     /// The [`Store`] of the tombstone, which contains any resources in the
     /// tombstone.
@@ -55,9 +56,9 @@ impl CanDecay for Tombstone {
     }
 }
 
-impl HasId for Tombstone {
-    fn id(&self) -> JsString {
-        Self::id(self)
+impl HasNativeId for Tombstone {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
     }
 }
 

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -377,7 +377,16 @@ pub struct SearchGoal {
     range: u32
 }
 
-#[wasm_bindgen(getter)]
+impl SearchGoal {
+    pub fn new(pos: Position, range: u32) -> Self {
+        SearchGoal {
+            pos,
+            range
+        }
+    }
+}
+
+#[wasm_bindgen]
 impl SearchGoal {
     #[wasm_bindgen(getter)]
     pub fn pos(&self) -> RoomPosition {

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -2,22 +2,23 @@
 //!
 //! [`RawMemory`]: https://docs.screeps.com/api/#RawMemory
 
-use js_sys::{Array, JsString, Object};
+use js_sys::{JsString, Object};
 
 use wasm_bindgen::prelude::*;
 
-use crate::JsHashMap;
+use crate::containers::JsHashMap;
 
 #[wasm_bindgen]
 extern "C" {
     pub type RawMemory;
 
+    //TODO: wiarchbe: This doesn't work :(
     /// Get an [`Object`] with all of the segments requested on the previous
     /// tick, with segment numbers as keys and segment data in [`JsString`] form
     /// as values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.segments)
-    #[wasm_bindgen(static_method_of = RawMemory, getter)]
+    #[wasm_bindgen(js_namespace = RawMemory, getter = segments)]
     fn segments_internal() -> Object;
 
     // todo ForeignSegment struct
@@ -25,7 +26,7 @@ extern "C" {
     /// last tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.foreignSegment)
-    #[wasm_bindgen(static_method_of = RawMemory, getter = ForeignSegment)]
+    #[wasm_bindgen(static_method_of = RawMemory, getter = foreignSegment)]
     pub fn foreign_segment() -> Option<Object>;
 
     /// Get the stored serialized memory as a [`JsString`].
@@ -48,7 +49,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setActiveSegments)
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setActiveSegments)]
-    pub fn set_active_segments(segment_ids: &Array);
+    pub fn set_active_segments(segment_ids: &[u8]);
 
     /// Sets available foreign memory segment for the next tick to a memory
     /// segment marked as public by another user. If no id is passed, the user's
@@ -70,16 +71,16 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setPublicSegments)
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setPublicSegments)]
-    pub fn set_public_segments(segment_ids: &Array);
+    pub fn set_public_segments(segment_ids: &[u8]);
 }
 
 impl RawMemory {
-    /// Get a [`JsHashMap<u8, JsString>`] with all of the segments requested on the previous
+    /// Get a [`JsHashMap<u8, String>`] with all of the segments requested on the previous
     /// tick, with segment numbers as keys and segment data in [`JsString`] form
     /// as values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.segments)    
-    pub fn segments() -> JsHashMap<u8, JsString> {
+    pub fn segments() -> JsHashMap<u8, String> {
         RawMemory::segments_internal().into()
     }
 }

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -2,7 +2,7 @@
 //!
 //! [`RawMemory`]: https://docs.screeps.com/api/#RawMemory
 
-use js_sys::{JsString, Object};
+use js_sys::{Array, JsString, Object};
 
 use wasm_bindgen::prelude::*;
 
@@ -18,7 +18,7 @@ extern "C" {
     /// as values.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.segments)
-    #[wasm_bindgen(js_namespace = RawMemory, getter = segments)]
+    #[wasm_bindgen(static_method_of = RawMemory, getter = segments)]
     fn segments_internal() -> Object;
 
     // todo ForeignSegment struct
@@ -49,7 +49,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setActiveSegments)
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setActiveSegments)]
-    pub fn set_active_segments(segment_ids: &[u8]);
+    pub fn set_active_segments_internal(segment_ids: &Array);
 
     /// Sets available foreign memory segment for the next tick to a memory
     /// segment marked as public by another user. If no id is passed, the user's
@@ -82,6 +82,12 @@ impl RawMemory {
     /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.segments)    
     pub fn segments() -> JsHashMap<u8, String> {
         RawMemory::segments_internal().into()
+    }
+
+    pub fn set_active_segments(segment_ids: &[u8]) {
+        let segment_ids: Array = segment_ids.iter().map(|s| *s as f64).map(JsValue::from_f64).collect();
+
+        RawMemory::set_active_segments_internal(&segment_ids)
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,8 +1,10 @@
+use std::str::FromStr;
+
 use enum_dispatch::enum_dispatch;
 use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
-use crate::{Position, RoomName, SingleRoomCostResult, constants::*, enums::*, objects::*};
+use crate::{ObjectId, Position, RawObjectId, RoomName, SingleRoomCostResult, constants::*, enums::*, objects::*};
 
 #[enum_dispatch]
 pub trait HasHits {
@@ -25,11 +27,56 @@ pub trait HasCooldown {
     fn cooldown(&self) -> u32;
 }
 
+pub trait HasNativeId {
+    fn native_id(&self) -> JsString;
+}
+
+pub trait MaybeHasNativeId {
+    fn native_id(&self) -> Option<JsString>;
+}
+
+impl<T> MaybeHasNativeId for T where T: HasNativeId {
+    fn native_id(&self) -> Option<JsString> {
+        Some(<Self as HasNativeId>::native_id(&self))
+    }
+}
+
+pub trait Resolvable: From<JsValue> {}
+
+impl<T> Resolvable for T where T: MaybeHasTypedId<T> + From<JsValue> {}
+
 #[enum_dispatch]
 pub trait HasId {
     /// Object ID of the object, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks.
-    fn id(&self) -> JsString;
+    fn raw_id(&self) -> RawObjectId;
+}
+
+impl<T> HasId for T where T: HasNativeId {
+    fn raw_id(&self) -> RawObjectId {
+        let id: String = self.native_id().into();
+
+        RawObjectId::from_str(&id).expect("expected object ID to be parseable")
+    }
+}
+
+#[enum_dispatch]
+pub trait HasTypedId<T> {
+    /// Object ID of the object, which can be used to efficiently fetch a
+    /// fresh reference to the object on subsequent ticks.
+    fn id(&self) -> ObjectId<T>;
+}
+
+impl<T> HasTypedId<T> for T where T: HasId {
+    fn id(&self) -> ObjectId<T> {
+        self.raw_id().into()
+    }
+}
+
+impl<T> HasTypedId<T> for &T where T: HasId {
+    fn id(&self) -> ObjectId<T> {
+        self.raw_id().into()
+    }
 }
 
 #[enum_dispatch]
@@ -37,12 +84,40 @@ pub trait MaybeHasId {
     /// Object ID of the object, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks, or `None` if the
     /// object doesn't currently have an id.
-    fn id(&self) -> Option<JsString>;
+    fn try_raw_id(&self) -> Option<RawObjectId>;
 }
 
-impl<T> MaybeHasId for T where T: HasId {
-    fn id(&self) -> Option<JsString> {
-        Some(self.id())
+impl<T> MaybeHasId for T where T: MaybeHasNativeId {
+    fn try_raw_id(&self) -> Option<RawObjectId> {
+        self
+            .native_id()
+            .map(String::from)
+            .map(|id| RawObjectId::from_str(&id).expect("expected object ID to be parseable"))
+    }
+}
+
+#[enum_dispatch]
+pub trait MaybeHasTypedId<T> {
+    /// Object ID of the object, which can be used to efficiently fetch a
+    /// fresh reference to the object on subsequent ticks, or `None` if the
+    /// object doesn't currently have an id.
+    fn try_id(&self) -> Option<ObjectId<T>>;
+}
+
+
+impl<T> MaybeHasTypedId<T> for T where T: MaybeHasId {
+    fn try_id(&self) -> Option<ObjectId<T>> {
+        self
+            .try_raw_id()
+            .map(Into::into)
+    }
+}
+
+impl<T> MaybeHasTypedId<T> for &T where T: MaybeHasId {
+    fn try_id(&self) -> Option<ObjectId<T>> {
+        self
+            .try_raw_id()
+            .map(Into::into)
     }
 }
 
@@ -108,8 +183,8 @@ pub trait SharedCreepProperties {
     /// Whether this creep is owned by the player.
     fn my(&self) -> bool;
 
-    /// The creep's name as an owned reference to a [`JsString`].
-    fn name(&self) -> JsString;
+    /// The creep's name as an owned reference to a [`String`].
+    fn name(&self) -> String;
 
     /// The [`Owner`] of this creep that contains the owner's username.
     fn owner(&self) -> Owner;
@@ -151,7 +226,7 @@ pub trait SharedCreepProperties {
 
     /// Display a string in a bubble above the creep next tick. 10 character
     /// limit.
-    fn say(&self, message: &JsString, public: bool) -> ReturnCode;
+    fn say(&self, message: &str, public: bool) -> ReturnCode;
 
     /// Immediately kill the creep.
     fn suicide(&self) -> ReturnCode;
@@ -189,7 +264,7 @@ pub trait HasEnergyForSpawn: HasStore + AsRef<RoomObject> {}
 ///
 /// # Contracts
 ///
-/// The reference returned from `AsRef<Reference>::as_ref` must be a valid
+/// The reference returned from `AsRef<RoomObject>::as_ref` must be a valid
 /// target for `Creep.transfer`.
 pub trait Transferable: AsRef<RoomObject> {}
 
@@ -198,7 +273,7 @@ pub trait Transferable: AsRef<RoomObject> {}
 ///
 /// # Contracts
 ///
-/// The reference returned from `AsRef<Reference>::as_ref` must be a valid
+/// The reference returned from `AsRef<RoomObject>::as_ref` must be a valid
 /// target for `Creep.withdraw`.
 pub trait Withdrawable: AsRef<RoomObject> {}
 
@@ -207,7 +282,7 @@ pub trait Withdrawable: AsRef<RoomObject> {}
 ///
 /// # Contracts
 ///
-/// The reference returned from `AsRef<Reference>::as_ref` must be a valid
+/// The reference returned from `AsRef<RoomObject>::as_ref` must be a valid
 /// target for `Creep.harvest`.
 pub trait Harvestable: AsRef<RoomObject> {}
 
@@ -216,16 +291,25 @@ pub trait Harvestable: AsRef<RoomObject> {}
 ///
 /// # Contracts
 ///
-/// The reference returned from `AsRef<Reference>::as_ref` must be a valid
+/// The reference returned from `AsRef<RoomObject>::as_ref` must be a valid
 /// target for `Creep.attack`.
 pub trait Attackable: HasHits + AsRef<RoomObject> {}
+
+/// Trait for all wrappers over Screeps JavaScript objects which can be the
+/// target of `Creep.dismantle`.
+///
+/// # Contracts
+///
+/// The reference returned from `AsRef<Structure>::as_ref` must be a valid
+/// target for `Creep.dismantle`.
+pub trait Dismantleable: HasHits + AsRef<Structure> {}
 
 /// Trait for all wrappers over Screeps JavaScript objects which can be the
 /// target of `Creep.heal`.
 ///
 /// # Contracts
 ///
-/// The reference returned from `AsRef<Reference>::as_ref` must be a valid
+/// The reference returned from `AsRef<RoomObject>::as_ref` must be a valid
 /// target for `Creep.heal`.
 pub trait Healable: AsRef<RoomObject> {}
 
@@ -291,6 +375,27 @@ impl Attackable for StructureTerminal {}
 impl Attackable for StructureTower {}
 impl Attackable for StructureWall {}
 impl Attackable for PowerCreep {}
+
+// NOTE: keep impls for Structure* in sync with accessor methods in
+// src/objects/structure.rs
+
+impl Dismantleable for StructureContainer {}
+impl Dismantleable for StructureExtension {}
+impl Dismantleable for StructureExtractor {}
+impl Dismantleable for StructureFactory {}
+impl Dismantleable for StructureLab {}
+impl Dismantleable for StructureLink {}
+impl Dismantleable for StructureNuker {}
+impl Dismantleable for StructureObserver {}
+impl Dismantleable for StructurePowerBank {}
+impl Dismantleable for StructurePowerSpawn {}
+impl Dismantleable for StructureRampart {}
+impl Dismantleable for StructureRoad {}
+impl Dismantleable for StructureSpawn {}
+impl Dismantleable for StructureStorage {}
+impl Dismantleable for StructureTerminal {}
+impl Dismantleable for StructureTower {}
+impl Dismantleable for StructureWall {}
 
 impl Healable for Creep {}
 impl Healable for PowerCreep {}


### PR DESCRIPTION
This change has been battle tested against my bot which exercises nearly all of the modified functionality below. There's plenty of cleanup that still needs to happen but I was able to completely move over to running bindgen on live as of this change.

Changes:
* Converted RCL to u8.
* Added interop for body parts.
* Fixed semantics for JsHashMap to allow for custom conversion. (i.e. keys are **always** strings in javascript so conversion is needed even if the key is a simple number.
* Added more structure object type conversions.
* Added more traits for operations that rely on specific structure types.
* Fixed cost matrix 'set' bug causing position to be (y, y) instead of (x, y).
* Added 'u8' getter to RoomCoordinate as an escape hatch where .into() can't infer the right types and becomes overly verbose.
* Shard/map/game/market are now back to parity on function semantics - appear to be static methods on the Rust side and do a simple property chain lookup on the JS side.
* Workaround for getRoomStatus throwing an exception on private servers. (Return a default 'normal' room if room status is not available.)
* Simplified ID semantics to reduce boilerplate code. (Implement either HasNativeId or MaybeHasNativeId and the rest is implemented with traits.)
* Added clone semantics to appropriate object types (creeps, structures, etc.)