### PR TITLE
Add and Update GH-Actions to use caches for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,18 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    name: Build (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable] # For now disable nightly toolchain
+        toolchain: [stable, nightly]
     steps:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
+          target: wasm32-unknown-unknown
           override: true
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -25,11 +27,13 @@ jobs:
           use-tool-cache: true
       - name: cargo web build
         uses: actions-rs/cargo@v1
+        continue-on-error: false
         with:
           command: web
-          args: build --target=wasm32-unknown-unknown --verbose
+          args: build --target=wasm32-unknown-unknown
       - name: cargo web build --all-features
         uses: actions-rs/cargo@v1
+        continue-on-error: false
         with:
           command: web
-          args: build --target=wasm32-unknown-unknown --all-features --verbose
+          args: build --target=wasm32-unknown-unknown --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,26 +11,47 @@ jobs:
         toolchain: [stable, nightly]
     steps:
       - name: Install toolchain
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           target: wasm32-unknown-unknown
           override: true
+
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Update Dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+
+      - name: Cache dependencies
+        env:
+          rustc-hash: ${{ steps.toolchain.outputs.rustc_hash }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ env.rustc-hash }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install cargo-web
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-web
           version: latest
           use-tool-cache: true
+
       - name: cargo web build
         uses: actions-rs/cargo@v1
         continue-on-error: false
         with:
           command: web
           args: build --target=wasm32-unknown-unknown
+
       - name: cargo web build --all-features
         uses: actions-rs/cargo@v1
         continue-on-error: false

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -67,8 +67,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ env.rustc-hash }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/clippy-check@v1
         continue-on-error: false
         with:
-          command: clippy
-          args: -- -D warnings
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features -- -D warnings

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,12 +1,10 @@
-# Based on https://github.com/actions-rs/meta/blob/master/recipes/msrv.md
-
 on: [push, pull_request]
 
-name: Test
+name: lint
 
 jobs:
-  check:
-    name: Check (${{ matrix.rust }})
+  fmt:
+    name: Rustfmt (${{ matrix.rust }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,11 +16,38 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
-        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
+          components: rustfmt
+          override: true
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        continue-on-error: false
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy (${{ matrix.rust }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          components: clippy
           override: true
 
       - name: Update Dependencies
@@ -41,51 +66,9 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ env.rustc-hash }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run cargo check
+      - name: Run cargo clippy
         uses: actions-rs/cargo@v1
         continue-on-error: false
         with:
-          command: check
-
-  test:
-    name: Test (${{ matrix.rust }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - nightly
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install toolchain
-        id: toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-
-      - name: Update Dependencies
-        uses: actions-rs/cargo@v1
-        with:
-          command: update
-
-      - name: Cache dependencies
-        env:
-          rustc-hash: ${{ steps.toolchain.outputs.rustc_hash }}
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ env.rustc-hash }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        continue-on-error: false
-        with:
-          command: test
-          args: --all-features
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,110 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/msrv.md
+
+on: [push, pull_request]
+
+name: Test
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        continue-on-error: false
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        continue-on-error: false
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        continue-on-error: false
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        continue-on-error: false
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ name: Test
 
 jobs:
   check:
-    name: Check
+    name: Check (${{ matrix.rust }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,6 +20,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
 
@@ -30,7 +31,7 @@ jobs:
           command: check
 
   test:
-    name: Test Suite
+    name: Test (${{ matrix.rust }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,6 +45,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
 
@@ -52,9 +54,10 @@ jobs:
         continue-on-error: false
         with:
           command: test
+          args: --all-features
 
   fmt:
-    name: Rustfmt
+    name: Rustfmt (${{ matrix.rust }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -68,11 +71,10 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
+          components: rustfmt
           override: true
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
@@ -96,11 +98,10 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: ${{ matrix.rust }}
+          components: clippy
           override: true
-
-      - name: Install clippy
-        run: rustup component add clippy
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,28 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+
+      - name: Update Dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+
+      - name: Cache dependencies
+        env:
+          rustc-hash: ${{ steps.toolchain.outputs.rustc_hash }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ env.rustc-hash }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo check
         uses: actions-rs/cargo@v1
@@ -43,11 +60,28 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install toolchain
+        id: toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+
+      - name: Update Dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+
+      - name: Cache dependencies
+        env:
+          rustc-hash: ${{ steps.toolchain.outputs.rustc_hash }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ env.rustc-hash }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
@@ -102,6 +136,22 @@ jobs:
           toolchain: ${{ matrix.rust }}
           components: clippy
           override: true
+
+      - name: Update Dependencies
+        uses: actions-rs/cargo@v1
+        with:
+          command: update
+
+      - name: Cache dependencies
+        env:
+          rustc-hash: ${{ steps.toolchain.outputs.rustc_hash }}
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ env.rustc-hash }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Update gh-actions and add some new actions from the [arena repo](https://www.github.com/rustyscreeps/screeps-arena-game-api).
This pr will use the [cache action](https://www.github.com/actions/cache), to save on build time and consequently action time.
It also updates the [clippy action](https://github.com/actions-rs/clippy-check) to automatically annotate the code.
But there are also some changes to consider, like removing the check task, as its redunant.

Also let me know if i should backport the changes to the arena repo.