### PR TITLE
impl std::error::Error for OutOfBoundsError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 
 - Remove re-exports of `game::*`, `pathfinder::*`, and `raw_memory::*` to resolve name conflict
   simplify crate namespace (breaking)
+- Implement `std::error::Error` for `OutOfBoundsError`, to make it more ergonomic to use with
+  other error types.
 
 0.10.0 (2023-03-13)
 ===================

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -1,8 +1,4 @@
-use std::{
-    convert::TryFrom,
-    error::Error,
-    fmt
-};
+use std::{convert::TryFrom, error::Error, fmt};
 
 use crate::constants::ROOM_SIZE;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -1,4 +1,8 @@
-use std::{convert::TryFrom, fmt};
+use std::{
+    convert::TryFrom,
+    error::Error,
+    fmt
+};
 
 use crate::constants::ROOM_SIZE;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -13,6 +17,8 @@ impl fmt::Display for OutOfBoundsError {
         write!(f, "Out of bounds coordinate: {}", self.0)
     }
 }
+
+impl Error for OutOfBoundsError {}
 
 #[inline]
 pub fn xy_to_linear_index(xy: RoomXY) -> usize {

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     convert::TryFrom,
-    error,
+    error::Error,
     fmt::{self, Write},
     ops,
     str::FromStr,
@@ -200,7 +200,7 @@ pub enum RoomNameConversionError {
     ParseError { err: RoomNameParseError },
 }
 
-impl error::Error for RoomNameConversionError {}
+impl Error for RoomNameConversionError {}
 
 impl fmt::Display for RoomNameConversionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -393,7 +393,7 @@ impl RoomNameParseError {
     }
 }
 
-impl error::Error for RoomNameParseError {}
+impl Error for RoomNameParseError {}
 
 impl fmt::Display for RoomNameParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
It was missing, resulting in more difficult usage of `?` to handle multiple kinds of errors. Also updated other imports to use std::error::Error instead of sometimes using std::error and then error::Error (as the only thing from module std::error).