### PR TITLE
Remove reexports of game::*, pathfinder::*, and raw_memory::*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- Remove re-exports of `game::*`, `pathfinder::*`, and `raw_memory::*` to resolve name conflict
+  simplify crate namespace (breaking)
+
 0.10.0 (2023-03-13)
 ===================
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,7 @@ pub(crate) mod prototypes;
 pub mod raw_memory;
 pub mod traits;
 
-pub use crate::{
-    constants::*, enums::*, game::*, js_collections::*, local::*, objects::*, pathfinder::*,
-    raw_memory::*, traits::*,
-};
+pub use crate::{constants::*, enums::*, js_collections::*, local::*, objects::*, traits::*};
 
 #[cfg(feature = "inter-shard-memory")]
 pub use crate::inter_shard_memory::*;

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -4,8 +4,9 @@ use crate::{
     objects::{
         ConstructionSite, Owner, Resource, RoomObject, Store, Structure, StructureController,
     },
+    pathfinder::SingleRoomCostResult,
     prelude::*,
-    CostMatrix, MoveToOptions, RoomName, RoomPosition, SingleRoomCostResult,
+    CostMatrix, MoveToOptions, RoomName, RoomPosition,
 };
 use js_sys::{Array, JsString};
 use wasm_bindgen::{prelude::*, JsCast};

--- a/src/objects/impls/creep_shared.rs
+++ b/src/objects/impls/creep_shared.rs
@@ -1,4 +1,6 @@
-use crate::{objects::PolyStyle, CostMatrix, FindPathOptions, RoomName, SingleRoomCostResult};
+use crate::{
+    objects::PolyStyle, pathfinder::SingleRoomCostResult, CostMatrix, FindPathOptions, RoomName,
+};
 use js_sys::Object;
 use wasm_bindgen::{prelude::*, JsCast};
 

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::{Direction, PowerCreepClass, PowerType, ResourceType, ReturnCode},
     objects::{Owner, Resource, RoomObject, Store, StructureController, StructurePowerSpawn},
+    pathfinder::SingleRoomCostResult,
     prelude::*,
     CostMatrix, JsCollectionFromValue, JsHashMap, MoveToOptions, RoomName, RoomPosition,
-    SingleRoomCostResult,
 };
 use js_sys::{JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast};

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -14,8 +14,9 @@ use crate::{
     js_collections::JsCollectionFromValue,
     local::LodashFilter,
     objects::*,
+    pathfinder::RoomCostResult,
     prelude::*,
-    FindConstant, RoomCostResult, RoomName,
+    FindConstant, RoomName,
 };
 
 use js_sys::{Array, JsString, Object};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,8 +8,8 @@ use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::*, enums::*, objects::*, JsObjectId, ObjectId, Position, RawObjectId, RoomName,
-    SingleRoomCostResult,
+    constants::*, enums::*, objects::*, pathfinder::SingleRoomCostResult, JsObjectId, ObjectId,
+    Position, RawObjectId, RoomName,
 };
 
 #[enum_dispatch]


### PR DESCRIPTION
Clean up the crate's reexports to something more similar to what it was under 0.9, and resolve the ambiguous re-export between `crate::game::market` from `game::*` and `crate::constants::market` from `constants::*`