### PR TITLE
Update upstream crates and populate missing constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 
 - Update `serde-wasm-bindgen` to 0.5
 - Update `enum-iterator` to 1.4 (breaking; `IntoEnumIterator` trait replaced with `Sequence`)
+- Implement `BODYPARTS_ALL`, `RESOURCES_ALL`, and `COLORS_ALL` constants using `enum-iterator`
 - Remove re-exports of `game::*`, `pathfinder::*`, and `raw_memory::*` to resolve name conflict
   and simplify crate namespace (breaking)
 - Implement `std::error::Error` for `OutOfBoundsError`, to make it more ergonomic to use with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 Unreleased
 ==========
 
+- Update `serde-wasm-bindgen` to 0.5
+- Update `enum-iterator` to 1.4 (breaking; `IntoEnumIterator` trait replaced with `Sequence`)
 - Remove re-exports of `game::*`, `pathfinder::*`, and `raw_memory::*` to resolve name conflict
-  simplify crate namespace (breaking)
+  and simplify crate namespace (breaking)
 - Implement `std::error::Error` for `OutOfBoundsError`, to make it more ergonomic to use with
-  other error types.
+  other error types
 
 0.10.0 (2023-03-13)
 ===================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 arrayvec = "0.7"
 enum_dispatch = "0.3"
-enum-iterator = "0.7"
+enum-iterator = "1.4"
 js-sys = "0.3"
 num-derive = "0.3"
 num-traits = "0.2"
@@ -38,7 +38,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
 wasm-bindgen = "0.2"
-serde-wasm-bindgen = "0.4"
+serde-wasm-bindgen = "0.5"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,6 @@
 //! Currently missing:
 //! - OBSTACLE_OBJECT_TYPES
 //! - WORLD_WIDTH / WORLD_HEIGHT (deprecated in Screeps)
-//! - BODYPARTS_ALL, RESOURCES_ALL, COLORS_ALL
 //! - POWER_INFO
 //!
 //! [1]: https://github.com/screeps/common/commits/master/lib/constants.js

--- a/src/constants/find.rs
+++ b/src/constants/find.rs
@@ -20,13 +20,13 @@
 //! [`Room::find`]: crate::Room::find
 //! [`objects::RoomObject`]: crate::RoomObject
 use crate::{enums::StructureObject, objects::*};
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::Sequence;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 /// Translates `FIND_*` constants.
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 #[repr(u16)]
 pub enum Find {
     /// Find all exit positions at the top of the room

--- a/src/constants/look.rs
+++ b/src/constants/look.rs
@@ -8,13 +8,13 @@
 //!
 //! [`Room::look_for_at`]: crate::objects::Room::look_for_at
 use crate::{constants::Terrain, enums::StructureObject, objects::*};
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::Sequence;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::{prelude::*, JsCast};
 
 /// Translates `LOOK_*` constants.
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 pub enum Look {
     Creeps = "creep",
     Energy = "energy",

--- a/src/constants/numbers.rs
+++ b/src/constants/numbers.rs
@@ -823,7 +823,8 @@ pub fn stronghold_rampart_hits(core_level: u32) -> Option<u32> {
 pub const STRONGHOLD_DECAY_TICKS: u32 = 75_000;
 
 // POWER_INFO not yet implemented
-// todo all of these can be IntoEnumIterator..
-// BODYPARTS_ALL, RESOURCES_ALL, COLORS_ALL not yet implemented
+// BODYPARTS_ALL implemented via Sequence trait in `small_enums.rs`
+// RESOURCES_ALL implemented via Sequence trait in `types.rs`
+// COLORS_ALL implemented via Sequence trait in `small_enums.rs`
 // INTERSHARD_RESOURCES defined in `types.rs`
 // COMMODITIES defined in `recipes.rs`

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -1,7 +1,7 @@
 //! Various constants translated as small enums.
 
 use crate::constants::find::Find;
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::Sequence;
 use js_sys::JsString;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -132,7 +132,7 @@ impl From<Result<(), ErrorCode>> for ReturnCode {
     FromPrimitive,
     Serialize_repr,
     Deserialize_repr,
-    IntoEnumIterator,
+    Sequence,
 )]
 #[repr(u8)]
 pub enum Direction {
@@ -215,7 +215,7 @@ impl fmt::Display for Direction {
     FromPrimitive,
     Serialize_repr,
     Deserialize_repr,
-    IntoEnumIterator,
+    Sequence,
 )]
 #[repr(u8)]
 pub enum ExitDirection {
@@ -261,7 +261,7 @@ impl From<ExitDirection> for Direction {
     Hash,
     Deserialize_repr,
     Serialize_repr,
-    IntoEnumIterator,
+    Sequence,
 )]
 #[repr(u8)]
 pub enum Color {
@@ -289,7 +289,7 @@ pub enum Color {
     FromPrimitive,
     Serialize_repr,
     Deserialize_repr,
-    IntoEnumIterator,
+    Sequence,
 )]
 #[repr(u8)]
 pub enum Terrain {
@@ -386,7 +386,7 @@ impl FromStr for Part {
     Hash,
     Serialize_repr,
     Deserialize_repr,
-    IntoEnumIterator,
+    Sequence,
 )]
 #[repr(u8)]
 pub enum Density {
@@ -438,13 +438,13 @@ impl Density {
     }
 
     pub fn iter_values() -> impl Iterator<Item = Density> {
-        <Density as enum_iterator::IntoEnumIterator>::into_enum_iter()
+        enum_iterator::all::<Density>()
     }
 }
 
 /// Translates `ORDER_*` constants.
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 pub enum OrderType {
     Sell = "sell",
     Buy = "buy",

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -249,7 +249,7 @@ impl From<ExitDirection> for Direction {
     }
 }
 
-/// Translates `COLOR_*` constants.
+/// Translates `COLOR_*` and `COLORS_ALL` constants.
 #[wasm_bindgen]
 #[derive(
     Debug,
@@ -322,9 +322,9 @@ impl Terrain {
     }
 }
 
-/// Translates body part constants.
+/// Translates body part type and `BODYPARTS_ALL` constants
 #[wasm_bindgen]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Deserialize, Serialize, Sequence)]
 pub enum Part {
     Move = "move",
     Work = "work",

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -1,6 +1,6 @@
 //! `*Type` constants.
 use crate::{JsCollectionFromValue, JsCollectionIntoValue};
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::Sequence;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
@@ -31,7 +31,7 @@ macro_rules! named_enum_serialize_deserialize {
 
 /// Translates `STRUCTURE_*` constants.
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Sequence)]
 pub enum StructureType {
     Spawn = "spawn",
     Extension = "extension",
@@ -203,7 +203,7 @@ impl StructureType {
 
 /// Translates `SUBSCRIPTION_TOKEN` and `INTERSHARD_RESOURCES` constants.
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 pub enum IntershardResourceType {
     // no longer used, not implemented
     // SubscriptionToken = "token",
@@ -214,7 +214,7 @@ pub enum IntershardResourceType {
 
 /// Resource type constant for all possible types of resources.
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Sequence)]
 pub enum ResourceType {
     Energy = "energy",
     Power = "power",
@@ -563,7 +563,7 @@ impl wasm_bindgen::describe::WasmDescribe for MarketResourceType {
 
 /// Translates the `POWER_CLASS` constants, which are classes of power creeps
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, IntoEnumIterator)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 pub enum PowerCreepClass {
     Operator = "operator",
 }
@@ -581,7 +581,7 @@ pub enum PowerCreepClass {
     FromPrimitive,
     Deserialize_repr,
     Serialize_repr,
-    IntoEnumIterator,
+    Sequence,
 )]
 #[repr(u32)]
 pub enum PowerType {

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -212,7 +212,8 @@ pub enum IntershardResourceType {
     AccessKey = "accessKey",
 }
 
-/// Resource type constant for all possible types of resources.
+/// Translates `RESOURCES_ALL` constant, representing all possible in-game
+/// (non-intershard) resources.
 #[wasm_bindgen]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Sequence)]
 pub enum ResourceType {
@@ -342,7 +343,7 @@ pub enum ResourceType {
     SymbolQoph = "symbol_qoph",
     #[cfg(feature = "symbols")]
     SymbolRes = "symbol_res",
-    // sin/sim mismatch is intended and present in the mod:
+    // sin/sim mismatch is intended here - see official mod:
     // https://github.com/screeps/mod-season2/blob/3dfaa8f6214b2610dbe2a700c6287a10e7960ae8/src/resources.js#L23
     #[cfg(feature = "symbols")]
     SymbolSin = "symbol_sim",
@@ -512,7 +513,7 @@ pub enum Boost {
 }
 
 /// Translates all resource types that can be used on the market.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 #[serde(untagged)]
 pub enum MarketResourceType {
     Resource(ResourceType),
@@ -626,7 +627,16 @@ impl JsCollectionIntoValue for PowerType {
 /// Translates the `EFFECT_*` constants, which are natural effect types
 #[wasm_bindgen]
 #[derive(
-    Copy, Clone, Debug, PartialEq, Eq, Hash, FromPrimitive, Serialize_repr, Deserialize_repr,
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    FromPrimitive,
+    Serialize_repr,
+    Deserialize_repr,
+    Sequence,
 )]
 #[repr(u32)]
 pub enum NaturalEffectType {
@@ -636,7 +646,7 @@ pub enum NaturalEffectType {
 
 /// Translates effect types on room objects, which can include both `PWR_*` and
 /// `EFFECT_*` constants.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Sequence)]
 pub enum EffectType {
     PowerEffect(PowerType),
     NaturalEffect(NaturalEffectType),


### PR DESCRIPTION
Update `serde-wasm-bindgen` and `enum-iterator` crates to current releases.  `enum-iterator` ergonomics changed significantly, this is a breaking change for anyone using those enumerators.

Also implemented the `BODYPARTS_ALL`, `RESOURCES_ALL`, and `COLORS_ALL` constants which were previously unimplemented using `enum-iterator` on existing enums (and noting that the `RESOURCES_ALL` constant excludes intershard resources which is reflected in the documentation here).