### PR TITLE
Move intershard and raw memory functions to the top of their modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Unreleased
 ==========
 
-- Move `crate::inter_shard_memory::InterShardMemory::*` to `crate::inter_shard_memory::*` and moved
+- Move `crate::inter_shard_memory::InterShardMemory::*` to `crate::inter_shard_memory::*` and move
   `crate::raw_memory::RawMemory::*` to `crate::raw_memory::*` for consistency (breaking)
 - Update `serde-wasm-bindgen` to 0.5
 - Update `enum-iterator` to 1.4 (breaking; `IntoEnumIterator` trait replaced with `Sequence`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Move `crate::inter_shard_memory::InterShardMemory::*` to `crate::inter_shard_memory::*` and moved
+  `crate::raw_memory::RawMemory::*` to `crate::raw_memory::*` for consistency (breaking)
 - Update `serde-wasm-bindgen` to 0.5
 - Update `enum-iterator` to 1.4 (breaking; `IntoEnumIterator` trait replaced with `Sequence`)
 - Implement `BODYPARTS_ALL`, `RESOURCES_ALL`, and `COLORS_ALL` constants using `enum-iterator`

--- a/src/constants/extra.rs
+++ b/src/constants/extra.rs
@@ -35,10 +35,10 @@ pub const CREEP_SAY_MAX_LENGTH: u32 = 10;
 /// Maximum length of names of flag objects.
 pub const FLAG_NAME_MAX_LENGTH: u32 = 60;
 
-/// Maximum size in UTF-16 units of data set in [`InterShardMemory`] for each
-/// shard.
+/// Maximum size in UTF-16 units of data allowed to be sent to
+/// [`inter_shard_memory::set_local`]
 ///
-/// [`InterShardMemory`]: crate::InterShardMemory
+/// [`inter_shard_memory::set_local`]: crate::inter_shard_memory::set_local
 pub const INTER_SHARD_MEMORY_SIZE_LIMIT: u32 = 100 * 1024;
 
 /// Owner username of hostile non-player structures and creeps which create

--- a/src/inter_shard_memory.rs
+++ b/src/inter_shard_memory.rs
@@ -1,4 +1,4 @@
-//! Interface for Screeps [`InterShardMemory`], allowing communication between
+//! Interface for Screeps inter-shard memory, allowing communication between
 //! instances of your code running on different shards.
 //!
 //! [Screeps documentation](https://docs.screeps.com/api/#InterShardMemory)
@@ -9,29 +9,41 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    pub type InterShardMemory;
+    type InterShardMemory;
 
-    /// Get the current local [`JsString`] intershard memory for this shard.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#InterShardMemory.getLocal)
     #[wasm_bindgen(static_method_of = InterShardMemory, js_name = getLocal)]
-    pub fn get_local() -> Option<JsString>;
+    fn get_local() -> Option<JsString>;
 
-    /// Overwrite the current shard's intershard memory segment with new
-    /// contents.  Maximum allowed length of [`INTER_SHARD_MEMORY_SIZE_LIMIT`]
-    /// bytes.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#InterShardMemory.setLocal)
-    ///
-    /// [`INTER_SHARD_MEMORY_SIZE_LIMIT`]:
-    /// crate::constants::INTER_SHARD_MEMORY_SIZE_LIMIT
     #[wasm_bindgen(static_method_of = InterShardMemory, js_name = setLocal)]
-    pub fn set_local(val: &JsString);
+    fn set_local(val: &JsString);
 
-    /// Get the data that another shard's code instance has written to its
-    /// intershard memory segment.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#InterShardMemory.getRemote)
     #[wasm_bindgen(static_method_of = InterShardMemory, js_name = getRemote)]
-    pub fn get_remote(val: &JsString) -> Option<JsString>;
+    fn get_remote(shard: &JsString) -> Option<JsString>;
+}
+
+/// Get the current local [`JsString`] intershard memory for this shard.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#InterShardMemory.getLocal)
+pub fn get_local() -> Option<JsString> {
+    InterShardMemory::get_local()
+}
+
+/// Overwrite the current shard's intershard memory segment with new
+/// contents.  Maximum allowed length of [`INTER_SHARD_MEMORY_SIZE_LIMIT`]
+/// UTF-16 units.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#InterShardMemory.setLocal)
+///
+/// [`INTER_SHARD_MEMORY_SIZE_LIMIT`]:
+/// crate::constants::INTER_SHARD_MEMORY_SIZE_LIMIT
+pub fn set_local(val: &JsString) {
+    InterShardMemory::set_local(val)
+}
+
+/// Get the data that another shard's code instance has written to its
+/// intershard memory segment.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#InterShardMemory.getRemote)
+pub fn get_remote(shard: &JsString) -> Option<JsString> {
+    InterShardMemory::get_remote(shard)
 }

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -20,86 +20,111 @@ use crate::js_collections::JsHashMap;
 
 #[wasm_bindgen]
 extern "C" {
-    pub type RawMemory;
+    type RawMemory;
 
     #[wasm_bindgen(static_method_of = RawMemory, getter = segments)]
-    fn segments_internal() -> Object;
+    fn segments() -> Object;
 
-    /// Get the foreign memory segment belonging to another player requested
-    /// last tick.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.foreignSegment)
     #[wasm_bindgen(static_method_of = RawMemory, getter = foreignSegment)]
-    pub fn foreign_segment() -> Option<ForeignSegment>;
+    fn foreign_segment() -> Option<ForeignSegment>;
 
-    /// Get the stored serialized memory as a [`JsString`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.get)
     #[wasm_bindgen(static_method_of = RawMemory)]
-    pub fn get() -> JsString;
+    fn get() -> JsString;
 
-    /// Overwrite the stored memory with a new [`JsString`]. Maximum allowed
-    /// size [`MEMORY_SIZE_LIMIT`] UTF-16 units.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.set)
-    ///
-    /// [`MEMORY_SIZE_LIMIT`]: crate::constants::MEMORY_SIZE_LIMIT
     #[wasm_bindgen(static_method_of = RawMemory)]
-    pub fn set(val: &JsString);
+    fn set(val: &JsString);
 
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setActiveSegments)]
-    fn set_active_segments_internal(segment_ids: &Array);
+    fn set_active_segments(segment_ids: &Array);
 
-    /// Sets available foreign memory segment for the next tick to a memory
-    /// segment marked as public by another user. If no id is passed, the user's
-    /// default public segment is retrieved.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setActiveForeignSegment)
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setActiveForeignSegment)]
-    pub fn set_active_foreign_segment(username: &JsString, segment_id: Option<u8>);
+    fn set_active_foreign_segment(username: &JsString, segment_id: Option<u8>);
 
-    /// Sets your default foreign memory segment for other players to read, or
-    /// remove your public segment with `None`.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setDefaultPublicSegment)
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setDefaultPublicSegment)]
-    pub fn set_default_public_segment(segment_id: Option<u8>);
+    fn set_default_public_segment(segment_id: Option<u8>);
 
-    /// Sets which of your memory segments are readable to other players as
-    /// foreign segments, overriding previous settings.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setPublicSegments)
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setPublicSegments)]
-    pub fn set_public_segments(segment_ids: &[u8]);
+    fn set_public_segments(segment_ids: &[u8]);
 }
 
-impl RawMemory {
-    /// Get a [`JsHashMap<u8, String>`] with all of the segments requested on
-    /// the previous tick, with segment numbers as keys and segment data in
-    /// [`JsString`] form as values.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.segments)
-    pub fn segments() -> JsHashMap<u8, String> {
-        RawMemory::segments_internal().into()
-    }
+/// Get a [`JsHashMap<u8, String>`] with all of the segments requested on
+/// the previous tick, with segment numbers as keys and segment data in
+/// [`JsString`] form as values.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.segments)
+pub fn segments() -> JsHashMap<u8, String> {
+    RawMemory::segments().into()
+}
 
-    /// Sets available memory segments for the next tick, as an array of numbers
-    /// from 0 to 99 (max of 10 segments allowed).
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setActiveSegments)
-    pub fn set_active_segments(segment_ids: &[u8]) {
-        let segment_ids: Array = segment_ids
-            .iter()
-            .map(|s| *s as f64)
-            .map(JsValue::from_f64)
-            .collect();
+/// Get the foreign memory segment belonging to another player requested
+/// last tick.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.foreignSegment)
+pub fn foreign_segment() -> Option<ForeignSegment> {
+    RawMemory::foreign_segment()
+}
 
-        RawMemory::set_active_segments_internal(&segment_ids)
-    }
+/// Get the stored serialized memory as a [`JsString`].
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.get)
+pub fn get() -> JsString {
+    RawMemory::get()
+}
+
+/// Overwrite the stored memory with a new [`JsString`]. Maximum allowed
+/// size [`MEMORY_SIZE_LIMIT`] UTF-16 units.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.set)
+///
+/// [`MEMORY_SIZE_LIMIT`]: crate::constants::MEMORY_SIZE_LIMIT
+pub fn set(val: &JsString) {
+    RawMemory::set(val)
+}
+
+/// Sets available memory segments for the next tick, as an array of numbers
+/// from 0 to 99 (max of 10 segments allowed).
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setActiveSegments)
+pub fn set_active_segments(segment_ids: &[u8]) {
+    let segment_ids: Array = segment_ids
+        .iter()
+        .map(|s| *s as f64)
+        .map(JsValue::from_f64)
+        .collect();
+
+    RawMemory::set_active_segments(&segment_ids)
+}
+
+/// Sets available foreign memory segment for the next tick to a memory
+/// segment marked as public by another user. If no id is passed, the user's
+/// default public segment is retrieved.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setActiveForeignSegment)
+pub fn set_active_foreign_segment(username: &JsString, segment_id: Option<u8>) {
+    RawMemory::set_active_foreign_segment(username, segment_id)
+}
+
+/// Sets your default foreign memory segment for other players to read, or
+/// remove your public segment with `None`.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setDefaultPublicSegment)
+pub fn set_default_public_segment(segment_id: Option<u8>) {
+    RawMemory::set_default_public_segment(segment_id)
+}
+
+/// Sets which of your memory segments are readable to other players as
+/// foreign segments, overriding previous settings.
+///
+/// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setPublicSegments)
+pub fn set_public_segments(segment_ids: &[u8]) {
+    RawMemory::set_public_segments(segment_ids)
 }
 
 #[wasm_bindgen]
 extern "C" {
+    /// The data from another user's foreign memory segment, which can be
+    /// retrieved by [`foreign_segment`], after being requested on the previous
+    /// tick by [`set_active_foreign_segment`].
     #[wasm_bindgen]
     pub type ForeignSegment;
     #[wasm_bindgen(method, getter)]


### PR DESCRIPTION
Make the wasm-bindgen type that holds the internal calls private for better ergonomics on imports and documentation in the same way we've already got for everything under the game module.