### PR TITLE
impl TryFrom<JsString> for RawObjectId and FromStr for JsObjectId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 - Implement `TryFrom<JsString>` for `RawObjectId`
+- Implement `FromStr` for `JsObjectId`
 - Move `crate::inter_shard_memory::InterShardMemory::*` to `crate::inter_shard_memory::*` and move
   `crate::raw_memory::RawMemory::*` to `crate::raw_memory::*` for consistency (breaking)
 - Update `serde-wasm-bindgen` to 0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ==========
 
+- Implement `TryFrom<JsString>` for `RawObjectId`
 - Move `crate::inter_shard_memory::InterShardMemory::*` to `crate::inter_shard_memory::*` and move
   `crate::raw_memory::RawMemory::*` to `crate::raw_memory::*` for consistency (breaking)
 - Update `serde-wasm-bindgen` to 0.5

--- a/src/js_collections.rs
+++ b/src/js_collections.rs
@@ -3,12 +3,13 @@ use std::{
     cmp::{Eq, PartialEq},
     fmt,
     marker::PhantomData,
+    str::FromStr,
 };
 
 use js_sys::{Array, JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast};
 
-use crate::{game, traits::Resolvable};
+use crate::{game, local::RawObjectIdParseError, traits::Resolvable};
 
 #[wasm_bindgen]
 extern "C" {
@@ -198,15 +199,14 @@ impl<T> PartialEq for JsObjectId<T> {
 }
 impl<T> Eq for JsObjectId<T> {}
 
-// impl<T> FromStr for JsObjectId<T> {
-//     type Err = RawObjectIdParseError;
+impl<T> FromStr for JsObjectId<T> {
+    type Err = RawObjectIdParseError;
 
-//     fn from_str(s: &str) -> Result<Self, RawObjectIdParseError> {
-//         let raw: RawObjectId = s.parse()?;
-
-//         Ok(raw.into())
-//     }
-// }
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let js_string: JsString = s.into();
+        Ok(js_string.into())
+    }
+}
 
 impl<T> fmt::Display for JsObjectId<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/local/object_id.rs
+++ b/src/local/object_id.rs
@@ -106,7 +106,7 @@ impl<T> Ord for ObjectId<T> {
 impl<T> FromStr for ObjectId<T> {
     type Err = RawObjectIdParseError;
 
-    fn from_str(s: &str) -> Result<Self, RawObjectIdParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         let raw: RawObjectId = s.parse()?;
 
         Ok(raw.into())

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -1,6 +1,7 @@
 use std::{fmt, fmt::Write, str::FromStr};
 
 use arrayvec::ArrayString;
+use js_sys::JsString;
 use serde::{
     de::{Error, Visitor},
     Deserialize, Serialize,
@@ -122,6 +123,15 @@ impl FromStr for RawObjectId {
         }
 
         Ok(Self::from(u128_id << 32 | pad_length))
+    }
+}
+
+impl TryFrom<JsString> for RawObjectId {
+    type Error = RawObjectIdParseError;
+
+    fn try_from(js_id: JsString) -> Result<Self, Self::Error> {
+        let id: String = js_id.into();
+        RawObjectId::from_str(&id)
     }
 }
 

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -110,7 +110,7 @@ impl<'de> Deserialize<'de> for RawObjectId {
 impl FromStr for RawObjectId {
     type Err = RawObjectIdParseError;
 
-    fn from_str(s: &str) -> Result<Self, RawObjectIdParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         // get the actual integer value of the id, which we'll store in the most
         // significant 96 bits of the u128
         let u128_id = u128::from_str_radix(s, 16)?;

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -311,7 +311,7 @@ impl ops::Sub<RoomName> for RoomName {
 impl FromStr for RoomName {
     type Err = RoomNameParseError;
 
-    fn from_str(s: &str) -> Result<Self, RoomNameParseError> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse_to_coords(s)
             .map_err(|()| RoomNameParseError::new(s))
             .and_then(|(x, y)| RoomName::from_coords(x, y))


### PR DESCRIPTION
Add `TryFrom<JsString>` for `RawObjectId`, which simply converts the string to a local one then uses the `FromStr` implementation.