### PR TITLE
TextStyle's stroke_width() and background_padding() bugfix in RoomVisual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased
   and simplify crate namespace (breaking)
 - Implement `std::error::Error` for `OutOfBoundsError`, to make it more ergonomic to use with
   other error types
+- Fix `TextStyle::stroke_width` and `TextStyle::background_padding` functions setting incorrect
+  values.
 
 0.10.0 (2023-03-13)
 ===================

--- a/src/objects/impls/room_visual.rs
+++ b/src/objects/impls/room_visual.rs
@@ -283,7 +283,7 @@ impl TextStyle {
     }
 
     pub fn stroke_width(mut self, val: f32) -> TextStyle {
-        self.opacity = Some(val);
+        self.stroke_width = Some(val);
         self
     }
 
@@ -293,7 +293,7 @@ impl TextStyle {
     }
 
     pub fn background_padding(mut self, val: f32) -> TextStyle {
-        self.opacity = Some(val);
+        self.background_padding = Some(val);
         self
     }
 


### PR DESCRIPTION
The methods were setting a different attribute.