### PR TITLE
Fix InnerSearchOptions using incorrect field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Fix `SearchOptions` not mapping to camel-cased field names when converting to js object. Fixes
+  `pathfinder::search` not using the specified settings for `max_ops`, `plain_cost`, etc.
 
 0.11.0 (2023-05-29)
 ===================

--- a/src/pathfinder.rs
+++ b/src/pathfinder.rs
@@ -187,6 +187,7 @@ where
 }
 
 #[derive(Default, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct InnerSearchOptions {
     plain_cost: Option<u8>,
     swamp_cost: Option<u8>,


### PR DESCRIPTION
The `InnerSearchOptions` struct is being converted to `JsSearchOptions` via serde_wasm_bindgen instead of using the setters; the setters have the correct camelCased field names but the `InnerSearchOptions` was converting using serde defaults. Adding `serde(rename_all = "camelCase")` fixes the field names so they match after conversion and are recognized by the pathfinder API.