### PR TITLE
Add missing season 5 functionality, remove unneeded Density iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Unreleased
   all of their contents re-exported to maintain compatibiltiy with existing imports
 - Move `CostMatrixSet` and `HasLocalPosition` traits from `crate::objects` to `crate::traits`
   (breaking)
+- Add `Creep::claim_reactor` function for season 5
+- Add `Density::thorium_amount` function with additional season 5 constants
+- Remove `Density::iter_values`, update documentation to indicate `enum_iterator::all` should be
+  used instead (breaking)
 
 0.11.0 (2023-05-29)
 ===================

--- a/src/constants/seasonal.rs
+++ b/src/constants/seasonal.rs
@@ -117,6 +117,7 @@ pub mod season_2 {
 /// on a private server.
 #[cfg(feature = "seasonal-season-5")]
 pub mod season_5 {
+    use crate::constants::Density;
     // RESOURCE_THORIUM defined in `types.rs`
     // FIND_REACTORS defined in `find.rs`
     /// Capacity of the [`Thorium`] storage of a [`Reactor`].
@@ -126,6 +127,22 @@ pub mod season_5 {
     // no official constant for this currently, but providing as 'extra' constant
     // for consistency with prior seasons
     pub const REACTOR_THORIUM_CAPACITY: u32 = 1_000;
+
+    impl Density {
+        /// Amount of [`Thorium`] generated for each density
+        /// level, replacing the amounts from [`Density::amount`].
+        ///
+        /// [`Thorium`]: crate::constants::ResourceType::Thorium
+        #[inline]
+        pub fn thorium_amount(self) -> u32 {
+            match self {
+                Density::Low => 10_000,
+                Density::Moderate => 22_000,
+                Density::High => 45_000,
+                Density::Ultra => 67_000,
+            }
+        }
+    }
 
     /// The added decay each tick for all creeps and decaying structures when
     /// [`Thorium`] is present on the same tile.

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -414,7 +414,7 @@ impl Density {
     ///
     /// These are values intended for subsequent percentage checks
     /// in the order `Low` -> `Medium` -> `High` -> `Ultra`. Use the
-    /// [`Density::iter_values`] iterator to iterate in this order.
+    /// [`enum_iterator::all`] iterator to iterate in this order.
     ///
     /// If low or ultra on previous regeneration, or random number rolled at
     /// probability [`MINERAL_DENSITY_CHANGE`], the mineral will determine a
@@ -426,8 +426,7 @@ impl Density {
     ///  - Ultra: 10% chance
     ///
     /// [source]: https://github.com/screeps/engine/blob/c0cfac8f746f26c660501686f16a1fcdb0396d8d/src/processor/intents/minerals/tick.js#L19
-    /// [`MINERAL_DENSITY_CHANGE`]:
-    /// crate::constants::MINERAL_DENSITY_CHANGE
+    /// [`MINERAL_DENSITY_CHANGE`]: crate::constants::MINERAL_DENSITY_CHANGE
     #[inline]
     pub fn probability(self) -> f32 {
         match self {
@@ -436,10 +435,6 @@ impl Density {
             Density::High => 0.9,
             Density::Ultra => 1.0,
         }
-    }
-
-    pub fn iter_values() -> impl Iterator<Item = Density> {
-        enum_iterator::all::<Density>()
     }
 }
 

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -12,6 +12,9 @@ use crate::{
     CostMatrix, MoveToOptions, RoomName, RoomPosition,
 };
 
+#[cfg(feature = "thorium")]
+use crate::objects::Reactor;
+
 #[wasm_bindgen]
 extern "C" {
     /// A [`Creep`] unit in the game world.
@@ -134,6 +137,14 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.claimController)
     #[wasm_bindgen(final, method, js_name = claimController)]
     pub fn claim_controller(this: &Creep, target: &StructureController) -> ReturnCode;
+
+    /// Claim a [`Reactor`] in melee range as your own using a creep's claim
+    /// parts.
+    ///
+    /// [Screeps documentation](https://docs-season.screeps.com/api/#Creep.claimReactor)
+    #[cfg(feature = "thorium")]
+    #[wasm_bindgen(final, method, js_name = claimReactor)]
+    pub fn claim_reactor(this: &Creep, target: &Reactor) -> ReturnCode;
 
     #[wasm_bindgen(final, method, js_name = dismantle)]
     fn dismantle_internal(this: &Creep, target: &Structure) -> ReturnCode;


### PR DESCRIPTION
Added missed function `Creep.claimReactor`, Thorium density info from the season 5 mod, and remove the no-longer-need `Density::iter_values` function.