### PR TITLE
Implement Position math manipulation for Direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased
 - Add `Density::thorium_amount` function with additional season 5 constants
 - Remove `Density::iter_values`, update documentation to indicate `enum_iterator::all` should be
   used instead (breaking)
+- Implement `From<Direction>` for `(i32, i32)`, as well as `Add<Direction>` and `Sub<Direction>`
+  for `Position`, to support using directions for position math
 
 0.11.0 (2023-05-29)
 ===================

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -147,6 +147,23 @@ pub enum Direction {
     TopLeft = 8,
 }
 
+impl From<Direction> for (i32, i32) {
+    /// Returns the change in (x, y) when moving in each direction.
+    #[inline]
+    fn from(direction: Direction) -> (i32, i32) {
+        match direction {
+            Direction::Top => (0, -1),
+            Direction::TopRight => (1, -1),
+            Direction::Right => (1, 0),
+            Direction::BottomRight => (1, 1),
+            Direction::Bottom => (0, 1),
+            Direction::BottomLeft => (-1, 1),
+            Direction::Left => (-1, 0),
+            Direction::TopLeft => (-1, -1),
+        }
+    }
+}
+
 impl ::std::ops::Neg for Direction {
     type Output = Direction;
 

--- a/src/local/position/extra_math.rs
+++ b/src/local/position/extra_math.rs
@@ -3,6 +3,7 @@
 use std::ops::{Add, Sub};
 
 use super::Position;
+use crate::constants::Direction;
 
 impl Position {
     /// Returns a new position offset from this position by the specified x
@@ -121,6 +122,16 @@ impl Add<(i32, i32)> for Position {
     }
 }
 
+impl Add<Direction> for Position {
+    type Output = Position;
+    #[inline]
+    fn add(self, direction: Direction) -> Self {
+        let (wx, wy) = self.world_coords();
+        let (x, y) = direction.into();
+        Self::from_world_coords(wx + x, wy + y)
+    }
+}
+
 impl Sub<(i32, i32)> for Position {
     type Output = Position;
 
@@ -128,6 +139,16 @@ impl Sub<(i32, i32)> for Position {
     #[inline]
     fn sub(self, (x, y): (i32, i32)) -> Self {
         self + (-x, -y)
+    }
+}
+
+impl Sub<Direction> for Position {
+    type Output = Position;
+    #[inline]
+    fn sub(self, direction: Direction) -> Self {
+        let (wx, wy) = self.world_coords();
+        let (x, y) = direction.into();
+        Self::from_world_coords(wx - x, wy - y)
     }
 }
 


### PR DESCRIPTION
Implements conversions to make working with `Direction` and `Position` a little easier:
 - `From<Direction>` for `(i32, i32)`
 - `Add<Direction>` and `Sub<Direction>` for `Position`