### PR TITLE
Trait fixes for Reactor and other seasonal objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- Add `HasNativeId` and `Transferable` traits to `Reactor`
+- Add `Transferable` and `Withdrawable` traits to season 1 and 2 object types
+
 0.12.0 (2023-06-07)
 ===================
 

--- a/src/objects/impls/reactor.rs
+++ b/src/objects/impls/reactor.rs
@@ -1,3 +1,4 @@
+use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
@@ -16,6 +17,9 @@ extern "C" {
     #[wasm_bindgen(extends = RoomObject)]
     #[derive(Clone, Debug)]
     pub type Reactor;
+
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Reactor) -> JsString;
 
     /// Ticks of continuous work this reactor has done.
     ///
@@ -48,6 +52,12 @@ extern "C" {
     /// [Screeps documentation](https://docs-season.screeps.com/api/#Reactor.owner)
     #[wasm_bindgen(method, getter)]
     pub fn owner(this: &Reactor) -> Option<Owner>;
+}
+
+impl HasNativeId for Reactor {
+    fn native_id(&self) -> JsString {
+        Self::id_internal(self)
+    }
 }
 
 impl HasStore for Reactor {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -431,6 +431,12 @@ impl Transferable for StructureTower {}
 impl Transferable for StructurePowerSpawn {}
 impl Transferable for StructureTerminal {}
 impl Transferable for PowerCreep {}
+#[cfg(feature = "score")]
+impl Transferable for ScoreCollector {}
+#[cfg(feature = "symbols")]
+impl Transferable for SymbolDecoder {}
+#[cfg(feature = "thorium")]
+impl Transferable for Reactor {}
 
 // NOTE: keep impls for Structure* in sync with accessor methods in
 // src/objects/structure.rs
@@ -447,6 +453,10 @@ impl Withdrawable for StructureTower {}
 impl Withdrawable for StructurePowerSpawn {}
 impl Withdrawable for StructureTerminal {}
 impl Withdrawable for Tombstone {}
+#[cfg(feature = "score")]
+impl Withdrawable for ScoreContainer {}
+#[cfg(feature = "symbols")]
+impl Withdrawable for SymbolContainer {}
 
 impl Harvestable for Deposit {}
 impl Harvestable for Mineral {}


### PR DESCRIPTION
Adding missed `HasNativeId` and `Transferable` traits that `Reactor` needs to be used properly.

Also added `Withdrawable` and `Transferable` to appropriate objects from past seasons.