### PR TITLE
Implement a custom Debug for RoomName with unpacked room name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Add custom implementation of `Debug` for `RoomName` showing the non-packed name
+
 0.12.1 (2023-06-10)
 ===================
 

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -32,7 +32,7 @@ use super::{HALF_WORLD_SIZE, VALID_ROOM_NAME_COORDINATES};
 /// from above.
 ///
 /// [`BTreeMap`]: std::collections::BTreeMap
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct RoomName {
     /// A bit-packed integer, containing, from highest-order to lowest:
     ///
@@ -78,6 +78,15 @@ impl fmt::Display for RoomName {
         }
 
         Ok(())
+    }
+}
+
+impl fmt::Debug for RoomName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RoomName")
+            .field("packed", &self.packed)
+            .field("real", &self.to_array_string())
+            .finish()
     }
 }
 


### PR DESCRIPTION
Debug output of `RoomName` contains the packed version; adding the unpacked/human readable version as well.