### PR TITLE
Add conversion from `ExitDirection` to `find::Exit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 - Add custom implementation of `Debug` for `RoomName` showing the non-packed name
+- Add implementation of `From<ExitDirection>` for `Exit`
 
 0.12.1 (2023-06-10)
 ===================

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use wasm_bindgen::prelude::*;
 
-use crate::constants::find::Find;
+use crate::{constants::find::Find, find::Exit};
 
 // Bindgen does not correctly handle i8 negative return values. Use custom
 // return values.
@@ -263,6 +263,17 @@ impl From<ExitDirection> for Direction {
             ExitDirection::Right => Direction::Right,
             ExitDirection::Bottom => Direction::Bottom,
             ExitDirection::Left => Direction::Left,
+        }
+    }
+}
+
+impl From<ExitDirection> for Exit {
+    fn from(value: ExitDirection) -> Self {
+        match value {
+            ExitDirection::Top => Exit::Top,
+            ExitDirection::Right => Exit::Right,
+            ExitDirection::Bottom => Exit::Bottom,
+            ExitDirection::Left => Exit::Left,
         }
     }
 }


### PR DESCRIPTION
This allows the output of `game::map::find_route` to be used in `find` methods to get the position of the target exit.