### PR TITLE
Add catch handling similar to create_flag for look methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- Change `RoomPosition` and `Position` methods `look` and `look_for` to return a `Result` instead
+  of panicking when used in room not visible in the current tick (breaking)
+
 0.12.2 (2023-06-17)
 ===================
 

--- a/src/local/position/game_methods.rs
+++ b/src/local/position/game_methods.rs
@@ -128,19 +128,21 @@ impl Position {
         RoomPosition::from(self).find_path_to_xy(x, y, options)
     }
 
-    /// Get all objects at this position.
+    /// Get all objects at this position. Will fail if the position is in a room
+    /// that's not visible during the current tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.look)
     #[inline]
-    pub fn look(self) -> Vec<LookResult> {
+    pub fn look(self) -> Result<Vec<LookResult>, ErrorCode> {
         RoomPosition::from(self).look()
     }
 
-    /// Get all objects of a given type at this position, if any.
+    /// Get all objects of a given type at this position, if any. Will fail if
+    /// the position is in a room that's not visible during the current tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.lookFor)
     #[inline]
-    pub fn look_for<T>(self, ty: T) -> Vec<T::Item>
+    pub fn look_for<T>(self, ty: T) -> Result<Vec<T::Item>, ErrorCode>
     where
         T: LookConstant,
     {


### PR DESCRIPTION
When a position's in a room without vision in the tick and a look method is called, the engine fires a stacktrace. This currently panics; adding a wrapper similar to `create_flag` where we consume the stack trace value and return one of our standard error types instead.