### PR TITLE
Hide the Find and Look internal enums from docs and don't reexport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 
 - Change `RoomPosition` and `Position` methods `look` and `look_for` to return a `Result` instead
   of panicking when used in room not visible in the current tick (breaking)
+- Remove re-exports of `constants::find::Find` and `constants::look::Look` enums and mark them as
+  hidden from docs, since they're likely to cause confusion and not generally needed (breaking)
 
 0.12.2 (2023-06-17)
 ===================

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -20,13 +20,8 @@ mod small_enums;
 mod types;
 
 pub use self::{
-    extra::*,
-    find::{Find, FindConstant},
-    look::{Look, LookConstant},
-    numbers::*,
-    recipes::FactoryRecipe,
-    small_enums::*,
-    types::*,
+    extra::*, find::FindConstant, look::LookConstant, numbers::*, recipes::FactoryRecipe,
+    small_enums::*, types::*,
 };
 
 /// Re-export of all constants related to [`Creep`] behavior and operations.

--- a/src/constants/find.rs
+++ b/src/constants/find.rs
@@ -25,7 +25,14 @@ use wasm_bindgen::prelude::*;
 
 use crate::{enums::StructureObject, objects::*};
 
-/// Translates `FIND_*` constants.
+/// Translates `FIND_*` constants for interal API calls
+///
+/// Unless you're storing the type of find constant to be used for a call, you
+/// likely want the constants which implement the `FindConstant` trait to make
+/// calls to find methods.
+///
+/// This is hidden from the documentation to avoid confusion due to its narrow
+/// use case, but wasm_bindgen requires it remain public.
 #[wasm_bindgen]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 #[repr(u16)]

--- a/src/constants/look.rs
+++ b/src/constants/look.rs
@@ -13,7 +13,15 @@ use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{constants::Terrain, enums::StructureObject, objects::*};
 
-/// Translates `LOOK_*` constants.
+/// Translates `LOOK_*` constants for interal API calls
+///
+/// Unless you're storing the type of look constant to be used for a call, you
+/// likely want the constants which implement the `LookConstant` trait to make
+/// calls to look methods.
+///
+/// This is hidden from the documentation to avoid confusion due to its
+/// narrow use case, but wasm_bindgen requires it remain public.
+#[doc(hidden)]
 #[wasm_bindgen]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
 pub enum Look {

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -11,8 +11,8 @@ use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
     constants::{
-        look::*, Color, Direction, ErrorCode, ExitDirection, Find, FindConstant, PowerType,
-        ResourceType, ReturnCode, StructureType,
+        find::*, look::*, Color, Direction, ErrorCode, ExitDirection, PowerType, ResourceType,
+        ReturnCode, StructureType,
     },
     local::{LodashFilter, RoomName},
     objects::*,


### PR DESCRIPTION
`Find` and `Look` enums are used for internal calls and mapped via the structs generated by macros - the enums themselves are unlikely ever useful to the user unless they're trying to store/serialize which type of call they want to make, and even then it's difficult to get back to the version that could be used in a call to one of the find/look methods.

They must be public due to requirements of wasm_bindgen, but it makes sense to hide them from the docs and drop their re-exports to avoid confusion.