### PR TITLE
Add checked version of `Position::from_world_coords` and checked add operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ Unreleased
 - Remove `ReturnCode` and replace with `Result<(), ErrorCode>` (breaking)
 - Add feature `unsafe-return-conversion` that allows skipping bounds checks on return codes for all
   game functions using integer return codes, risking undefined behavior for values outside the
-  expected range.
+  expected range
+- Add `Position::checked_from_world_coords` allowing an error return instead of a panic for out of
+  bounds coordinates
+- Add `Position::checked_add` and `Position::checked_add_direction`, alternatives to `Add<_>` which
+  can error
 
 0.12.2 (2023-06-17)
 ===================

--- a/src/local.rs
+++ b/src/local.rs
@@ -21,6 +21,14 @@ const HALF_WORLD_SIZE: i32 = 128;
 /// Valid room name coordinates.
 const VALID_ROOM_NAME_COORDINATES: Range<i32> = -HALF_WORLD_SIZE..HALF_WORLD_SIZE;
 
+/// Valid world positions
+// not an inclusive range since the range for world coords is `-128..=127`, and
+// the range for room coords is `0..=49`.
+const VALID_WORLD_POSITIONS: Range<i32> =
+    -((ROOM_SIZE as i32) * HALF_WORLD_SIZE)..(ROOM_SIZE as i32) * HALF_WORLD_SIZE;
+
+use crate::ROOM_SIZE;
+
 pub use self::{
     cost_matrix::*, lodash_filter::*, object_id::*, position::*, room_coordinate::*, room_name::*,
 };

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -246,7 +246,7 @@ impl fmt::Display for Position {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct WorldPositionOutOfBoundsError(i32, i32);
+pub struct WorldPositionOutOfBoundsError(pub i32, pub i32);
 
 impl Position {
     /// Create a new Position

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -3,6 +3,7 @@
 //! This is a reimplementation/translation of the `RoomPosition` code originally
 //! written in JavaScript. All RoomPosition to RoomPosition operations in this
 //! file stay within Rust.
+use core::fmt::Debug;
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
     fmt,
@@ -243,6 +244,9 @@ impl fmt::Display for Position {
         )
     }
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WorldPositionOutOfBoundsError(i32, i32);
 
 impl Position {
     /// Create a new Position

--- a/src/local/position/world_utils.rs
+++ b/src/local/position/world_utils.rs
@@ -1,3 +1,5 @@
+use crate::local::{position::WorldPositionOutOfBoundsError, VALID_WORLD_POSITIONS};
+
 use super::{Position, HALF_WORLD_SIZE};
 
 impl Position {
@@ -42,37 +44,55 @@ impl Position {
     ///
     /// Panics if either x or y is out of the range `-128 * 50 .. +128 * 50`.
     ///
+    /// For a checked variant of this function, see
+    /// [`Position::checked_from_world_coords`].
+    ///
     /// See [`Position::world_coords`].
     #[inline]
+    #[track_caller]
     pub fn from_world_coords(x: i32, y: i32) -> Self {
-        // not inclusive since the range for world coords in `-128..=127`, and the range
-        // for room coords is `0..=49`.
-        assert!(
-            (-HALF_WORLD_SIZE * 50..HALF_WORLD_SIZE * 50).contains(&x),
-            "out of bounds world x: {x}"
-        );
-        assert!(
-            (-HALF_WORLD_SIZE * 50..HALF_WORLD_SIZE * 50).contains(&y),
-            "out of bounds world y: {y}"
-        );
+        Self::checked_from_world_coords(x, y).unwrap()
+    }
 
-        // We do the `HALF_WORLD_SIZE` transition here first so that the division and
-        // modulo operations work correctly.
-        let pos_x = (x + HALF_WORLD_SIZE * 50) as u32;
-        let pos_y = (y + HALF_WORLD_SIZE * 50) as u32;
-        let room_x = pos_x / 50;
-        let room_y = pos_y / 50;
-        let x = (pos_x % 50) as u8;
-        let y = (pos_y % 50) as u8;
+    /// Creates a room position from world coords if they are within the range
+    /// `-128 * 50 .. +128 * 50`. Otherwise returns `None`.
+    ///
+    /// For a panicing variant of this function, see
+    /// [`Position::from_world_coords`].
+    ///
+    /// See [`Position::world_coords`].
+    #[inline]
+    pub fn checked_from_world_coords(
+        x: i32,
+        y: i32,
+    ) -> Result<Self, WorldPositionOutOfBoundsError> {
+        if VALID_WORLD_POSITIONS.contains(&x) && VALID_WORLD_POSITIONS.contains(&y) {
+            // We do the `HALF_WORLD_SIZE` transition here first so that the division and
+            // modulo operations work correctly.
+            let pos_x = (x + HALF_WORLD_SIZE * 50) as u32;
+            let pos_y = (y + HALF_WORLD_SIZE * 50) as u32;
+            let room_x = pos_x / 50;
+            let room_y = pos_y / 50;
+            let x = (pos_x % 50) as u8;
+            let y = (pos_y % 50) as u8;
 
-        Self::from_coords_and_world_coords_adjusted(x, y, room_x, room_y)
+            Ok(Self::from_coords_and_world_coords_adjusted(
+                x, y, room_x, room_y,
+            ))
+        } else {
+            Err(WorldPositionOutOfBoundsError(x, y))
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::Position;
-    use crate::local::RoomCoordinate;
+    use crate::{
+        local::{position::WorldPositionOutOfBoundsError, RoomCoordinate},
+        ROOM_SIZE,
+    };
+    use core::ops::Range;
 
     const TEST_ROOM_NAMES: &[&str] = &[
         "E1N1", "E20N0", "W0N0", "E0N0", "W0S0", "E0S0", "W0N0", "E0N0", "W0S0", "E0S0", "W50S20",
@@ -99,6 +119,97 @@ mod test {
                     let (wx, wy) = original_pos.world_coords();
                     let new = Position::from_world_coords(wx, wy);
                     assert_eq!(original_pos, new);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn checked_world_coords() {
+        // this tests:
+        // - the 16 rooms around the center of the world
+        // - the 16 rooms around each corner of the max world size (12 of them are out
+        //   of bounds)
+
+        const ROOM_RANGE: Range<i32> = -((ROOM_SIZE as i32) * 2)..((ROOM_SIZE as i32) * 2);
+        for x in ROOM_RANGE {
+            for y in ROOM_RANGE {
+                let room_x = x.div_euclid(50);
+                let room_y = y.div_euclid(50);
+                let pos_x = x.rem_euclid(50) as u8;
+                let pos_y = y.rem_euclid(50) as u8;
+
+                let new_pos = Position::checked_from_world_coords(x, y).unwrap();
+                assert_eq!(room_x, new_pos.room_x());
+                assert_eq!(room_y, new_pos.room_y());
+                assert_eq!(pos_x, new_pos.x().u8());
+                assert_eq!(pos_y, new_pos.y().u8());
+            }
+        }
+
+        const CORNERS: [(i32, i32); 4] =
+            [(-6400, 6399), (6399, 6399), (-6400, -6400), (6399, 6400)];
+        for (corner_x, corner_y) in CORNERS {
+            for x in ROOM_RANGE {
+                for y in ROOM_RANGE {
+                    let x = corner_x + x;
+                    let y = corner_y + y;
+
+                    if x < -6400 || x > 6399 || y < -6400 || y > 6399 {
+                        assert_eq!(
+                            Err(WorldPositionOutOfBoundsError(x, y)),
+                            Position::checked_from_world_coords(x, y)
+                        );
+                    } else {
+                        let room_x = x.div_euclid(50);
+                        let room_y = y.div_euclid(50);
+                        let pos_x = x.rem_euclid(50) as u8;
+                        let pos_y = y.rem_euclid(50) as u8;
+
+                        let new_pos = Position::checked_from_world_coords(x, y).unwrap();
+                        assert_eq!(room_x, new_pos.room_x());
+                        assert_eq!(room_y, new_pos.room_y());
+                        assert_eq!(pos_x, new_pos.x().u8());
+                        assert_eq!(pos_y, new_pos.y().u8());
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "WorldPositionOutOfBoundsError(6400, 6400)")]
+    fn oob_world_coords_panic() {
+        // note: world coords are -6400..6400 (not including the end)
+        let _val = Position::from_world_coords(6400, 6400);
+    }
+
+    #[test]
+    #[should_panic(expected = "WorldPositionOutOfBoundsError(6400, 6399)")]
+    fn oob_coords_add() {
+        let pos = Position::from_world_coords(6395, 6399);
+        let _new_pos = pos + (5, 0);
+    }
+
+    // don't run this test if debug assertions are enabled, it won't complete
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn exhaustive_checked_world_coords() {
+        use crate::local::VALID_WORLD_POSITIONS;
+        // Test that the entire input space returns `Some` or `None` as expected.
+        // If this test completes in release mode, it means that the compiler is able to
+        // prove enough to optimize it away. If the test stops being instant,
+        // something went wrong with the implementation or the compiler (probably the
+        // implementation).
+        for x in i32::MIN..=i32::MAX {
+            for y in i32::MIN..=i32::MAX {
+                if VALID_WORLD_POSITIONS.contains(&x) && VALID_WORLD_POSITIONS.contains(&y) {
+                    assert!(matches!(Position::checked_from_world_coords(x, y), Ok(_)));
+                } else {
+                    assert_eq!(
+                        Err(WorldPositionOutOfBoundsError(x, y)),
+                        Position::checked_from_world_coords(x, y)
+                    );
                 }
             }
         }


### PR DESCRIPTION
This also implements `Position::from_world_coords` and several other methods in terms of `checked_from_world_coords`, and adds `#[track_caller]` so that the file and line number of the *caller* is used when the coords are out of bounds.

All checked operations can be expressed in terms of `Position::world_coords` and `Position::checked_from_world_coords`, but for convenience, checked versions of the `Add` impls are added.

With optimizations enabled, the compiler appears to be able to determine the valid range of inputs that produce `Ok` and `Err` and determine the value of the `Position` or error.  In fact, a check over the entirety of the input space gets compiled out to succeed instantly!  This unfortunately probably cannot be as useful in cases where positions and offsets are dynamically created, especially from JS, but it appears that the compiler can tell that the output of this function is in bounds anyway.