### PR TITLE
Fix bad property mapping for crate::raw_memory::ForeignSegment::id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
   of panicking when used in room not visible in the current tick (breaking)
 - Remove re-exports of `constants::find::Find` and `constants::look::Look` enums and mark them as
   hidden from docs, since they're likely to cause confusion and not generally needed (breaking)
+- Fix js property mapping for `crate::raw_memory::ForeignSegment::id`
 
 0.12.2 (2023-06-17)
 ===================

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -128,7 +128,7 @@ extern "C" {
     pub type ForeignSegment;
     #[wasm_bindgen(method, getter)]
     pub fn username(this: &ForeignSegment) -> JsString;
-    #[wasm_bindgen(method, getter = type)]
+    #[wasm_bindgen(method, getter)]
     pub fn id(this: &ForeignSegment) -> u8;
     #[wasm_bindgen(method, getter)]
     pub fn data(this: &ForeignSegment) -> JsString;


### PR DESCRIPTION
`raw_memory::ForeignSegment::id()` had a bad paste from elsewhere that accesses the wrong attribute.