### PR TITLE
Replace `ReturnCode` with `Result<(), ErrorCode>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
   hidden from docs, since they're likely to cause confusion and not generally needed (breaking)
 - Fix js property mapping for `crate::raw_memory::ForeignSegment::id`
 - Remove `ReturnCode` and replace with `Result<(), ErrorCode>` (breaking)
+- Add feature `unsafe-return-conversion` that allows skipping bounds checks on return codes for all
+  game functions using integer return codes, risking undefined behavior for values outside the
+  expected range.
 
 0.12.2 (2023-06-17)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - Remove re-exports of `constants::find::Find` and `constants::look::Look` enums and mark them as
   hidden from docs, since they're likely to cause confusion and not generally needed (breaking)
 - Fix js property mapping for `crate::raw_memory::ForeignSegment::id`
+- Remove `ReturnCode` and replace with `Result<(), ErrorCode>` (breaking)
 
 0.12.2 (2023-06-17)
 ===================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ symbols = []
 # Enable thorium resource and reactor structure - used in season 5
 thorium = []
 
+# Enable unsafe conversions of return codes with undefined behavior when values
+# aren't in the expected range
+unsafe-return-conversion = []
+
 ## Sets of the above features for different server environments
 
 # Official MMO server features, not present on other environments

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -40,7 +40,7 @@ pub mod creep {
             MAX_CREEP_SIZE, RANGED_HEAL_POWER, REPAIR_COST, REPAIR_POWER, SPAWN_RENEW_RATIO,
             UPGRADE_CONTROLLER_POWER,
         },
-        small_enums::{Part, ReturnCode},
+        small_enums::Part,
     };
 }
 

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -1,79 +1,17 @@
 //! Various constants translated as small enums.
-use std::{
-    convert::{Infallible, TryFrom},
-    fmt,
-    str::FromStr,
-};
+use std::{convert::Infallible, fmt, str::FromStr};
 
 use enum_iterator::Sequence;
 use js_sys::JsString;
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use wasm_bindgen::prelude::*;
 
-use crate::constants::find::{Exit, Find};
-
-// Bindgen does not correctly handle i8 negative return values. Use custom
-// return values.
-/// Translates return code constants.
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum ReturnCode {
-    Ok = 0,
-    NotOwner = -1,
-    NoPath = -2,
-    NameExists = -3,
-    Busy = -4,
-    NotFound = -5,
-    NotEnough = -6,
-    InvalidTarget = -7,
-    Full = -8,
-    NotInRange = -9,
-    InvalidArgs = -10,
-    Tired = -11,
-    NoBodypart = -12,
-    RclNotEnough = -14,
-    GclNotEnough = -15,
-}
-
-impl wasm_bindgen::convert::IntoWasmAbi for ReturnCode {
-    type Abi = i32;
-
-    #[inline]
-    fn into_abi(self) -> Self::Abi {
-        (self as i32).into_abi()
-    }
-}
-
-impl wasm_bindgen::convert::FromWasmAbi for ReturnCode {
-    type Abi = i32;
-
-    #[inline]
-    unsafe fn from_abi(js: i32) -> Self {
-        Self::from_i32(js).unwrap()
-    }
-}
-
-impl wasm_bindgen::describe::WasmDescribe for ReturnCode {
-    fn describe() {
-        wasm_bindgen::describe::inform(wasm_bindgen::describe::I32)
-    }
-}
-
-impl TryFrom<JsValue> for ReturnCode {
-    type Error = String;
-
-    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
-        value
-            .as_f64()
-            .and_then(|f| Self::from_i32(f as i32))
-            .ok_or_else(|| "expected number for return code".to_owned())
-    }
-}
+use crate::{
+    constants::find::{Exit, Find},
+    prelude::*,
+};
 
 /// Translates non-OK return codes.
 #[derive(
@@ -97,26 +35,49 @@ pub enum ErrorCode {
     GclNotEnough = -15,
 }
 
-impl From<ReturnCode> for Result<(), ErrorCode> {
-    fn from(value: ReturnCode) -> Self {
-        match value {
-            ReturnCode::Ok => Ok(()),
-            code => {
-                // SAFETY: ErrorCode is a duplicate of ReturnCode, minus the Ok variant that
-                // was covered above.
-                let err_code = unsafe { ErrorCode::from_i8(code as i8).unwrap_unchecked() };
-                Err(err_code)
-            }
+impl FromReturnCode for ErrorCode {
+    type Error = Self;
+
+    fn result_from_i8_unchecked(val: i8) -> Result<(), Self::Error> {
+        match val {
+            0 => Ok(()),
+            -1 => Err(ErrorCode::NotOwner),
+            -2 => Err(ErrorCode::NoPath),
+            -3 => Err(ErrorCode::NameExists),
+            -4 => Err(ErrorCode::Busy),
+            -5 => Err(ErrorCode::NotFound),
+            -6 => Err(ErrorCode::NotEnough),
+            -7 => Err(ErrorCode::InvalidTarget),
+            -8 => Err(ErrorCode::Full),
+            -9 => Err(ErrorCode::NotInRange),
+            -10 => Err(ErrorCode::InvalidArgs),
+            -11 => Err(ErrorCode::Tired),
+            -12 => Err(ErrorCode::NoBodypart),
+            -14 => Err(ErrorCode::RclNotEnough),
+            -15 => Err(ErrorCode::GclNotEnough),
+            // SAFETY: Return codes must always be one of the values already covered
+            _ => unsafe { std::hint::unreachable_unchecked() },
         }
     }
-}
 
-impl From<Result<(), ErrorCode>> for ReturnCode {
-    fn from(value: Result<(), ErrorCode>) -> Self {
-        match value {
-            Ok(_) => ReturnCode::Ok,
-            // SAFETY: all ErrorCodes are valid ReturnCodes.
-            Err(code) => unsafe { ReturnCode::from_i8(code as i8).unwrap_unchecked() },
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ErrorCode::NotOwner)),
+            -2 => Some(Err(ErrorCode::NoPath)),
+            -3 => Some(Err(ErrorCode::NameExists)),
+            -4 => Some(Err(ErrorCode::Busy)),
+            -5 => Some(Err(ErrorCode::NotFound)),
+            -6 => Some(Err(ErrorCode::NotEnough)),
+            -7 => Some(Err(ErrorCode::InvalidTarget)),
+            -8 => Some(Err(ErrorCode::Full)),
+            -9 => Some(Err(ErrorCode::NotInRange)),
+            -10 => Some(Err(ErrorCode::InvalidArgs)),
+            -11 => Some(Err(ErrorCode::Tired)),
+            -12 => Some(Err(ErrorCode::NoBodypart)),
+            -14 => Some(Err(ErrorCode::RclNotEnough)),
+            -15 => Some(Err(ErrorCode::GclNotEnough)),
+            _ => None,
         }
     }
 }

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -38,7 +38,7 @@ pub enum ErrorCode {
 impl FromReturnCode for ErrorCode {
     type Error = Self;
 
-    fn result_from_i8_unchecked(val: i8) -> Result<(), Self::Error> {
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         match val {
             0 => Ok(()),
             -1 => Err(ErrorCode::NotOwner),

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -56,7 +56,10 @@ impl FromReturnCode for ErrorCode {
             -14 => Err(ErrorCode::RclNotEnough),
             -15 => Err(ErrorCode::GclNotEnough),
             // SAFETY: Return codes must always be one of the values already covered
+            #[cfg(feature = "unsafe-return-conversion")]
             _ => unsafe { std::hint::unreachable_unchecked() },
+            #[cfg(not(feature = "unsafe-return-conversion"))]
+            _ => unreachable!(),
         }
     }
 

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -123,7 +123,7 @@ pub fn halt() {
 ///
 /// [`CPU_SET_SHARD_LIMITS_COOLDOWN`]: crate::constants::CPU_SET_SHARD_LIMITS_COOLDOWN
 pub fn set_shard_limits(limits: &Object) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(Cpu::set_shard_limits(limits))
+    ErrorCode::result_from_i8(Cpu::set_shard_limits(limits))
 }
 
 /// Consume a [`CpuUnlock`] to unlock your full CPU for 24 hours.
@@ -132,7 +132,7 @@ pub fn set_shard_limits(limits: &Object) -> Result<(), ErrorCode> {
 ///
 /// [`CpuUnlock`]: crate::constants::IntershardResourceType::CpuUnlock
 pub fn unlock() -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(Cpu::unlock())
+    ErrorCode::result_from_i8(Cpu::unlock())
 }
 
 /// Generate a [`Pixel`], consuming [`PIXEL_CPU_COST`] CPU from your bucket.
@@ -143,7 +143,7 @@ pub fn unlock() -> Result<(), ErrorCode> {
 /// [`PIXEL_CPU_COST`]: crate::constants::PIXEL_CPU_COST
 #[cfg(feature = "generate-pixel")]
 pub fn generate_pixel() -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(Cpu::generate_pixel())
+    ErrorCode::result_from_i8(Cpu::generate_pixel())
 }
 
 #[wasm_bindgen]

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -4,7 +4,7 @@
 use js_sys::{JsString, Object};
 use wasm_bindgen::prelude::*;
 
-use crate::{constants::ReturnCode, js_collections::JsHashMap};
+use crate::{constants::ErrorCode, prelude::*};
 
 #[wasm_bindgen]
 extern "C" {
@@ -39,14 +39,14 @@ extern "C" {
     fn halt();
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = setShardLimits)]
-    fn set_shard_limits(limits: &Object) -> ReturnCode;
+    fn set_shard_limits(limits: &Object) -> i8;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = unlock)]
-    fn unlock() -> ReturnCode;
+    fn unlock() -> i8;
 
     #[cfg(feature = "generate-pixel")]
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = generatePixel)]
-    fn generate_pixel() -> ReturnCode;
+    fn generate_pixel() -> i8;
 }
 
 /// Your assigned CPU for the current shard.
@@ -122,8 +122,8 @@ pub fn halt() {
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.setShardLimits)
 ///
 /// [`CPU_SET_SHARD_LIMITS_COOLDOWN`]: crate::constants::CPU_SET_SHARD_LIMITS_COOLDOWN
-pub fn set_shard_limits(limits: &Object) -> ReturnCode {
-    Cpu::set_shard_limits(limits)
+pub fn set_shard_limits(limits: &Object) -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(Cpu::set_shard_limits(limits))
 }
 
 /// Consume a [`CpuUnlock`] to unlock your full CPU for 24 hours.
@@ -131,8 +131,8 @@ pub fn set_shard_limits(limits: &Object) -> ReturnCode {
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.unlock)
 ///
 /// [`CpuUnlock`]: crate::constants::IntershardResourceType::CpuUnlock
-pub fn unlock() -> ReturnCode {
-    Cpu::unlock()
+pub fn unlock() -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(Cpu::unlock())
 }
 
 /// Generate a [`Pixel`], consuming [`PIXEL_CPU_COST`] CPU from your bucket.
@@ -142,8 +142,8 @@ pub fn unlock() -> ReturnCode {
 /// [`Pixel`]: crate::constants::IntershardResourceType::Pixel
 /// [`PIXEL_CPU_COST`]: crate::constants::PIXEL_CPU_COST
 #[cfg(feature = "generate-pixel")]
-pub fn generate_pixel() -> ReturnCode {
-    Cpu::generate_pixel()
+pub fn generate_pixel() -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(Cpu::generate_pixel())
 }
 
 #[wasm_bindgen]

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -347,8 +347,8 @@ where
     if result >= 0 {
         Ok(ExitDirection::from_i8(result).expect("expected exit direction for pathing"))
     } else {
-        // SAFETY: can never be an `Ok()` return from `result_from_i8_unchecked` because
+        // SAFETY: can never be an `Ok()` return from `result_from_i8` because
         // non-negative values are handled by the first branch above
-        Err(unsafe { ErrorCode::result_from_i8_unchecked(result).unwrap_err_unchecked() })
+        Err(unsafe { ErrorCode::result_from_i8(result).unwrap_err_unchecked() })
     }
 }

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -1,7 +1,7 @@
 //! Game map related functionality.
 //!
 //! [Screeps documentation](https://docs.screeps.com/api/#Game-map)
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 
 use enum_iterator::Sequence;
 use js_sys::{Array, JsString, Object};
@@ -10,10 +10,10 @@ use serde::Deserialize;
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    constants::{Direction, ExitDirection, ReturnCode},
-    js_collections::JsHashMap,
+    constants::{Direction, ErrorCode, ExitDirection},
     local::RoomName,
     objects::RoomTerrain,
+    prelude::*,
 };
 
 #[wasm_bindgen]
@@ -25,7 +25,7 @@ extern "C" {
     fn describe_exits(room_name: &JsString) -> Object;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = findExit)]
-    fn find_exit(from_room: &JsString, to_room: &JsString, options: &JsValue) -> i32;
+    fn find_exit(from_room: &JsString, to_room: &JsString, options: &JsValue) -> i8;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "map", static_method_of = Map, js_name = findRoute)]
     fn find_route(from_room: &JsString, to_room: &JsString, options: &JsValue) -> JsValue;
@@ -290,7 +290,7 @@ pub fn find_route<F>(
     from: RoomName,
     to: RoomName,
     options: Option<FindRouteOptions<F>>,
-) -> Result<Vec<RouteStep>, ReturnCode>
+) -> Result<Vec<RouteStep>, ErrorCode>
 where
     F: FnMut(RoomName, RoomName) -> f64,
 {
@@ -313,10 +313,12 @@ where
 
         Ok(steps)
     } else {
-        let return_code =
-            ReturnCode::try_from(result).expect("expected return code for pathing failure");
-
-        Err(return_code)
+        // SAFETY: can never be a 0 return from the find_route API function
+        Err(unsafe {
+            ErrorCode::try_result_from_jsvalue(&result)
+                .expect("expected return code for pathing failure")
+                .unwrap_err_unchecked()
+        })
     }
 }
 
@@ -329,7 +331,7 @@ pub fn find_exit<F>(
     from: RoomName,
     to: RoomName,
     options: Option<FindRouteOptions<F>>,
-) -> Result<ExitDirection, ReturnCode>
+) -> Result<ExitDirection, ErrorCode>
 where
     F: FnMut(RoomName, RoomName) -> f64,
 {
@@ -343,8 +345,10 @@ where
     };
 
     if result >= 0 {
-        Ok(ExitDirection::from_i32(result).expect("expected exit direction for pathing"))
+        Ok(ExitDirection::from_i8(result).expect("expected exit direction for pathing"))
     } else {
-        Err(ReturnCode::from_i32(result).expect("expected return code for pathing failure"))
+        // SAFETY: can never be an `Ok()` return from `result_from_i8_unchecked` because
+        // non-negative values are handled by the first branch above
+        Err(unsafe { ErrorCode::result_from_i8_unchecked(result).unwrap_err_unchecked() })
     }
 }

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -5,9 +5,9 @@ use js_sys::{Array, JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    constants::{MarketResourceType, OrderType, ResourceType, ReturnCode},
-    js_collections::{JsCollectionFromValue, JsHashMap},
+    constants::{ErrorCode, MarketResourceType, OrderType, ResourceType},
     local::{LodashFilter, RoomName},
+    prelude::*,
 };
 
 #[wasm_bindgen]
@@ -31,19 +31,19 @@ extern "C" {
     fn calc_transaction_cost(amount: u32, room_1: &JsString, room_2: &JsString) -> u32;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = cancelOrder)]
-    fn cancel_order(order_id: &JsString) -> ReturnCode;
+    fn cancel_order(order_id: &JsString) -> i8;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = changeOrderPrice)]
-    fn change_order_price(order_id: &JsString, new_price: f64) -> ReturnCode;
+    fn change_order_price(order_id: &JsString, new_price: f64) -> i8;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = createOrder)]
-    fn create_order(order_parameters: &Object) -> ReturnCode;
+    fn create_order(order_parameters: &Object) -> i8;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = deal)]
-    fn deal(order_id: &JsString, amount: u32, room_name: Option<&JsString>) -> ReturnCode;
+    fn deal(order_id: &JsString, amount: u32, room_name: Option<&JsString>) -> i8;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = extendOrder)]
-    fn extend_order(order_id: &JsString, add_amount: u32) -> ReturnCode;
+    fn extend_order(order_id: &JsString, add_amount: u32) -> i8;
 
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "market", static_method_of = Market, js_name = getAllOrders)]
     fn get_all_orders(filter: Option<&LodashFilter>) -> Array;
@@ -106,8 +106,8 @@ pub fn calc_transaction_cost(amount: u32, room_1: &JsString, room_2: &JsString) 
 /// associated fees.
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.cancelOrder)
-pub fn cancel_order(order_id: &JsString) -> ReturnCode {
-    Market::cancel_order(order_id)
+pub fn cancel_order(order_id: &JsString) -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(Market::cancel_order(order_id))
 }
 
 /// Change the price of an existing order. If new_price is greater than old
@@ -117,16 +117,16 @@ pub fn cancel_order(order_id: &JsString) -> ReturnCode {
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.changeOrderPrice)
 ///
 /// [`MARKET_FEE`]: crate::constants::MARKET_FEE
-pub fn change_order_price(order_id: &JsString, new_price: f64) -> ReturnCode {
-    Market::change_order_price(order_id, new_price)
+pub fn change_order_price(order_id: &JsString, new_price: f64) -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(Market::change_order_price(order_id, new_price))
 }
 
 // todo type to serialize call options into
 /// Create a new order on the market.
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.createOrder)
-pub fn create_order(order_parameters: &Object) -> ReturnCode {
-    Market::create_order(order_parameters)
+pub fn create_order(order_parameters: &Object) -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(Market::create_order(order_parameters))
 }
 
 /// Execute a trade on an order on the market. Name of a room with a
@@ -134,19 +134,23 @@ pub fn create_order(order_parameters: &Object) -> ReturnCode {
 /// order is for an account resource.
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.deal)
-pub fn deal(order_id: &JsString, amount: u32, room_name: Option<RoomName>) -> ReturnCode {
-    match room_name {
+pub fn deal(
+    order_id: &JsString,
+    amount: u32,
+    room_name: Option<RoomName>,
+) -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(match room_name {
         Some(r) => Market::deal(order_id, amount, Some(&r.into())),
         None => Market::deal(order_id, amount, None),
-    }
+    })
 }
 
 /// Adds more capacity to one of your existing orders, offering or
 /// requesting more of the resource and incurring additional fees.
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.extendOrder)
-pub fn extend_order(order_id: &JsString, add_amount: u32) -> ReturnCode {
-    Market::extend_order(order_id, add_amount)
+pub fn extend_order(order_id: &JsString, add_amount: u32) -> Result<(), ErrorCode> {
+    ErrorCode::result_from_i8_unchecked(Market::extend_order(order_id, add_amount))
 }
 
 /// Get all [`Order`]s on the market, with an optional

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -107,7 +107,7 @@ pub fn calc_transaction_cost(amount: u32, room_1: &JsString, room_2: &JsString) 
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.cancelOrder)
 pub fn cancel_order(order_id: &JsString) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(Market::cancel_order(order_id))
+    ErrorCode::result_from_i8(Market::cancel_order(order_id))
 }
 
 /// Change the price of an existing order. If new_price is greater than old
@@ -118,7 +118,7 @@ pub fn cancel_order(order_id: &JsString) -> Result<(), ErrorCode> {
 ///
 /// [`MARKET_FEE`]: crate::constants::MARKET_FEE
 pub fn change_order_price(order_id: &JsString, new_price: f64) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(Market::change_order_price(order_id, new_price))
+    ErrorCode::result_from_i8(Market::change_order_price(order_id, new_price))
 }
 
 // todo type to serialize call options into
@@ -126,7 +126,7 @@ pub fn change_order_price(order_id: &JsString, new_price: f64) -> Result<(), Err
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.createOrder)
 pub fn create_order(order_parameters: &Object) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(Market::create_order(order_parameters))
+    ErrorCode::result_from_i8(Market::create_order(order_parameters))
 }
 
 /// Execute a trade on an order on the market. Name of a room with a
@@ -139,7 +139,7 @@ pub fn deal(
     amount: u32,
     room_name: Option<RoomName>,
 ) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(match room_name {
+    ErrorCode::result_from_i8(match room_name {
         Some(r) => Market::deal(order_id, amount, Some(&r.into())),
         None => Market::deal(order_id, amount, None),
     })
@@ -150,7 +150,7 @@ pub fn deal(
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.extendOrder)
 pub fn extend_order(order_id: &JsString, add_amount: u32) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8_unchecked(Market::extend_order(order_id, add_amount))
+    ErrorCode::result_from_i8(Market::extend_order(order_id, add_amount))
 }
 
 /// Get all [`Order`]s on the market, with an optional

--- a/src/js_collections.rs
+++ b/src/js_collections.rs
@@ -9,7 +9,7 @@ use std::{
 use js_sys::{Array, JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast};
 
-use crate::{game, local::RawObjectIdParseError, traits::Resolvable};
+use crate::{game, local::RawObjectIdParseError, prelude::*};
 
 #[wasm_bindgen]
 extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,12 @@
 //! Enables the thorium resource and reactor object, introduced for Screeps
 //! Seasonal's fifth season.
 //!
+//! ## `unsafe-return-conversion`
+//!
+//! Enables return code conversion from game functions that presumes all return
+//! code values are in the expected ranges skipping checks, and risks undefined
+//! behavior if they are not.
+//!
 //! ## `mmo`
 //!
 //! Enables the `generate-pixel` and `inter-shard-memory` features, which are

--- a/src/local/position/game_methods.rs
+++ b/src/local/position/game_methods.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     constants::{
         look::{LookConstant, LookResult},
-        Color, ErrorCode, FindConstant, ReturnCode, StructureType,
+        Color, ErrorCode, FindConstant, StructureType,
     },
     local::{RoomCoordinate, RoomName},
     objects::{CostMatrix, FindPathOptions, Path, RoomPosition},
@@ -28,7 +28,7 @@ impl Position {
         self,
         ty: StructureType,
         name: Option<&JsString>,
-    ) -> ReturnCode {
+    ) -> Result<(), ErrorCode> {
         RoomPosition::from(self).create_construction_site(ty, name)
     }
 

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -11,7 +11,7 @@ use arrayvec::ArrayString;
 use js_sys::JsString;
 use wasm_bindgen::{JsCast, JsValue};
 
-use crate::js_collections::{JsCollectionFromValue, JsCollectionIntoValue};
+use crate::prelude::*;
 
 use super::{HALF_WORLD_SIZE, VALID_ROOM_NAME_COORDINATES};
 

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    constants::{ReturnCode, StructureType},
+    constants::{ErrorCode, StructureType},
     objects::{Owner, RoomObject},
     prelude::*,
 };
@@ -17,55 +17,81 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type ConstructionSite;
 
-    /// The Object ID of the [`ConstructionSite`], or `None` if it was created
-    /// this tick.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.id)
     #[wasm_bindgen(method, getter = id)]
     fn id_internal(this: &ConstructionSite) -> Option<JsString>;
 
+    #[wasm_bindgen(method, getter = my)]
+    fn my_internal(this: &ConstructionSite) -> bool;
+
+    #[wasm_bindgen(method, getter = owner)]
+    fn owner_internal(this: &ConstructionSite) -> Owner;
+
+    #[wasm_bindgen(method, getter = progress)]
+    fn progress_internal(this: &ConstructionSite) -> u32;
+
+    #[wasm_bindgen(method, getter = progressTotal)]
+    fn progress_total_internal(this: &ConstructionSite) -> u32;
+
+    #[wasm_bindgen(method, getter = structureType)]
+    fn structure_type_internal(this: &ConstructionSite) -> StructureType;
+
+    #[wasm_bindgen(method, js_name = remove)]
+    fn remove_internal(this: &ConstructionSite) -> i8;
+}
+
+impl ConstructionSite {
     /// Whether you own the [`ConstructionSite`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.my)
-    #[wasm_bindgen(method, getter)]
-    pub fn my(this: &ConstructionSite) -> bool;
+    pub fn my(&self) -> bool {
+        self.my_internal()
+    }
 
     /// The [`Owner`] of this construction site, which contains the owner's
     /// username.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.owner)
-    #[wasm_bindgen(method, getter)]
-    pub fn owner(this: &ConstructionSite) -> Owner;
+    pub fn owner(&self) -> Owner {
+        self.owner_internal()
+    }
 
     /// The current progress toward completion of the structure being built.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.progress)
-    #[wasm_bindgen(method, getter)]
-    pub fn progress(this: &ConstructionSite) -> u32;
+    pub fn progress(&self) -> u32 {
+        self.progress_internal()
+    }
 
     /// The total progess toward constuction progress needed for the structure
     /// to be completed.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.progressTotal)
-    #[wasm_bindgen(method, getter = progressTotal)]
-    pub fn progress_total(this: &ConstructionSite) -> u32;
+    pub fn progress_total(&self) -> u32 {
+        self.progress_total_internal()
+    }
 
     /// The type of structure being constructed.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure.structureType)
-    #[wasm_bindgen(method, getter = structureType)]
-    pub fn structure_type(this: &ConstructionSite) -> StructureType;
+    pub fn structure_type(&self) -> StructureType {
+        self.structure_type_internal()
+    }
 
     /// Remove the [`ConstructionSite`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.remove)
-    #[wasm_bindgen(method)]
-    pub fn remove(this: &ConstructionSite) -> ReturnCode;
+    pub fn remove(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.remove_internal())
+    }
 }
 
 impl MaybeHasNativeId for ConstructionSite {
+    /// The Object ID of the [`ConstructionSite`], or `None` if it was created
+    /// this tick.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.id)
     fn try_native_id(&self) -> Option<JsString> {
-        Self::id_internal(self)
+        self.id_internal()
     }
 }
 

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -81,7 +81,7 @@ impl ConstructionSite {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.remove)
     pub fn remove(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.remove_internal())
+        ErrorCode::result_from_i8(self.remove_internal())
     }
 }
 

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -263,7 +263,7 @@ impl Creep {
     where
         T: ?Sized + Attackable,
     {
-        ErrorCode::result_from_i8_unchecked(self.attack_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.attack_internal(target.as_ref()))
     }
 
     /// Attack a [`StructureController`] in melee range using a creep's claim
@@ -271,7 +271,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.attackController)
     pub fn attack_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.attack_controller_internal(target))
+        ErrorCode::result_from_i8(self.attack_controller_internal(target))
     }
 
     /// Use a creep's work parts to consume carried energy, putting it toward
@@ -279,7 +279,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.build)
     pub fn build(&self, target: &ConstructionSite) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.build_internal(target))
+        ErrorCode::result_from_i8(self.build_internal(target))
     }
 
     /// Cancel an a successfully called creep function from earlier in the tick,
@@ -288,7 +288,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.cancelOrder)
     pub fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.cancel_order_internal(target))
+        ErrorCode::result_from_i8(self.cancel_order_internal(target))
     }
 
     /// Claim an unowned [`StructureController`] in melee range as your own
@@ -296,7 +296,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.claimController)
     pub fn claim_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.claim_controller_internal(target))
+        ErrorCode::result_from_i8(self.claim_controller_internal(target))
     }
 
     /// Claim a [`Reactor`] in melee range as your own using a creep's claim
@@ -305,7 +305,7 @@ impl Creep {
     /// [Screeps documentation](https://docs-season.screeps.com/api/#Creep.claimReactor)
     #[cfg(feature = "thorium")]
     pub fn claim_reactor(&self, target: &Reactor) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.claim_reactor_internal(target))
+        ErrorCode::result_from_i8(self.claim_reactor_internal(target))
     }
 
     /// Dismantle a [`Structure`] in melee range, removing [`DISMANTLE_POWER`]
@@ -323,14 +323,14 @@ impl Creep {
     where
         T: ?Sized + Dismantleable,
     {
-        ErrorCode::result_from_i8_unchecked(self.dismantle_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.dismantle_internal(target.as_ref()))
     }
 
     /// Drop a resource on the ground from the creep's [`Store`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.drop)
     pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.drop_internal(ty, amount))
+        ErrorCode::result_from_i8(self.drop_internal(ty, amount))
     }
 
     /// Consume [`ResourceType::Ghodium`] (in the amount of [`SAFE_MODE_COST`])
@@ -341,7 +341,7 @@ impl Creep {
     ///
     /// [`SAFE_MODE_COST`]: crate::constants::SAFE_MODE_COST
     pub fn generate_safe_mode(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.generate_safe_mode_internal(target))
+        ErrorCode::result_from_i8(self.generate_safe_mode_internal(target))
     }
 
     /// Get the number of parts of the given type the creep has in its body,
@@ -363,7 +363,7 @@ impl Creep {
     where
         T: ?Sized + Harvestable,
     {
-        ErrorCode::result_from_i8_unchecked(self.harvest_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.harvest_internal(target.as_ref()))
     }
 
     /// Heal a [`Creep`] or [`PowerCreep`] in melee range, including itself.
@@ -375,21 +375,21 @@ impl Creep {
     where
         T: ?Sized + Healable,
     {
-        ErrorCode::result_from_i8_unchecked(self.heal_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.heal_internal(target.as_ref()))
     }
 
     /// Move one square in the specified direction.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.move)
     pub fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.move_direction_internal(direction))
+        ErrorCode::result_from_i8(self.move_direction_internal(direction))
     }
 
     /// Accept an attempt by another creep to pull this one.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.move)
     pub fn move_pulled_by(&self, target: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.move_pulled_by_internal(target))
+        ErrorCode::result_from_i8(self.move_pulled_by_internal(target))
     }
 
     /// Move the creep along a previously determined path returned from a
@@ -397,14 +397,14 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.moveByPath)
     pub fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.move_by_path_internal(path))
+        ErrorCode::result_from_i8(self.move_by_path_internal(path))
     }
 
     /// Whether to send an email notification when this creep is attacked.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.notifyWhenAttacked)
     pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.notify_when_attacked_internal(enabled))
+        ErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
     }
 
     /// Pick up a [`Resource`] in melee range (or at the same position as the
@@ -412,14 +412,14 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.pickup)
     pub fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.pickup_internal(target))
+        ErrorCode::result_from_i8(self.pickup_internal(target))
     }
 
     /// Help another creep to move by pulling, if the second creep accepts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.pull)
     pub fn pull(&self, target: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.pull_internal(target))
+        ErrorCode::result_from_i8(self.pull_internal(target))
     }
 
     /// Attack a target in range 3 using a creep's ranged attack parts.
@@ -429,7 +429,7 @@ impl Creep {
     where
         T: ?Sized + Attackable,
     {
-        ErrorCode::result_from_i8_unchecked(self.ranged_attack_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.ranged_attack_internal(target.as_ref()))
     }
 
     /// Heal a target in range 3 using a creep's heal parts.
@@ -439,7 +439,7 @@ impl Creep {
     where
         T: ?Sized + Healable,
     {
-        ErrorCode::result_from_i8_unchecked(self.ranged_heal_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.ranged_heal_internal(target.as_ref()))
     }
 
     /// Attack all enemy targets in range using a creep's ranged attack parts,
@@ -447,7 +447,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedMassAttack)
     pub fn ranged_mass_attack(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.ranged_mass_attack_internal())
+        ErrorCode::result_from_i8(self.ranged_mass_attack_internal())
     }
 
     /// Repair a target in range 3 using carried energy and the creep's work
@@ -455,7 +455,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.repair)
     pub fn repair(&self, target: &RoomObject) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.repair_internal(target))
+        ErrorCode::result_from_i8(self.repair_internal(target))
     }
 
     /// Reserve an unowned [`StructureController`] in melee range using a
@@ -463,7 +463,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.reserveController)
     pub fn reserve_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.reserve_controller_internal(target))
+        ErrorCode::result_from_i8(self.reserve_controller_internal(target))
     }
 
     /// Display a string in a bubble above the creep next tick. 10 character
@@ -471,7 +471,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.say)
     pub fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.say_internal(message, public))
+        ErrorCode::result_from_i8(self.say_internal(message, public))
     }
 
     /// Add (or remove, using an empty string) a sign to a
@@ -483,7 +483,7 @@ impl Creep {
         target: &StructureController,
         text: &str,
     ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.sign_controller_internal(target, text))
+        ErrorCode::result_from_i8(self.sign_controller_internal(target, text))
     }
 
     /// Immediately kill the creep.
@@ -492,7 +492,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.suicide)
     pub fn suicide(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.suicide_internal())
+        ErrorCode::result_from_i8(self.suicide_internal())
     }
 
     /// Upgrade a [`StructureController`] in range 3 using carried energy and
@@ -500,7 +500,7 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.upgradeController)
     pub fn upgrade_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.upgrade_controller_internal(target))
+        ErrorCode::result_from_i8(self.upgrade_controller_internal(target))
     }
 }
 
@@ -582,7 +582,7 @@ impl SharedCreepProperties for Creep {
         T: HasPosition,
     {
         let target: RoomPosition = target.pos().into();
-        ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
+        ErrorCode::result_from_i8(self.move_to_internal(&target, &JsValue::UNDEFINED))
     }
 
     fn move_to_with_options<T, F>(
@@ -598,10 +598,10 @@ impl SharedCreepProperties for Creep {
 
         if let Some(options) = options {
             options.into_js_options(|js_options| {
-                ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, js_options))
+                ErrorCode::result_from_i8(self.move_to_internal(&target, js_options))
             })
         } else {
-            ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
+            ErrorCode::result_from_i8(self.move_to_internal(&target, &JsValue::UNDEFINED))
         }
     }
 
@@ -630,7 +630,7 @@ impl SharedCreepProperties for Creep {
     where
         T: Transferable,
     {
-        ErrorCode::result_from_i8_unchecked(self.transfer_internal(target.as_ref(), ty, amount))
+        ErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
     }
 
     fn withdraw<T>(
@@ -642,7 +642,7 @@ impl SharedCreepProperties for Creep {
     where
         T: Withdrawable,
     {
-        ErrorCode::result_from_i8_unchecked(self.withdraw_internal(target.as_ref(), ty, amount))
+        ErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
     }
 }
 

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -2,7 +2,7 @@ use js_sys::{Array, JsString};
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    constants::{Direction, Part, ResourceType, ReturnCode},
+    constants::{Direction, ErrorCode, Part, ResourceType},
     objects::{
         ConstructionSite, Owner, Resource, RoomObject, Store, Structure, StructureController,
     },
@@ -26,133 +26,312 @@ extern "C" {
     #[wasm_bindgen(method, getter = body)]
     fn body_internal(this: &Creep) -> Array;
 
+    #[wasm_bindgen(method, getter = fatigue)]
+    fn fatigue_internal(this: &Creep) -> u32;
+
+    #[wasm_bindgen(method, getter = hits)]
+    fn hits_internal(this: &Creep) -> u32;
+
+    #[wasm_bindgen(method, getter = hitsMax)]
+    fn hits_max_internal(this: &Creep) -> u32;
+
+    #[wasm_bindgen(method, getter = id)]
+    fn id_internal(this: &Creep) -> Option<JsString>;
+
+    #[wasm_bindgen(method, getter = memory)]
+    fn memory_internal(this: &Creep) -> JsValue;
+
+    #[wasm_bindgen(method, setter = memory)]
+    fn set_memory_internal(this: &Creep, val: &JsValue);
+
+    #[wasm_bindgen(method, getter = my)]
+    fn my_internal(this: &Creep) -> bool;
+
+    #[wasm_bindgen(method, getter = name)]
+    fn name_internal(this: &Creep) -> JsString;
+
+    #[wasm_bindgen(method, getter = owner)]
+    fn owner_internal(this: &Creep) -> Owner;
+
+    #[wasm_bindgen(method, getter = saying)]
+    fn saying_internal(this: &Creep) -> Option<JsString>;
+
+    #[wasm_bindgen(method, getter = spawning)]
+    fn spawning_internal(this: &Creep) -> bool;
+
+    #[wasm_bindgen(final, method, getter = store)]
+    fn store_internal(this: &Creep) -> Store;
+
+    #[wasm_bindgen(method, getter = ticksToLive)]
+    fn ticks_to_live_internal(this: &Creep) -> Option<u32>;
+
+    #[wasm_bindgen(final, method, js_name = attack)]
+    fn attack_internal(this: &Creep, target: &RoomObject) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = attackController)]
+    fn attack_controller_internal(this: &Creep, target: &StructureController) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = build)]
+    fn build_internal(this: &Creep, target: &ConstructionSite) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = cancelOrder)]
+    fn cancel_order_internal(this: &Creep, target: &JsString) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = claimController)]
+    fn claim_controller_internal(this: &Creep, target: &StructureController) -> i8;
+
+    #[cfg(feature = "thorium")]
+    #[wasm_bindgen(final, method, js_name = claimReactor)]
+    fn claim_reactor_internal(this: &Creep, target: &Reactor) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = dismantle)]
+    fn dismantle_internal(this: &Creep, target: &Structure) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = drop)]
+    fn drop_internal(this: &Creep, ty: ResourceType, amount: Option<u32>) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = generateSafeMode)]
+    fn generate_safe_mode_internal(this: &Creep, target: &StructureController) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = getActiveBodyparts)]
+    fn get_active_bodyparts_internal(this: &Creep, ty: Part) -> u8;
+
+    #[wasm_bindgen(final, method, js_name = harvest)]
+    fn harvest_internal(this: &Creep, target: &RoomObject) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = heal)]
+    fn heal_internal(this: &Creep, target: &RoomObject) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = move)]
+    fn move_direction_internal(this: &Creep, direction: Direction) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = move)]
+    fn move_pulled_by_internal(this: &Creep, target: &Creep) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = moveByPath)]
+    fn move_by_path_internal(this: &Creep, path: &JsValue) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = moveTo)]
+    fn move_to_internal(this: &Creep, target: &JsValue, options: &JsValue) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = notifyWhenAttacked)]
+    fn notify_when_attacked_internal(this: &Creep, enabled: bool) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = pickup)]
+    fn pickup_internal(this: &Creep, target: &Resource) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = pull)]
+    fn pull_internal(this: &Creep, target: &Creep) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = rangedAttack)]
+    fn ranged_attack_internal(this: &Creep, target: &RoomObject) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = rangedHeal)]
+    fn ranged_heal_internal(this: &Creep, target: &RoomObject) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = rangedMassAttack)]
+    fn ranged_mass_attack_internal(this: &Creep) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = repair)]
+    fn repair_internal(this: &Creep, target: &RoomObject) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = reserveController)]
+    fn reserve_controller_internal(this: &Creep, target: &StructureController) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = say)]
+    fn say_internal(this: &Creep, message: &str, public: bool) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = signController)]
+    fn sign_controller_internal(this: &Creep, target: &StructureController, text: &str) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = suicide)]
+    fn suicide_internal(this: &Creep) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = transfer)]
+    fn transfer_internal(
+        this: &Creep,
+        target: &RoomObject,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = upgradeController)]
+    fn upgrade_controller_internal(this: &Creep, target: &StructureController) -> i8;
+
+    #[wasm_bindgen(final, method, js_name = withdraw)]
+    fn withdraw_internal(
+        this: &Creep,
+        target: &RoomObject,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> i8;
+}
+
+impl Creep {
+    /// Retrieve a [`Vec<BodyPart>`] containing details about the creep's body
+    /// parts and boosts.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.body)
+    pub fn body(&self) -> Vec<BodyPart> {
+        self.body_internal().iter().map(BodyPart::from).collect()
+    }
+
     /// The amount of fatigue the creep has. If greater than 0, it cannot move
     /// this tick without being pulled.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.fatigue)
-    #[wasm_bindgen(method, getter)]
-    pub fn fatigue(this: &Creep) -> u32;
+    pub fn fatigue(&self) -> u32 {
+        self.fatigue_internal()
+    }
 
     /// Retrieve the current hits of this creep.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.hits)
-    #[wasm_bindgen(method, getter)]
-    pub fn hits(this: &Creep) -> u32;
+    pub fn hits(&self) -> u32 {
+        self.hits_internal()
+    }
 
     /// Retrieve the maximum hits of this creep, which generally equals 50 per
     /// body part.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.hitsMax)
-    #[wasm_bindgen(method, getter = hitsMax)]
-    pub fn hits_max(this: &Creep) -> u32;
-
-    /// Object ID of the creep, which can be used to efficiently fetch a fresh
-    /// reference to the object on subsequent ticks.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.id)
-    #[wasm_bindgen(method, getter = id)]
-    fn id_internal(this: &Creep) -> Option<JsString>;
+    pub fn hits_max(&self) -> u32 {
+        self.hits_max_internal()
+    }
 
     /// A shortcut to `Memory.creeps[creep.name]`.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.memory)
-    #[wasm_bindgen(method, getter)]
-    pub fn memory(this: &Creep) -> JsValue;
+    pub fn memory(&self) -> JsValue {
+        self.memory_internal()
+    }
 
     /// Sets a new value to `Memory.creeps[creep.name]`.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.memory)
-    #[wasm_bindgen(method, setter)]
-    pub fn set_memory(this: &Creep, val: &JsValue);
+    pub fn set_memory(&self, val: &JsValue) {
+        self.set_memory_internal(val)
+    }
 
     /// Whether this creep is owned by the player.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.my)
-    #[wasm_bindgen(method, getter)]
-    pub fn my(this: &Creep) -> bool;
-
-    #[wasm_bindgen(method, getter = name)]
-    fn name_internal(this: &Creep) -> JsString;
+    pub fn my(&self) -> bool {
+        self.my_internal()
+    }
 
     /// The [`Owner`] of this creep that contains the owner's username.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.owner)
-    #[wasm_bindgen(method, getter)]
-    pub fn owner(this: &Creep) -> Owner;
+    pub fn owner(&self) -> Owner {
+        self.owner_internal()
+    }
 
     /// What the creep said last tick.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.saying)
-    #[wasm_bindgen(method, getter)]
-    pub fn saying(this: &Creep) -> Option<JsString>;
+    pub fn saying(&self) -> Option<JsString> {
+        self.saying_internal()
+    }
 
     /// Whether the creep is still spawning.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.spawning)
-    #[wasm_bindgen(method, getter)]
-    pub fn spawning(this: &Creep) -> bool;
+    pub fn spawning(&self) -> bool {
+        self.spawning_internal()
+    }
 
     /// The [`Store`] of the creep, which contains information about what
     /// resources it is it carrying.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.store)
-    #[wasm_bindgen(final, method, getter)]
-    pub fn store(this: &Creep) -> Store;
+    pub fn store(&self) -> Store {
+        self.store_internal()
+    }
 
     /// The number of ticks the creep has left to live
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.ticksToLive)
-    #[wasm_bindgen(method, getter = ticksToLive)]
-    pub fn ticks_to_live(this: &Creep) -> Option<u32>;
+    pub fn ticks_to_live(&self) -> Option<u32> {
+        self.ticks_to_live_internal()
+    }
 
-    #[wasm_bindgen(final, method, js_name = attack)]
-    fn attack_internal(this: &Creep, target: &RoomObject) -> ReturnCode;
+    /// Attack a target in melee range using a creep's attack parts.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.attack)
+    pub fn attack<T>(&self, target: &T) -> Result<(), ErrorCode>
+    where
+        T: ?Sized + Attackable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.attack_internal(target.as_ref()))
+    }
 
     /// Attack a [`StructureController`] in melee range using a creep's claim
     /// parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.attackController)
-    #[wasm_bindgen(final, method, js_name = attackController)]
-    pub fn attack_controller(this: &Creep, target: &StructureController) -> ReturnCode;
+    pub fn attack_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.attack_controller_internal(target))
+    }
 
     /// Use a creep's work parts to consume carried energy, putting it toward
     /// progress in a [`ConstructionSite`] in range 3.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.build)
-    #[wasm_bindgen(final, method)]
-    pub fn build(this: &Creep, target: &ConstructionSite) -> ReturnCode;
+    pub fn build(&self, target: &ConstructionSite) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.build_internal(target))
+    }
 
     /// Cancel an a successfully called creep function from earlier in the tick,
     /// with a [`JsString`] that must contain the JS version of the function
     /// name.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.cancelOrder)
-    #[wasm_bindgen(final, method, js_name = cancelOrder)]
-    pub fn cancel_order(this: &Creep, target: &JsString) -> ReturnCode;
+    pub fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.cancel_order_internal(target))
+    }
 
     /// Claim an unowned [`StructureController`] in melee range as your own
     /// using a creep's claim parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.claimController)
-    #[wasm_bindgen(final, method, js_name = claimController)]
-    pub fn claim_controller(this: &Creep, target: &StructureController) -> ReturnCode;
+    pub fn claim_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.claim_controller_internal(target))
+    }
 
     /// Claim a [`Reactor`] in melee range as your own using a creep's claim
     /// parts.
     ///
     /// [Screeps documentation](https://docs-season.screeps.com/api/#Creep.claimReactor)
     #[cfg(feature = "thorium")]
-    #[wasm_bindgen(final, method, js_name = claimReactor)]
-    pub fn claim_reactor(this: &Creep, target: &Reactor) -> ReturnCode;
+    pub fn claim_reactor(&self, target: &Reactor) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.claim_reactor_internal(target))
+    }
 
-    #[wasm_bindgen(final, method, js_name = dismantle)]
-    fn dismantle_internal(this: &Creep, target: &Structure) -> ReturnCode;
+    /// Dismantle a [`Structure`] in melee range, removing [`DISMANTLE_POWER`]
+    /// hits per effective work part, giving the creep energy equivalent to half
+    /// of the cost to repair the same hits. Can only be used against types
+    /// of structures that can be constructed; if
+    /// [`StructureType::construction_cost`] is `None`, dismantling is
+    /// impossible.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.dismantle)
+    ///
+    /// [`DISMANTLE_POWER`]: crate::constants::DISMANTLE_POWER
+    /// [`StructureType::construction_cost`]: crate::constants::StructureType::construction_cost
+    pub fn dismantle<T>(&self, target: &T) -> Result<(), ErrorCode>
+    where
+        T: ?Sized + Dismantleable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.dismantle_internal(target.as_ref()))
+    }
 
     /// Drop a resource on the ground from the creep's [`Store`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.drop)
-    #[wasm_bindgen(final, method)]
-    pub fn drop(this: &Creep, ty: ResourceType, amount: Option<u32>) -> ReturnCode;
+    pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.drop_internal(ty, amount))
+    }
 
     /// Consume [`ResourceType::Ghodium`] (in the amount of [`SAFE_MODE_COST`])
     /// from the creep's [`Store`] to add a safe mode activation to a
@@ -161,146 +340,310 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.generateSafeMode)
     ///
     /// [`SAFE_MODE_COST`]: crate::constants::SAFE_MODE_COST
-    #[wasm_bindgen(final, method, js_name = generateSafeMode)]
-    pub fn generate_safe_mode(this: &Creep, target: &StructureController) -> ReturnCode;
+    pub fn generate_safe_mode(&self, target: &StructureController) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.generate_safe_mode_internal(target))
+    }
 
     /// Get the number of parts of the given type the creep has in its body,
     /// excluding fully damaged parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.getActiveBodyparts)
-    #[wasm_bindgen(final, method, js_name = getActiveBodyparts)]
-    pub fn get_active_bodyparts(this: &Creep, ty: Part) -> u8;
+    pub fn get_active_bodyparts(&self, ty: Part) -> u8 {
+        self.get_active_bodyparts_internal(ty)
+    }
 
-    #[wasm_bindgen(final, method, js_name = harvest)]
-    fn harvest_internal(this: &Creep, target: &RoomObject) -> ReturnCode;
+    /// Harvest from a [`Source`], [`Mineral`], or [`Deposit`] in melee range.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.harvest)
+    ///
+    /// [`Source`]: crate::objects::Source
+    /// [`Mineral`]: crate::objects::Mineral
+    /// [`Deposit`]: crate::objects::Deposit
+    pub fn harvest<T>(&self, target: &T) -> Result<(), ErrorCode>
+    where
+        T: ?Sized + Harvestable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.harvest_internal(target.as_ref()))
+    }
 
-    #[wasm_bindgen(final, method, js_name = heal)]
-    fn heal_internal(this: &Creep, target: &RoomObject) -> ReturnCode;
+    /// Heal a [`Creep`] or [`PowerCreep`] in melee range, including itself.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.heal)
+    ///
+    /// [`PowerCreep`]: crate::objects::PowerCreep
+    pub fn heal<T>(&self, target: &T) -> Result<(), ErrorCode>
+    where
+        T: ?Sized + Healable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.heal_internal(target.as_ref()))
+    }
 
     /// Move one square in the specified direction.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.move)
-    #[wasm_bindgen(final, method, js_name = move)]
-    pub fn move_direction(this: &Creep, direction: Direction) -> ReturnCode;
+    pub fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.move_direction_internal(direction))
+    }
 
     /// Accept an attempt by another creep to pull this one.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.move)
-    #[wasm_bindgen(final, method, js_name = move)]
-    pub fn move_pulled_by(this: &Creep, target: &Creep) -> ReturnCode;
+    pub fn move_pulled_by(&self, target: &Creep) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.move_pulled_by_internal(target))
+    }
 
     /// Move the creep along a previously determined path returned from a
     /// pathfinding function, in array or serialized string form.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.moveByPath)
-    #[wasm_bindgen(final, method, js_name = moveByPath)]
-    pub fn move_by_path(this: &Creep, path: &JsValue) -> ReturnCode;
-
-    /// Move the creep toward the specified goal, either a [`RoomPosition`] or
-    /// [`RoomObject`]. Note that using this function will store data in
-    /// `Memory.creeps[creep_name]` and enable the default serialization
-    /// behavior of the `Memory` object, which may hamper attempts to directly
-    /// use `RawMemory`.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.moveByPath)
-    #[wasm_bindgen(final, method, js_name = moveTo)]
-    fn move_to_internal(this: &Creep, target: &JsValue, options: &JsValue) -> ReturnCode;
+    pub fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.move_by_path_internal(path))
+    }
 
     /// Whether to send an email notification when this creep is attacked.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.notifyWhenAttacked)
-    #[wasm_bindgen(final, method, js_name = notifyWhenAttacked)]
-    pub fn notify_when_attacked(this: &Creep, enabled: bool) -> ReturnCode;
+    pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.notify_when_attacked_internal(enabled))
+    }
 
     /// Pick up a [`Resource`] in melee range (or at the same position as the
     /// creep).
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.pickup)
-    #[wasm_bindgen(final, method)]
-    pub fn pickup(this: &Creep, target: &Resource) -> ReturnCode;
+    pub fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.pickup_internal(target))
+    }
 
     /// Help another creep to move by pulling, if the second creep accepts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.pull)
-    #[wasm_bindgen(final, method)]
-    pub fn pull(this: &Creep, target: &Creep) -> ReturnCode;
+    pub fn pull(&self, target: &Creep) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.pull_internal(target))
+    }
 
-    #[wasm_bindgen(final, method, js_name = rangedAttack)]
-    fn ranged_attack_internal(this: &Creep, target: &RoomObject) -> ReturnCode;
+    /// Attack a target in range 3 using a creep's ranged attack parts.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedAttack)
+    pub fn ranged_attack<T>(&self, target: &T) -> Result<(), ErrorCode>
+    where
+        T: ?Sized + Attackable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.ranged_attack_internal(target.as_ref()))
+    }
 
-    #[wasm_bindgen(final, method, js_name = rangedHeal)]
-    fn ranged_heal_internal(this: &Creep, target: &RoomObject) -> ReturnCode;
+    /// Heal a target in range 3 using a creep's heal parts.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedHeal)
+    pub fn ranged_heal<T>(&self, target: &T) -> Result<(), ErrorCode>
+    where
+        T: ?Sized + Healable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.ranged_heal_internal(target.as_ref()))
+    }
 
     /// Attack all enemy targets in range using a creep's ranged attack parts,
     /// with lower damage depending on range.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedMassAttack)
-    #[wasm_bindgen(final, method, js_name = rangedMassAttack)]
-    pub fn ranged_mass_attack(this: &Creep) -> ReturnCode;
+    pub fn ranged_mass_attack(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.ranged_mass_attack_internal())
+    }
 
     /// Repair a target in range 3 using carried energy and the creep's work
     /// parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.repair)
-    #[wasm_bindgen(final, method)]
-    pub fn repair(this: &Creep, target: &RoomObject) -> ReturnCode;
+    pub fn repair(&self, target: &RoomObject) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.repair_internal(target))
+    }
 
     /// Reserve an unowned [`StructureController`] in melee range using a
     /// creep's claim parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.reserveController)
-    #[wasm_bindgen(final, method, js_name = reserveController)]
-    pub fn reserve_controller(this: &Creep, target: &StructureController) -> ReturnCode;
+    pub fn reserve_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.reserve_controller_internal(target))
+    }
 
     /// Display a string in a bubble above the creep next tick. 10 character
     /// limit.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.say)
-    #[wasm_bindgen(final, method)]
-    pub fn say(this: &Creep, message: &str, public: bool) -> ReturnCode;
+    pub fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.say_internal(message, public))
+    }
 
     /// Add (or remove, using an empty string) a sign to a
     /// [`StructureController`] in melee range.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.signController)
-    #[wasm_bindgen(final, method, js_name = signController)]
-    pub fn sign_controller(this: &Creep, target: &StructureController, text: &str) -> ReturnCode;
+    pub fn sign_controller(
+        &self,
+        target: &StructureController,
+        text: &str,
+    ) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.sign_controller_internal(target, text))
+    }
 
     /// Immediately kill the creep.
     ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.suicide)
-    #[wasm_bindgen(final, method)]
-    pub fn suicide(this: &Creep) -> ReturnCode;
-
-    /// Transfer a resource from the creep's store to [`Structure`],
-    /// [`PowerCreep`], or another [`Creep`].
+    /// Actions taken by the creep earlier in the tick may be cancelled.
     ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.transfer)
-    #[wasm_bindgen(final, method, js_name = transfer)]
-    fn transfer_internal(
-        this: &Creep,
-        target: &RoomObject,
-        ty: ResourceType,
-        amount: Option<u32>,
-    ) -> ReturnCode;
+    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.suicide)
+    pub fn suicide(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.suicide_internal())
+    }
 
     /// Upgrade a [`StructureController`] in range 3 using carried energy and
     /// the creep's work parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.upgradeController)
-    #[wasm_bindgen(final, method, js_name = upgradeController)]
-    pub fn upgrade_controller(this: &Creep, target: &StructureController) -> ReturnCode;
+    pub fn upgrade_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.upgrade_controller_internal(target))
+    }
+}
 
-    /// Withdraw a resource from a [`Structure`], [`Tombstone`], or [`Ruin`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.withdraw)
-    #[wasm_bindgen(final, method, js_name = withdraw)]
-    fn withdraw_internal(
-        this: &Creep,
-        target: &RoomObject,
+impl JsCollectionFromValue for Creep {
+    fn from_value(val: JsValue) -> Self {
+        val.unchecked_into()
+    }
+}
+
+impl HasHits for Creep {
+    fn hits(&self) -> u32 {
+        self.hits()
+    }
+
+    fn hits_max(&self) -> u32 {
+        self.hits_max()
+    }
+}
+
+impl MaybeHasNativeId for Creep {
+    fn try_native_id(&self) -> Option<JsString> {
+        self.id_internal()
+    }
+}
+
+impl HasStore for Creep {
+    fn store(&self) -> Store {
+        self.store()
+    }
+}
+
+impl SharedCreepProperties for Creep {
+    fn memory(&self) -> JsValue {
+        self.memory()
+    }
+
+    fn set_memory(&self, val: &JsValue) {
+        self.set_memory(val)
+    }
+
+    fn my(&self) -> bool {
+        self.my()
+    }
+
+    fn name(&self) -> String {
+        self.name_internal().into()
+    }
+
+    fn owner(&self) -> Owner {
+        self.owner()
+    }
+
+    fn saying(&self) -> Option<JsString> {
+        self.saying()
+    }
+
+    fn ticks_to_live(&self) -> Option<u32> {
+        self.ticks_to_live()
+    }
+
+    fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode> {
+        self.cancel_order(target)
+    }
+
+    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
+        self.drop(ty, amount)
+    }
+
+    fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode> {
+        self.move_direction(direction)
+    }
+
+    fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode> {
+        self.move_by_path(path)
+    }
+
+    fn move_to<T>(&self, target: T) -> Result<(), ErrorCode>
+    where
+        T: HasPosition,
+    {
+        let target: RoomPosition = target.pos().into();
+        ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
+    }
+
+    fn move_to_with_options<T, F>(
+        &self,
+        target: T,
+        options: Option<MoveToOptions<F>>,
+    ) -> Result<(), ErrorCode>
+    where
+        T: HasPosition,
+        F: FnMut(RoomName, CostMatrix) -> SingleRoomCostResult,
+    {
+        let target: RoomPosition = target.pos().into();
+
+        if let Some(options) = options {
+            options.into_js_options(|js_options| {
+                ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, js_options))
+            })
+        } else {
+            ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
+        }
+    }
+
+    fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
+        self.notify_when_attacked(enabled)
+    }
+
+    fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
+        self.pickup(target)
+    }
+
+    fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
+        self.say(message, public)
+    }
+
+    fn suicide(&self) -> Result<(), ErrorCode> {
+        self.suicide()
+    }
+
+    fn transfer<T>(
+        &self,
+        target: &T,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> ReturnCode;
+    ) -> Result<(), ErrorCode>
+    where
+        T: Transferable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.transfer_internal(target.as_ref(), ty, amount))
+    }
+
+    fn withdraw<T>(
+        &self,
+        target: &T,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> Result<(), ErrorCode>
+    where
+        T: Withdrawable,
+    {
+        ErrorCode::result_from_i8_unchecked(self.withdraw_internal(target.as_ref(), ty, amount))
+    }
 }
 
 #[wasm_bindgen]
@@ -319,214 +662,4 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     pub fn hits(this: &BodyPart) -> u32;
-}
-
-impl Creep {
-    /// Retrieve a [`Vec<BodyPart>`] containing details about the creep's body
-    /// parts and boosts.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.body)
-    pub fn body(&self) -> Vec<BodyPart> {
-        self.body_internal().iter().map(BodyPart::from).collect()
-    }
-
-    /// Attack a target in melee range using a creep's attack parts.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.attack)
-    pub fn attack<T>(&self, target: &T) -> ReturnCode
-    where
-        T: ?Sized + Attackable,
-    {
-        Self::attack_internal(self, target.as_ref())
-    }
-
-    /// Dismantle a [`Structure`] in melee range, removing [`DISMANTLE_POWER`]
-    /// hits per effective work part, giving the creep energy equivalent to half
-    /// of the cost to repair the same hits. Can only be used against types
-    /// of structures that can be constructed; if
-    /// [`StructureType::construction_cost`] is `None`, dismantling is
-    /// impossible.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.dismantle)
-    ///
-    /// [`DISMANTLE_POWER`]: crate::constants::DISMANTLE_POWER
-    /// [`StructureType::construction_cost`]: crate::constants::StructureType::construction_cost
-    pub fn dismantle<T>(&self, target: &T) -> ReturnCode
-    where
-        T: ?Sized + Dismantleable,
-    {
-        Self::dismantle_internal(self, target.as_ref())
-    }
-
-    /// Harvest from a [`Source`], [`Mineral`], or [`Deposit`] in melee range.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.harvest)
-    ///
-    /// [`Source`]: crate::objects::Source
-    /// [`Mineral`]: crate::objects::Mineral
-    /// [`Deposit`]: crate::objects::Deposit
-    pub fn harvest<T>(&self, target: &T) -> ReturnCode
-    where
-        T: ?Sized + Harvestable,
-    {
-        Self::harvest_internal(self, target.as_ref())
-    }
-
-    /// Heal a [`Creep`] or [`PowerCreep`] in melee range, including itself.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.heal)
-    ///
-    /// [`PowerCreep`]: crate::objects::PowerCreep
-    pub fn heal<T>(&self, target: &T) -> ReturnCode
-    where
-        T: ?Sized + Healable,
-    {
-        Self::heal_internal(self, target.as_ref())
-    }
-
-    /// Attack a target in range 3 using a creep's ranged attack parts.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedAttack)
-    pub fn ranged_attack<T>(&self, target: &T) -> ReturnCode
-    where
-        T: ?Sized + Attackable,
-    {
-        Self::ranged_attack_internal(self, target.as_ref())
-    }
-
-    /// Heal a target in range 3 using a creep's heal parts.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedHeal)
-    pub fn ranged_heal<T>(&self, target: &T) -> ReturnCode
-    where
-        T: ?Sized + Healable,
-    {
-        Self::ranged_heal_internal(self, target.as_ref())
-    }
-}
-
-impl JsCollectionFromValue for Creep {
-    fn from_value(val: JsValue) -> Self {
-        val.unchecked_into()
-    }
-}
-
-impl HasHits for Creep {
-    fn hits(&self) -> u32 {
-        Self::hits(self)
-    }
-
-    fn hits_max(&self) -> u32 {
-        Self::hits_max(self)
-    }
-}
-
-impl MaybeHasNativeId for Creep {
-    fn try_native_id(&self) -> Option<JsString> {
-        Self::id_internal(self)
-    }
-}
-
-impl HasStore for Creep {
-    fn store(&self) -> Store {
-        Self::store(self)
-    }
-}
-
-impl SharedCreepProperties for Creep {
-    fn memory(&self) -> JsValue {
-        Self::memory(self)
-    }
-
-    fn set_memory(&self, val: &JsValue) {
-        Self::set_memory(self, val)
-    }
-
-    fn my(&self) -> bool {
-        Self::my(self)
-    }
-
-    fn name(&self) -> String {
-        Self::name_internal(self).into()
-    }
-
-    fn owner(&self) -> Owner {
-        Self::owner(self)
-    }
-
-    fn saying(&self) -> Option<JsString> {
-        Self::saying(self)
-    }
-
-    fn ticks_to_live(&self) -> Option<u32> {
-        Self::ticks_to_live(self)
-    }
-
-    fn cancel_order(&self, target: &JsString) -> ReturnCode {
-        Self::cancel_order(self, target)
-    }
-
-    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> ReturnCode {
-        Self::drop(self, ty, amount)
-    }
-
-    fn move_direction(&self, direction: Direction) -> ReturnCode {
-        Self::move_direction(self, direction)
-    }
-
-    fn move_by_path(&self, path: &JsValue) -> ReturnCode {
-        Self::move_by_path(self, path)
-    }
-
-    fn move_to<T>(&self, target: T) -> ReturnCode
-    where
-        T: HasPosition,
-    {
-        let target: RoomPosition = target.pos().into();
-        Self::move_to_internal(self, &target, &JsValue::UNDEFINED)
-    }
-
-    fn move_to_with_options<T, F>(&self, target: T, options: Option<MoveToOptions<F>>) -> ReturnCode
-    where
-        T: HasPosition,
-        F: FnMut(RoomName, CostMatrix) -> SingleRoomCostResult,
-    {
-        let target: RoomPosition = target.pos().into();
-
-        if let Some(options) = options {
-            options.into_js_options(|js_options| Self::move_to_internal(self, &target, js_options))
-        } else {
-            Self::move_to_internal(self, &target, &JsValue::UNDEFINED)
-        }
-    }
-
-    fn notify_when_attacked(&self, enabled: bool) -> ReturnCode {
-        Self::notify_when_attacked(self, enabled)
-    }
-
-    fn pickup(&self, target: &Resource) -> ReturnCode {
-        Self::pickup(self, target)
-    }
-
-    fn say(&self, message: &str, public: bool) -> ReturnCode {
-        Self::say(self, message, public)
-    }
-
-    fn suicide(&self) -> ReturnCode {
-        Self::suicide(self)
-    }
-
-    fn transfer<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> ReturnCode
-    where
-        T: Transferable,
-    {
-        Self::transfer_internal(self, target.as_ref(), ty, amount)
-    }
-
-    fn withdraw<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> ReturnCode
-    where
-        T: Withdrawable,
-    {
-        Self::withdraw_internal(self, target.as_ref(), ty, amount)
-    }
 }

--- a/src/objects/impls/deposit.rs
+++ b/src/objects/impls/deposit.rs
@@ -47,18 +47,18 @@ extern "C" {
 
 impl CanDecay for Deposit {
     fn ticks_to_decay(&self) -> u32 {
-        Self::ticks_to_decay(self)
+        self.ticks_to_decay()
     }
 }
 
 impl HasCooldown for Deposit {
     fn cooldown(&self) -> u32 {
-        Self::cooldown(self)
+        self.cooldown()
     }
 }
 
 impl HasNativeId for Deposit {
     fn native_id(&self) -> JsString {
-        Self::id_internal(self)
+        self.id_internal()
     }
 }

--- a/src/objects/impls/flag.rs
+++ b/src/objects/impls/flag.rs
@@ -3,8 +3,8 @@ use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
     constants::Color,
-    js_collections::JsCollectionFromValue,
     objects::{RoomObject, RoomPosition},
+    prelude::*,
 };
 
 #[wasm_bindgen]

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -39,7 +39,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Mineral.id)
     #[wasm_bindgen(method, getter = id)]
-    fn id(this: &Mineral) -> JsString;
+    fn id_internal(this: &Mineral) -> JsString;
 
     /// The number of ticks until this mineral regenerates from depletion.
     ///
@@ -50,6 +50,6 @@ extern "C" {
 
 impl HasNativeId for Mineral {
     fn native_id(&self) -> JsString {
-        Self::id(self)
+        Self::id_internal(self)
     }
 }

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -2,7 +2,7 @@ use js_sys::{JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    constants::{Direction, PowerCreepClass, PowerType, ResourceType, ReturnCode},
+    constants::{Direction, ErrorCode, PowerCreepClass, PowerType, ResourceType},
     local::RoomName,
     objects::{
         CostMatrix, MoveToOptions, Owner, Resource, RoomObject, RoomPosition, Store,
@@ -21,217 +21,173 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type PowerCreep;
 
-    /// Create a new power creep in your account. Note that it will not
-    /// initially be spawned.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.create)
     #[wasm_bindgen(static_method_of = PowerCreep)]
-    pub fn create(name: &JsString, class: PowerCreepClass) -> ReturnCode;
+    fn create_internal(name: &JsString, class: PowerCreepClass) -> i8;
 
-    /// Retrieve this power creep's [`PowerCreepClass`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.className)
     #[wasm_bindgen(method, getter = className)]
-    pub fn class(this: &PowerCreep) -> PowerCreepClass;
+    fn class_internal(this: &PowerCreep) -> PowerCreepClass;
 
-    /// Retrieve the current hits of this power creep.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.hits)
-    #[wasm_bindgen(method, getter)]
-    pub fn hits(this: &PowerCreep) -> u32;
+    #[wasm_bindgen(method, getter = hits)]
+    fn hits_internal(this: &PowerCreep) -> u32;
 
-    /// Retrieve the maximum hits of this power creep.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.hitsMax)
     #[wasm_bindgen(method, getter = hitsMax)]
-    pub fn hits_max(this: &PowerCreep) -> u32;
+    fn hits_max_internal(this: &PowerCreep) -> u32;
 
-    /// Object ID of the power creep, which can be used to efficiently fetch a
-    /// fresh reference to the object on subsequent ticks, or `None` if not
-    /// spawned on the current shard.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.id)
     #[wasm_bindgen(method, getter = id)]
     fn id_internal(this: &PowerCreep) -> JsString;
 
-    /// Current level of the power creep, which can be increased with
-    /// [`PowerCreep::upgrade`] if you have unspent GPL.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.level)
-    #[wasm_bindgen(method, getter)]
-    pub fn level(this: &PowerCreep) -> u32;
+    #[wasm_bindgen(method, getter = level)]
+    fn level_internal(this: &PowerCreep) -> u32;
 
-    /// A shortcut to `Memory.powerCreeps[power_creep.name]`.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.memory)
-    #[wasm_bindgen(method, getter)]
-    pub fn memory(this: &PowerCreep) -> JsValue;
+    #[wasm_bindgen(method, getter = memory)]
+    fn memory_internal(this: &PowerCreep) -> JsValue;
 
-    /// Sets a new value to `Memory.powerCreeps[power_creep.name]`.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.memory)
-    #[wasm_bindgen(method, setter)]
-    pub fn set_memory(this: &PowerCreep, val: &JsValue);
+    #[wasm_bindgen(method, setter = memory)]
+    fn set_memory_internal(this: &PowerCreep, val: &JsValue);
 
-    /// Whether this power creep is owned by the player.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.my)
-    #[wasm_bindgen(method, getter)]
-    pub fn my(this: &PowerCreep) -> bool;
+    #[wasm_bindgen(method, getter = my)]
+    fn my_internal(this: &PowerCreep) -> bool;
 
-    /// The power creep's name as an owned reference to a [`JsString`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.name)
     #[wasm_bindgen(method, getter = name)]
     fn name_internal(this: &PowerCreep) -> JsString;
 
-    /// The [`Owner`] of this power creep that contains the owner's username.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.owner)
-    #[wasm_bindgen(method, getter)]
-    pub fn owner(this: &PowerCreep) -> Owner;
+    #[wasm_bindgen(method, getter = owner)]
+    fn owner_internal(this: &PowerCreep) -> Owner;
 
     #[wasm_bindgen(method, getter = powers)]
     fn powers_internal(this: &PowerCreep) -> Object;
 
-    /// What the power creep said last tick.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.saying)
-    #[wasm_bindgen(method, getter)]
-    pub fn saying(this: &PowerCreep) -> Option<JsString>;
+    #[wasm_bindgen(method, getter = saying)]
+    fn saying_internal(this: &PowerCreep) -> Option<JsString>;
 
-    /// The [`Store`] of the power creep, which contains information about what
-    /// resources it is it carrying.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.store)
-    #[wasm_bindgen(method, getter)]
-    pub fn store(this: &PowerCreep) -> Store;
+    #[wasm_bindgen(method, getter = store)]
+    fn store_internal(this: &PowerCreep) -> Store;
 
-    /// The shard the power creep is currently spawned on, if spawned.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.shard)
-    #[wasm_bindgen(method, getter)]
-    pub fn shard(this: &PowerCreep) -> Option<JsString>;
+    #[wasm_bindgen(method, getter = shard)]
+    fn shard_internal(this: &PowerCreep) -> Option<JsString>;
 
-    /// The number of ticks the power creep has left to live, which can be
-    /// renewed at a [`StructurePowerSpawn`] or [`StructurePowerBank`]
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.ticksToLive)
     #[wasm_bindgen(method, getter = ticksToLive)]
-    pub fn ticks_to_live(this: &PowerCreep) -> Option<u32>;
+    fn ticks_to_live_internal(this: &PowerCreep) -> Option<u32>;
 
-    /// Cancel an a successfully called power creep function from earlier in the
-    /// tick, with a [`JsString`] that must contain the JS version of the
-    /// function name.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.cancelOrder)
     #[wasm_bindgen(method, js_name = cancelOrder)]
-    pub fn cancel_order(this: &PowerCreep, target: &JsString) -> ReturnCode;
+    fn cancel_order_internal(this: &PowerCreep, target: &JsString) -> i8;
 
-    /// Drop a resource on the ground from the power creep's [`Store`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.drop)
-    #[wasm_bindgen(method)]
-    pub fn drop(this: &PowerCreep, ty: ResourceType, amount: Option<u32>) -> ReturnCode;
+    #[wasm_bindgen(method, js_name = drop)]
+    fn drop_internal(this: &PowerCreep, ty: ResourceType, amount: Option<u32>) -> i8;
 
-    /// Enable powers to be used in this room on a [`StructureController`] in
-    /// melee range. You do not need to own the controller.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.enableRoom)
     #[wasm_bindgen(method, js_name = enableRoom)]
-    pub fn enable_room(this: &PowerCreep, target: &StructureController) -> ReturnCode;
+    fn enable_room_internal(this: &PowerCreep, target: &StructureController) -> i8;
 
-    /// Move one square in the specified direction.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.move)
     #[wasm_bindgen(method, js_name = move)]
-    pub fn move_direction(this: &PowerCreep, direction: Direction) -> ReturnCode;
+    fn move_direction_internal(this: &PowerCreep, direction: Direction) -> i8;
 
-    /// Move the power creep along a previously determined path returned from a
-    /// pathfinding function, in array or serialized string form.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.moveByPath)
     #[wasm_bindgen(method, js_name = moveByPath)]
-    pub fn move_by_path(this: &PowerCreep, path: &JsValue) -> ReturnCode;
+    fn move_by_path_internal(this: &PowerCreep, path: &JsValue) -> i8;
 
-    /// Move the creep toward the specified goal, either a [`RoomPosition`] or
-    /// [`RoomObject`]. Note that using this function will store data in
-    /// `Memory.creeps[creep_name]` and enable the default serialization
-    /// behavior of the `Memory` object, which may hamper attempts to directly
-    /// use `RawMemory`.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.moveByPath)
     #[wasm_bindgen(method, js_name = moveTo)]
-    fn move_to_internal(this: &PowerCreep, target: &JsValue, options: &JsValue) -> ReturnCode;
+    fn move_to_internal(this: &PowerCreep, target: &JsValue, options: &JsValue) -> i8;
 
-    /// Whether to send an email notification when this power creep is attacked.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.notifyWhenAttacked)
     #[wasm_bindgen(method, js_name = notifyWhenAttacked)]
-    pub fn notify_when_attacked(this: &PowerCreep, enabled: bool) -> ReturnCode;
+    fn notify_when_attacked_internal(this: &PowerCreep, enabled: bool) -> i8;
 
-    /// Pick up a [`Resource`] in melee range (or at the same position as the
-    /// creep).
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.pickup)
-    #[wasm_bindgen(method)]
-    pub fn pickup(this: &PowerCreep, target: &Resource) -> ReturnCode;
+    #[wasm_bindgen(method, js_name = pickup)]
+    fn pickup_internal(this: &PowerCreep, target: &Resource) -> i8;
 
-    /// Renew the power creep's TTL using a [`StructurePowerSpawn`] or
-    /// [`StructurePowerBank`] in melee range.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.renew)
-    #[wasm_bindgen(method)]
-    pub fn renew(this: &PowerCreep, target: &RoomObject) -> ReturnCode;
+    #[wasm_bindgen(method, js_name = renew)]
+    fn renew_internal(this: &PowerCreep, target: &RoomObject) -> i8;
 
-    /// Display a string in a bubble above the power creep next tick. 10
-    /// character limit.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.say)
-    #[wasm_bindgen(method)]
-    pub fn say(this: &PowerCreep, message: &str, public: bool) -> ReturnCode;
+    #[wasm_bindgen(method, js_name = say)]
+    fn say_internal(this: &PowerCreep, message: &str, public: bool) -> i8;
 
-    /// Immediately kill the power creep.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.suicide)
-    #[wasm_bindgen(method)]
-    pub fn suicide(this: &PowerCreep) -> ReturnCode;
+    #[wasm_bindgen(method, js_name = suicide)]
+    fn suicide_internal(this: &PowerCreep) -> i8;
 
-    /// Transfer a resource from the power creep's store to [`Structure`],
-    /// [`Creep`], or another [`PowerCreep`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.transfer)
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = transfer)]
     fn transfer_internal(
         this: &PowerCreep,
         target: &RoomObject,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> ReturnCode;
+    ) -> i8;
 
-    /// Use one of the power creep's powers.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.usePower)
     #[wasm_bindgen(method, js_name = usePower)]
-    pub fn use_power(
-        this: &PowerCreep,
-        power: PowerType,
-        target: Option<&RoomObject>,
-    ) -> ReturnCode;
+    fn use_power_internal(this: &PowerCreep, power: PowerType, target: Option<&RoomObject>) -> i8;
 
-    /// Withdraw a resource from a [`Structure`], [`Tombstone`], or [`Ruin`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.withdraw)
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = withdraw)]
     fn withdraw_internal(
         this: &PowerCreep,
         target: &RoomObject,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> ReturnCode;
+    ) -> i8;
 }
 
 impl PowerCreep {
+    /// Create a new power creep in your account. Note that it will not
+    /// initially be spawned.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.create)
+    pub fn create(name: &JsString, class: PowerCreepClass) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(Self::create_internal(name, class))
+    }
+
+    /// Retrieve this power creep's [`PowerCreepClass`].
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.className)
+    pub fn class(&self) -> PowerCreepClass {
+        self.class_internal()
+    }
+
+    /// Retrieve the current hits of this power creep.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.hits)
+    pub fn hits(&self) -> u32 {
+        self.hits_internal()
+    }
+
+    /// Retrieve the maximum hits of this power creep.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.hitsMax)
+    pub fn hits_max(&self) -> u32 {
+        self.hits_max_internal()
+    }
+
+    /// Current level of the power creep, which can be increased with
+    /// [`PowerCreep::upgrade`] if you have unspent GPL.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.level)
+    pub fn level(&self) -> u32 {
+        self.level_internal()
+    }
+
+    /// A shortcut to `Memory.powerCreeps[power_creep.name]`.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.memory)
+    pub fn memory(&self) -> JsValue {
+        self.memory_internal()
+    }
+
+    /// Sets a new value to `Memory.powerCreeps[power_creep.name]`.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.memory)
+    pub fn set_memory(&self, val: &JsValue) {
+        self.set_memory_internal(val)
+    }
+
+    /// Whether this power creep is owned by the player.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.my)
+    pub fn my(&self) -> bool {
+        self.my_internal()
+    }
+
+    /// The [`Owner`] of this power creep that contains the owner's username.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.owner)
+    pub fn owner(&self) -> Owner {
+        self.owner_internal()
+    }
+
     /// The levels of this power creep's abilities, with [`PowerType`] keys and
     /// values containing power level and cooldown.
     ///
@@ -239,27 +195,145 @@ impl PowerCreep {
     pub fn powers(&self) -> JsHashMap<PowerType, PowerInfo> {
         self.powers_internal().into()
     }
+
+    /// What the power creep said last tick.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.saying)
+    pub fn saying(&self) -> Option<JsString> {
+        self.saying_internal()
+    }
+
+    /// The [`Store`] of the power creep, which contains information about what
+    /// resources it is it carrying.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.store)
+    pub fn store(&self) -> Store {
+        self.store_internal()
+    }
+
+    /// The shard the power creep is currently spawned on, if spawned.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.shard)
+    pub fn shard(&self) -> Option<JsString> {
+        self.shard_internal()
+    }
+
+    /// The number of ticks the power creep has left to live, which can be
+    /// renewed at a [`StructurePowerSpawn`] or [`StructurePowerBank`]
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.ticksToLive)
+    pub fn ticks_to_live(&self) -> Option<u32> {
+        self.ticks_to_live_internal()
+    }
+
+    /// Cancel an a successfully called power creep function from earlier in the
+    /// tick, with a [`JsString`] that must contain the JS version of the
+    /// function name.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.cancelOrder)
+    pub fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.cancel_order_internal(target))
+    }
+
+    /// Drop a resource on the ground from the power creep's [`Store`].
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.drop)
+    pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.drop_internal(ty, amount))
+    }
+
+    /// Enable powers to be used in this room on a [`StructureController`] in
+    /// melee range. You do not need to own the controller.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.enableRoom)
+    pub fn enable_room(&self, target: &StructureController) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.enable_room_internal(target))
+    }
+
+    /// Move one square in the specified direction.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.move)
+    pub fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.move_direction_internal(direction))
+    }
+
+    /// Move the power creep along a previously determined path returned from a
+    /// pathfinding function, in array or serialized string form.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.moveByPath)
+    pub fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.move_by_path_internal(path))
+    }
+
+    /// Whether to send an email notification when this power creep is attacked.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.notifyWhenAttacked)
+    pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.notify_when_attacked_internal(enabled))
+    }
+
+    /// Pick up a [`Resource`] in melee range (or at the same position as the
+    /// creep).
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.pickup)
+    pub fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.pickup_internal(target))
+    }
+
+    /// Renew the power creep's TTL using a [`StructurePowerSpawn`] or
+    /// [`StructurePowerBank`] in melee range.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.renew)
+    pub fn renew(&self, target: &RoomObject) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.renew_internal(target))
+    }
+
+    /// Display a string in a bubble above the power creep next tick. 10
+    /// character limit.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.say)
+    pub fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.say_internal(message, public))
+    }
+
+    /// Immediately kill the power creep.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.suicide)
+    pub fn suicide(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.suicide_internal())
+    }
+
+    /// Use one of the power creep's powers.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.usePower)
+    pub fn use_power(
+        &self,
+        power: PowerType,
+        target: Option<&RoomObject>,
+    ) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.use_power_internal(power, target))
+    }
 }
 
 impl HasHits for PowerCreep {
     fn hits(&self) -> u32 {
-        Self::hits(self)
+        self.hits()
     }
 
     fn hits_max(&self) -> u32 {
-        Self::hits_max(self)
+        self.hits_max()
     }
 }
 
 impl HasNativeId for PowerCreep {
     fn native_id(&self) -> JsString {
-        Self::id_internal(self)
+        self.id_internal()
     }
 }
 
 impl HasStore for PowerCreep {
     fn store(&self) -> Store {
-        Self::store(self)
+        self.store()
     }
 }
 
@@ -268,58 +342,62 @@ impl HasStore for PowerCreep {
 
 impl SharedCreepProperties for PowerCreep {
     fn memory(&self) -> JsValue {
-        Self::memory(self)
+        self.memory()
     }
 
     fn set_memory(&self, val: &JsValue) {
-        Self::set_memory(self, val)
+        self.set_memory(val)
     }
 
     fn my(&self) -> bool {
-        Self::my(self)
+        self.my()
     }
 
     fn name(&self) -> String {
-        Self::name_internal(self).into()
+        self.name_internal().into()
     }
 
     fn owner(&self) -> Owner {
-        Self::owner(self)
+        self.owner()
     }
 
     fn saying(&self) -> Option<JsString> {
-        Self::saying(self)
+        self.saying()
     }
 
     fn ticks_to_live(&self) -> Option<u32> {
-        Self::ticks_to_live(self)
+        self.ticks_to_live()
     }
 
-    fn cancel_order(&self, target: &JsString) -> ReturnCode {
-        Self::cancel_order(self, target)
+    fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode> {
+        self.cancel_order(target)
     }
 
-    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> ReturnCode {
-        Self::drop(self, ty, amount)
+    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
+        self.drop(ty, amount)
     }
 
-    fn move_direction(&self, direction: Direction) -> ReturnCode {
-        Self::move_direction(self, direction)
+    fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode> {
+        self.move_direction(direction)
     }
 
-    fn move_by_path(&self, path: &JsValue) -> ReturnCode {
-        Self::move_by_path(self, path)
+    fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode> {
+        self.move_by_path(path)
     }
 
-    fn move_to<T>(&self, target: T) -> ReturnCode
+    fn move_to<T>(&self, target: T) -> Result<(), ErrorCode>
     where
         T: HasPosition,
     {
         let target: RoomPosition = target.pos().into();
-        Self::move_to_internal(self, &target, &JsValue::UNDEFINED)
+        ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
     }
 
-    fn move_to_with_options<T, F>(&self, target: T, options: Option<MoveToOptions<F>>) -> ReturnCode
+    fn move_to_with_options<T, F>(
+        &self,
+        target: T,
+        options: Option<MoveToOptions<F>>,
+    ) -> Result<(), ErrorCode>
     where
         T: HasPosition,
         F: FnMut(RoomName, CostMatrix) -> SingleRoomCostResult,
@@ -327,40 +405,52 @@ impl SharedCreepProperties for PowerCreep {
         let target: RoomPosition = target.pos().into();
 
         if let Some(options) = options {
-            options.into_js_options(|js_options| Self::move_to_internal(self, &target, js_options))
+            options.into_js_options(|js_options| {
+                ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, js_options))
+            })
         } else {
-            Self::move_to_internal(self, &target, &JsValue::UNDEFINED)
+            ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
         }
     }
 
-    fn notify_when_attacked(&self, enabled: bool) -> ReturnCode {
-        Self::notify_when_attacked(self, enabled)
+    fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.notify_when_attacked_internal(enabled))
     }
 
-    fn pickup(&self, target: &Resource) -> ReturnCode {
-        Self::pickup(self, target)
+    fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.pickup_internal(target))
     }
 
-    fn say(&self, message: &str, public: bool) -> ReturnCode {
-        Self::say(self, message, public)
+    fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.say_internal(message, public))
     }
 
-    fn suicide(&self) -> ReturnCode {
-        Self::suicide(self)
+    fn suicide(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.suicide_internal())
     }
 
-    fn transfer<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> ReturnCode
+    fn transfer<T>(
+        &self,
+        target: &T,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> Result<(), ErrorCode>
     where
         T: Transferable,
     {
-        Self::transfer_internal(self, target.as_ref(), ty, amount)
+        ErrorCode::result_from_i8_unchecked(self.transfer_internal(target.as_ref(), ty, amount))
     }
 
-    fn withdraw<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> ReturnCode
+    fn withdraw<T>(
+        &self,
+        target: &T,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> Result<(), ErrorCode>
     where
         T: Withdrawable,
     {
-        Self::withdraw_internal(self, target.as_ref(), ty, amount)
+        ErrorCode::result_from_i8_unchecked(self.withdraw_internal(target.as_ref(), ty, amount))
     }
 }
 
@@ -373,11 +463,47 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type AccountPowerCreep;
 
+    #[wasm_bindgen(method, getter = className)]
+    fn class_internal(this: &AccountPowerCreep) -> PowerCreepClass;
+
+    #[wasm_bindgen(method, getter = deleteTime)]
+    fn delete_time_internal(this: &AccountPowerCreep) -> Option<f64>;
+
+    #[wasm_bindgen(method, getter = level)]
+    fn level_internal(this: &AccountPowerCreep) -> u32;
+
+    #[wasm_bindgen(method, getter = name)]
+    fn name_internal(this: &AccountPowerCreep) -> JsString;
+
+    #[wasm_bindgen(method, getter = powers)]
+    fn powers_internal(this: &AccountPowerCreep) -> Object;
+
+    #[wasm_bindgen(method, getter = shard)]
+    fn shard_internal(this: &AccountPowerCreep) -> Option<JsString>;
+
+    #[wasm_bindgen(method, getter = spawnCooldownTime)]
+    fn spawn_cooldown_time_internal(this: &AccountPowerCreep) -> Option<f64>;
+
+    #[wasm_bindgen(method, js_name = delete)]
+    fn delete_internal(this: &AccountPowerCreep, cancel: bool) -> i8;
+
+    #[wasm_bindgen(method, js_name = rename)]
+    fn rename_internal(this: &AccountPowerCreep, name: &JsString) -> i8;
+
+    #[wasm_bindgen(method, js_name = spawn)]
+    fn spawn_internal(this: &AccountPowerCreep, target: &StructurePowerSpawn) -> i8;
+
+    #[wasm_bindgen(method, js_name = upgrade)]
+    fn upgrade_internal(this: &AccountPowerCreep, power: PowerType) -> i8;
+}
+
+impl AccountPowerCreep {
     /// Retrieve this power creep's [`PowerCreepClass`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.className)
-    #[wasm_bindgen(method, getter = className)]
-    pub fn class(this: &AccountPowerCreep) -> PowerCreepClass;
+    pub fn class(&self) -> PowerCreepClass {
+        self.class_internal()
+    }
 
     // todo should be u64 but seems to panic at the moment, follow up
     /// The timestamp, in milliseconds since epoch, when the [`PowerCreep`] will
@@ -385,73 +511,70 @@ extern "C" {
     /// with the same function until then.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.deleteTime)
-    #[wasm_bindgen(method, getter = deleteTime)]
-    pub fn delete_time(this: &AccountPowerCreep) -> Option<f64>;
+    pub fn delete_time(&self) -> Option<f64> {
+        self.delete_time_internal()
+    }
 
     /// Current level of the power creep, which can be increased with
     /// [`PowerCreep::upgrade`] if you have unspent GPL.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.level)
-    #[wasm_bindgen(method, getter)]
-    pub fn level(this: &AccountPowerCreep) -> u32;
+    pub fn level(&self) -> u32 {
+        self.level_internal()
+    }
 
-    /// The power creep's name as an owned reference to a [`JsString`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.name)
-    #[wasm_bindgen(method, getter = name)]
-    fn name_internal(this: &AccountPowerCreep) -> JsString;
-
-    #[wasm_bindgen(method, getter = powers)]
-    fn powers_internal(this: &AccountPowerCreep) -> Object;
-
-    /// The shard the power creep is currently spawned on, if spawned.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.shard)
-    #[wasm_bindgen(method, getter)]
-    pub fn shard(this: &AccountPowerCreep) -> Option<JsString>;
-
-    // todo should be u64 but seems to panic at the moment, follow up
-    /// The timestamp, in milliseconds since epoch, when the power creep will be
-    /// allowed to spawn again after dying.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.spawnCooldownTime)
-    #[wasm_bindgen(method, getter = spawnCooldownTime)]
-    pub fn spawn_cooldown_time(this: &AccountPowerCreep) -> Option<f64>;
-
-    /// Set a power creep that is not currently spawned to be deleted. Can be
-    /// cancelled with `true` for the cancel paramater.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.delete)
-    #[wasm_bindgen(method)]
-    pub fn delete(this: &AccountPowerCreep, cancel: bool) -> ReturnCode;
-
-    /// Change the name of the power creep. Must not be spawned.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.rename)
-    #[wasm_bindgen(method)]
-    pub fn rename(this: &AccountPowerCreep, name: &JsString) -> ReturnCode;
-
-    /// Spawn the power creep at a [`StructurePowerSpawn`].
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.spawn)
-    #[wasm_bindgen(method)]
-    pub fn spawn(this: &AccountPowerCreep, target: &StructurePowerSpawn) -> ReturnCode;
-
-    /// Upgrade this power creep, consuming one available GPL and adding a new
-    /// level to one of its powers.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.upgrade)
-    #[wasm_bindgen(method)]
-    pub fn upgrade(this: &AccountPowerCreep, power: PowerType) -> ReturnCode;
-}
-
-impl AccountPowerCreep {
     /// The levels of this power creep's abilities, with [`PowerType`] keys and
     /// values containing power level and cooldown.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.powers)
     pub fn powers(&self) -> JsHashMap<PowerType, PowerInfo> {
         self.powers_internal().into()
+    }
+
+    /// The shard the power creep is currently spawned on, if spawned.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.shard)
+    pub fn shard(&self) -> Option<JsString> {
+        self.shard_internal()
+    }
+
+    // todo should be u64 but seems to panic at the moment, follow up
+    /// The timestamp, in milliseconds since epoch, when the power creep will be
+    /// allowed to spawn again after dying.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.spawnCooldownTime)
+    pub fn spawn_cooldown_time(&self) -> Option<f64> {
+        self.spawn_cooldown_time_internal()
+    }
+
+    /// Set a power creep that is not currently spawned to be deleted. Can be
+    /// cancelled with `true` for the cancel paramater.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.delete)
+    pub fn delete(&self, cancel: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.delete_internal(cancel))
+    }
+
+    /// Change the name of the power creep. Must not be spawned.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.rename)
+    pub fn rename(&self, name: &JsString) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.rename_internal(name))
+    }
+
+    /// Spawn the power creep at a [`StructurePowerSpawn`].
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.spawn)
+    pub fn spawn(&self, target: &StructurePowerSpawn) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.spawn_internal(target))
+    }
+
+    /// Upgrade this power creep, consuming one available GPL and adding a new
+    /// level to one of its powers.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.upgrade)
+    pub fn upgrade(&self, power: PowerType) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.upgrade_internal(power))
     }
 }
 

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -128,7 +128,7 @@ impl PowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.create)
     pub fn create(name: &JsString, class: PowerCreepClass) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(Self::create_internal(name, class))
+        ErrorCode::result_from_i8(Self::create_internal(name, class))
     }
 
     /// Retrieve this power creep's [`PowerCreepClass`].
@@ -232,14 +232,14 @@ impl PowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.cancelOrder)
     pub fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.cancel_order_internal(target))
+        ErrorCode::result_from_i8(self.cancel_order_internal(target))
     }
 
     /// Drop a resource on the ground from the power creep's [`Store`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.drop)
     pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.drop_internal(ty, amount))
+        ErrorCode::result_from_i8(self.drop_internal(ty, amount))
     }
 
     /// Enable powers to be used in this room on a [`StructureController`] in
@@ -247,14 +247,14 @@ impl PowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.enableRoom)
     pub fn enable_room(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.enable_room_internal(target))
+        ErrorCode::result_from_i8(self.enable_room_internal(target))
     }
 
     /// Move one square in the specified direction.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.move)
     pub fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.move_direction_internal(direction))
+        ErrorCode::result_from_i8(self.move_direction_internal(direction))
     }
 
     /// Move the power creep along a previously determined path returned from a
@@ -262,14 +262,14 @@ impl PowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.moveByPath)
     pub fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.move_by_path_internal(path))
+        ErrorCode::result_from_i8(self.move_by_path_internal(path))
     }
 
     /// Whether to send an email notification when this power creep is attacked.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.notifyWhenAttacked)
     pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.notify_when_attacked_internal(enabled))
+        ErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
     }
 
     /// Pick up a [`Resource`] in melee range (or at the same position as the
@@ -277,7 +277,7 @@ impl PowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.pickup)
     pub fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.pickup_internal(target))
+        ErrorCode::result_from_i8(self.pickup_internal(target))
     }
 
     /// Renew the power creep's TTL using a [`StructurePowerSpawn`] or
@@ -285,7 +285,7 @@ impl PowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.renew)
     pub fn renew(&self, target: &RoomObject) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.renew_internal(target))
+        ErrorCode::result_from_i8(self.renew_internal(target))
     }
 
     /// Display a string in a bubble above the power creep next tick. 10
@@ -293,14 +293,14 @@ impl PowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.say)
     pub fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.say_internal(message, public))
+        ErrorCode::result_from_i8(self.say_internal(message, public))
     }
 
     /// Immediately kill the power creep.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.suicide)
     pub fn suicide(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.suicide_internal())
+        ErrorCode::result_from_i8(self.suicide_internal())
     }
 
     /// Use one of the power creep's powers.
@@ -311,7 +311,7 @@ impl PowerCreep {
         power: PowerType,
         target: Option<&RoomObject>,
     ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.use_power_internal(power, target))
+        ErrorCode::result_from_i8(self.use_power_internal(power, target))
     }
 }
 
@@ -390,7 +390,7 @@ impl SharedCreepProperties for PowerCreep {
         T: HasPosition,
     {
         let target: RoomPosition = target.pos().into();
-        ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
+        ErrorCode::result_from_i8(self.move_to_internal(&target, &JsValue::UNDEFINED))
     }
 
     fn move_to_with_options<T, F>(
@@ -406,27 +406,27 @@ impl SharedCreepProperties for PowerCreep {
 
         if let Some(options) = options {
             options.into_js_options(|js_options| {
-                ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, js_options))
+                ErrorCode::result_from_i8(self.move_to_internal(&target, js_options))
             })
         } else {
-            ErrorCode::result_from_i8_unchecked(self.move_to_internal(&target, &JsValue::UNDEFINED))
+            ErrorCode::result_from_i8(self.move_to_internal(&target, &JsValue::UNDEFINED))
         }
     }
 
     fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.notify_when_attacked_internal(enabled))
+        ErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
     }
 
     fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.pickup_internal(target))
+        ErrorCode::result_from_i8(self.pickup_internal(target))
     }
 
     fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.say_internal(message, public))
+        ErrorCode::result_from_i8(self.say_internal(message, public))
     }
 
     fn suicide(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.suicide_internal())
+        ErrorCode::result_from_i8(self.suicide_internal())
     }
 
     fn transfer<T>(
@@ -438,7 +438,7 @@ impl SharedCreepProperties for PowerCreep {
     where
         T: Transferable,
     {
-        ErrorCode::result_from_i8_unchecked(self.transfer_internal(target.as_ref(), ty, amount))
+        ErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
     }
 
     fn withdraw<T>(
@@ -450,7 +450,7 @@ impl SharedCreepProperties for PowerCreep {
     where
         T: Withdrawable,
     {
-        ErrorCode::result_from_i8_unchecked(self.withdraw_internal(target.as_ref(), ty, amount))
+        ErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
     }
 }
 
@@ -552,21 +552,21 @@ impl AccountPowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.delete)
     pub fn delete(&self, cancel: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.delete_internal(cancel))
+        ErrorCode::result_from_i8(self.delete_internal(cancel))
     }
 
     /// Change the name of the power creep. Must not be spawned.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.rename)
     pub fn rename(&self, name: &JsString) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.rename_internal(name))
+        ErrorCode::result_from_i8(self.rename_internal(name))
     }
 
     /// Spawn the power creep at a [`StructurePowerSpawn`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.spawn)
     pub fn spawn(&self, target: &StructurePowerSpawn) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.spawn_internal(target))
+        ErrorCode::result_from_i8(self.spawn_internal(target))
     }
 
     /// Upgrade this power creep, consuming one available GPL and adding a new
@@ -574,7 +574,7 @@ impl AccountPowerCreep {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.upgrade)
     pub fn upgrade(&self, power: PowerType) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.upgrade_internal(power))
+        ErrorCode::result_from_i8(self.upgrade_internal(power))
     }
 }
 

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -240,7 +240,7 @@ impl Room {
         ty: StructureType,
         name: Option<&JsString>,
     ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.create_construction_site_internal(x, y, ty, name))
+        ErrorCode::result_from_i8(self.create_construction_site_internal(x, y, ty, name))
     }
 
     /// Creates a [`Flag`] at given coordinates within this room. The name of

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::{prelude::*, JsCast};
 use crate::{
     constants::{
         find::*, look::*, Color, Direction, ErrorCode, ExitDirection, PowerType, ResourceType,
-        ReturnCode, StructureType,
+        StructureType,
     },
     local::{LodashFilter, RoomName},
     objects::*,
@@ -94,26 +94,14 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Room, js_name = deserializePath)]
     fn deserialize_path_internal(path: &JsString) -> Array;
 
-    /// Creates a construction site at given coordinates within this room. If
-    /// it's a [`StructureSpawn`], a name can optionally be assigned for the
-    /// structure.
-    ///
-    /// See [`RoomPosition::create_construction_site`] to create at a specified
-    /// position.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Room.createConstructionSite)
-    ///
-    /// [`StructureSpawn`]: crate::objects::StructureSpawn
-    /// [`RoomPosition::create_construction_site`]:
-    /// crate::objects::RoomPosition::create_construction_site
     #[wasm_bindgen(final, method, js_name = createConstructionSite)]
-    pub fn create_construction_site(
+    fn create_construction_site_internal(
         this: &Room,
         x: u8,
         y: u8,
         ty: StructureType,
         name: Option<&JsString>,
-    ) -> ReturnCode;
+    ) -> i8;
 
     #[wasm_bindgen(final, method, js_name = createFlag)]
     fn create_flag_internal(
@@ -231,6 +219,28 @@ impl Room {
 
     pub fn visual(&self) -> RoomVisual {
         RoomVisual::new(Some(self.name()))
+    }
+
+    /// Creates a construction site at given coordinates within this room. If
+    /// it's a [`StructureSpawn`], a name can optionally be assigned for the
+    /// structure.
+    ///
+    /// See [`RoomPosition::create_construction_site`] to create at a specified
+    /// position.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Room.createConstructionSite)
+    ///
+    /// [`StructureSpawn`]: crate::objects::StructureSpawn
+    /// [`RoomPosition::create_construction_site`]:
+    /// crate::objects::RoomPosition::create_construction_site
+    pub fn create_construction_site(
+        &self,
+        x: u8,
+        y: u8,
+        ty: StructureType,
+        name: Option<&JsString>,
+    ) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.create_construction_site_internal(x, y, ty, name))
     }
 
     /// Creates a [`Flag`] at given coordinates within this room. The name of

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -224,7 +224,7 @@ impl RoomPosition {
         ty: StructureType,
         name: Option<&JsString>,
     ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(Self::create_construction_site_internal(self, ty, name))
+        ErrorCode::result_from_i8(Self::create_construction_site_internal(self, ty, name))
     }
 
     /// Creates a [`Flag`] at this position. If successful, returns the name of

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -5,7 +5,7 @@ use num_traits::*;
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    constants::{find::*, look::*, Color, Direction, ErrorCode, ReturnCode, StructureType},
+    constants::{find::*, look::*, Color, Direction, ErrorCode, StructureType},
     local::{Position, RoomCoordinate, RoomName},
     objects::{CostMatrix, FindPathOptions, Path},
     pathfinder::RoomCostResult,
@@ -67,18 +67,12 @@ extern "C" {
     #[wasm_bindgen(method, setter = __packedPos)]
     pub fn set_packed(this: &RoomPosition, val: u32);
 
-    /// Creates a [`ConstructionSite`] at this position. If it's a
-    /// [`StructureSpawn`], a name can optionally be assigned for the structure.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.createConstructionSite)
-    ///
-    /// [`ConstructionSite`]: crate::objects::ConstructionSite
     #[wasm_bindgen(method, js_name = createConstructionSite)]
-    pub fn create_construction_site(
+    fn create_construction_site_internal(
         this: &RoomPosition,
         ty: StructureType,
         name: Option<&JsString>,
-    ) -> ReturnCode;
+    ) -> i8;
 
     #[wasm_bindgen(method, catch, js_name = createFlag)]
     fn create_flag_internal(
@@ -217,6 +211,20 @@ impl RoomPosition {
         Self::room_name_internal(self)
             .try_into()
             .expect("expected parseable room name")
+    }
+
+    /// Creates a [`ConstructionSite`] at this position. If it's a
+    /// [`StructureSpawn`], a name can optionally be assigned for the structure.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.createConstructionSite)
+    ///
+    /// [`ConstructionSite`]: crate::objects::ConstructionSite
+    pub fn create_construction_site(
+        &self,
+        ty: StructureType,
+        name: Option<&JsString>,
+    ) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(Self::create_construction_site_internal(self, ty, name))
     }
 
     /// Creates a [`Flag`] at this position. If successful, returns the name of

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -51,6 +51,6 @@ impl RoomTerrain {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer)
     pub fn get_raw_buffer_to_array(&self, destination: &Uint8Array) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.get_raw_buffer_to_array_internal(destination))
+        ErrorCode::result_from_i8(self.get_raw_buffer_to_array_internal(destination))
     }
 }

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -1,7 +1,10 @@
 use js_sys::{JsString, Uint8Array};
 use wasm_bindgen::prelude::*;
 
-use crate::constants::{ReturnCode, Terrain};
+use crate::{
+    constants::{ErrorCode, Terrain},
+    prelude::*,
+};
 
 #[wasm_bindgen]
 extern "C" {
@@ -24,17 +27,30 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn get(this: &RoomTerrain, x: u8, y: u8) -> Terrain;
 
-    //TODO: wiarchbe: Need to handle return code?
+    #[wasm_bindgen(method, js_name = getRawBuffer)]
+    fn get_raw_buffer_internal(this: &RoomTerrain) -> JsValue;
+
+    #[wasm_bindgen(method, js_name = getRawBuffer)]
+    fn get_raw_buffer_to_array_internal(this: &RoomTerrain, destination: &Uint8Array) -> i8;
+}
+
+impl RoomTerrain {
     /// Get a copy of the underlying Uint8Array with the data about the room's
     /// terrain.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer)
-    #[wasm_bindgen(method, js_name = getRawBuffer)]
-    pub fn get_raw_buffer(this: &RoomTerrain) -> Uint8Array;
+    pub fn get_raw_buffer(&self) -> Result<Uint8Array, ErrorCode> {
+        // the only possible error for this function is invalid args, so simply return
+        // that directly instead of further checks if it's not a Uint8Array
+        self.get_raw_buffer_internal()
+            .dyn_into()
+            .map_err(|_| ErrorCode::InvalidArgs)
+    }
 
     /// Copy the data about the room's terrain into an existing [`Uint8Array`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer)
-    #[wasm_bindgen(method, js_name = getRawBuffer)]
-    pub fn get_raw_buffer_to_array(this: &RoomTerrain, destination: &Uint8Array) -> ReturnCode;
+    pub fn get_raw_buffer_to_array(&self, destination: &Uint8Array) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.get_raw_buffer_to_array_internal(destination))
+    }
 }

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -97,7 +97,7 @@ where
     }
 
     fn destroy(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(Structure::destroy(self.as_ref()))
+        ErrorCode::result_from_i8(Structure::destroy(self.as_ref()))
     }
 
     fn is_active(&self) -> bool {
@@ -105,6 +105,6 @@ where
     }
 
     fn notify_when_attacked(&self, val: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(Structure::notify_when_attacked(self.as_ref(), val))
+        ErrorCode::result_from_i8(Structure::notify_when_attacked(self.as_ref(), val))
     }
 }

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ReturnCode, StructureType},
+    constants::{ErrorCode, StructureType},
     objects::RoomObject,
     prelude::*,
 };
@@ -50,7 +50,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure.destroy)
     #[wasm_bindgen(method)]
-    pub fn destroy(this: &Structure) -> ReturnCode;
+    pub fn destroy(this: &Structure) -> i8;
 
     /// Determine if the structure is active and can be used at the current RCL.
     ///
@@ -63,7 +63,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure.notifyWhenAttacked)
     #[wasm_bindgen(method, js_name = notifyWhenAttacked)]
-    pub fn notify_when_attacked(this: &Structure, val: bool) -> ReturnCode;
+    pub fn notify_when_attacked(this: &Structure, val: bool) -> i8;
 }
 
 impl<T> HasNativeId for T
@@ -96,15 +96,15 @@ where
         Structure::structure_type(self.as_ref())
     }
 
-    fn destroy(&self) -> ReturnCode {
-        Structure::destroy(self.as_ref())
+    fn destroy(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(Structure::destroy(self.as_ref()))
     }
 
     fn is_active(&self) -> bool {
         Structure::is_active(self.as_ref())
     }
 
-    fn notify_when_attacked(&self, val: bool) -> ReturnCode {
-        Structure::notify_when_attacked(self.as_ref(), val)
+    fn notify_when_attacked(&self, val: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(Structure::notify_when_attacked(self.as_ref(), val))
     }
 }

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -2,8 +2,9 @@ use js_sys::{Date, JsString};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ReturnCode,
+    constants::ErrorCode,
     objects::{OwnedStructure, RoomObject, Structure},
+    prelude::*,
 };
 
 #[wasm_bindgen]
@@ -100,13 +101,23 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.activateSafeMode)
     #[wasm_bindgen(method, js_name = activateSafeMode)]
-    pub fn activate_safe_mode(this: &StructureController) -> ReturnCode;
+    fn activate_safe_mode_internal(this: &StructureController) -> i8;
 
     /// Relinquish ownership of the controller and its room.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.unclaim)
-    #[wasm_bindgen(method)]
-    pub fn unclaim(this: &StructureController) -> ReturnCode;
+    #[wasm_bindgen(method, js_name = unclaim)]
+    fn unclaim_internal(this: &StructureController) -> i8;
+}
+
+impl StructureController {
+    pub fn activate_safe_mode(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.activate_safe_mode_internal())
+    }
+
+    pub fn unclaim(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.unclaim_internal())
+    }
 }
 
 #[wasm_bindgen]

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -112,11 +112,11 @@ extern "C" {
 
 impl StructureController {
     pub fn activate_safe_mode(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.activate_safe_mode_internal())
+        ErrorCode::result_from_i8(self.activate_safe_mode_internal())
     }
 
     pub fn unclaim(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.unclaim_internal())
+        ErrorCode::result_from_i8(self.unclaim_internal())
     }
 }
 

--- a/src/objects/impls/structure_factory.rs
+++ b/src/objects/impls/structure_factory.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ResourceType, ReturnCode},
+    constants::{ErrorCode, ResourceType},
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -41,8 +41,14 @@ extern "C" {
     /// Produce a commodity in the factory.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureFactory.produce)
-    #[wasm_bindgen(method)]
-    pub fn produce(this: &StructureFactory, ty: ResourceType) -> ReturnCode;
+    #[wasm_bindgen(method, js_name = produce)]
+    fn produce_internal(this: &StructureFactory, ty: ResourceType) -> i8;
+}
+
+impl StructureFactory {
+    pub fn produce(&self, ty: ResourceType) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.produce_internal(ty))
+    }
 }
 
 impl HasCooldown for StructureFactory {

--- a/src/objects/impls/structure_factory.rs
+++ b/src/objects/impls/structure_factory.rs
@@ -47,7 +47,7 @@ extern "C" {
 
 impl StructureFactory {
     pub fn produce(&self, ty: ResourceType) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.produce_internal(ty))
+        ErrorCode::result_from_i8(self.produce_internal(ty))
     }
 }
 

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ResourceType, ReturnCode},
+    constants::{ErrorCode, ResourceType},
     objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -37,6 +37,25 @@ extern "C" {
     #[wasm_bindgen(method, getter = mineralType)]
     pub fn mineral_type(this: &StructureLab) -> Option<ResourceType>;
 
+    #[wasm_bindgen(method, js_name = boostCreep)]
+    fn boost_creep_internal(this: &StructureLab, creep: &Creep, body_part_count: Option<u32>)
+        -> i8;
+
+    #[wasm_bindgen(method, js_name = reverseReaction)]
+    fn reverse_reaction_internal(
+        this: &StructureLab,
+        lab1: &StructureLab,
+        lab2: &StructureLab,
+    ) -> i8;
+
+    #[wasm_bindgen(method, js_name = runReaction)]
+    fn run_reaction_internal(this: &StructureLab, lab1: &StructureLab, lab2: &StructureLab) -> i8;
+
+    #[wasm_bindgen(method, js_name = unboostCreep)]
+    fn unboost_creep_internal(this: &StructureLab, creep: &Creep) -> i8;
+}
+
+impl StructureLab {
     /// Boost a [`Creep`] in melee range, consuming [`LAB_BOOST_ENERGY`] energy
     /// and [`LAB_BOOST_MINERAL`] of the boost compound from the
     /// [`StructureLab::store`] per boosted body part.
@@ -45,34 +64,33 @@ extern "C" {
     ///
     /// [`LAB_BOOST_ENERGY`]: crate::constants::numbers::LAB_BOOST_ENERGY
     /// [`LAB_BOOST_MINERAL`]: crate::constants::numbers::LAB_BOOST_MINERAL
-    #[wasm_bindgen(method, js_name = boostCreep)]
     pub fn boost_creep(
-        this: &StructureLab,
+        &self,
         creep: &Creep,
         body_part_count: Option<u32>,
-    ) -> ReturnCode;
+    ) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.boost_creep_internal(creep, body_part_count))
+    }
 
     /// Reverse a reaction, splitting the compound in this [`StructureLab`] into
     /// its components in two other labs.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.reverseReaction)
-    #[wasm_bindgen(method, js_name = reverseReaction)]
     pub fn reverse_reaction(
-        this: &StructureLab,
+        &self,
         lab1: &StructureLab,
         lab2: &StructureLab,
-    ) -> ReturnCode;
+    ) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.reverse_reaction_internal(lab1, lab2))
+    }
 
     /// Run a reaction, combining components from two other [`StructureLab`]s
     /// into a new compound in this lab.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.runReaction)
-    #[wasm_bindgen(method, js_name = runReaction)]
-    pub fn run_reaction(
-        this: &StructureLab,
-        lab1: &StructureLab,
-        lab2: &StructureLab,
-    ) -> ReturnCode;
+    pub fn run_reaction(&self, lab1: &StructureLab, lab2: &StructureLab) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.run_reaction_internal(lab1, lab2))
+    }
 
     /// Unboost a [`Creep`], removing all boosts from its body and dropping
     /// [`LAB_UNBOOST_MINERAL`] per body part on the ground, with a cooldown
@@ -81,8 +99,9 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.unboostCreep)
     ///
     /// [`LAB_UNBOOST_ENERGY`]: crate::constants::numbers::LAB_UNBOOST_ENERGY
-    #[wasm_bindgen(method, js_name = unboostCreep)]
-    pub fn unboost_creep(this: &StructureLab, creep: &Creep) -> ReturnCode;
+    pub fn unboost_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.unboost_creep_internal(creep))
+    }
 }
 
 impl HasCooldown for StructureLab {

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -69,7 +69,7 @@ impl StructureLab {
         creep: &Creep,
         body_part_count: Option<u32>,
     ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.boost_creep_internal(creep, body_part_count))
+        ErrorCode::result_from_i8(self.boost_creep_internal(creep, body_part_count))
     }
 
     /// Reverse a reaction, splitting the compound in this [`StructureLab`] into
@@ -81,7 +81,7 @@ impl StructureLab {
         lab1: &StructureLab,
         lab2: &StructureLab,
     ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.reverse_reaction_internal(lab1, lab2))
+        ErrorCode::result_from_i8(self.reverse_reaction_internal(lab1, lab2))
     }
 
     /// Run a reaction, combining components from two other [`StructureLab`]s
@@ -89,7 +89,7 @@ impl StructureLab {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.runReaction)
     pub fn run_reaction(&self, lab1: &StructureLab, lab2: &StructureLab) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.run_reaction_internal(lab1, lab2))
+        ErrorCode::result_from_i8(self.run_reaction_internal(lab1, lab2))
     }
 
     /// Unboost a [`Creep`], removing all boosts from its body and dropping
@@ -100,7 +100,7 @@ impl StructureLab {
     ///
     /// [`LAB_UNBOOST_ENERGY`]: crate::constants::numbers::LAB_UNBOOST_ENERGY
     pub fn unboost_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.unboost_creep_internal(creep))
+        ErrorCode::result_from_i8(self.unboost_creep_internal(creep))
     }
 }
 

--- a/src/objects/impls/structure_link.rs
+++ b/src/objects/impls/structure_link.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ReturnCode,
+    constants::ErrorCode,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -30,6 +30,15 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn store(this: &StructureLink) -> Store;
 
+    #[wasm_bindgen(method, js_name = transferEnergy)]
+    fn transfer_energy_internal(
+        this: &StructureLink,
+        target: &StructureLink,
+        amount: Option<u32>,
+    ) -> i8;
+}
+
+impl StructureLink {
     /// Transfer energy from this [`StructureLink`] to another, losing
     /// [`LINK_LOSS_RATIO`] percent of the energt and incurring a cooldown of
     /// [`LINK_COOLDOWN`] tick per range to the target.
@@ -38,12 +47,13 @@ extern "C" {
     ///
     /// [`LINK_LOSS_RATIO`]: crate::constants::LINK_LOSS_RATIO
     /// [`LINK_COOLDOWN`]: crate::constants::LINK_COOLDOWN
-    #[wasm_bindgen(method, js_name = transferEnergy)]
     pub fn transfer_energy(
-        this: &StructureLink,
+        &self,
         target: &StructureLink,
         amount: Option<u32>,
-    ) -> ReturnCode;
+    ) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.transfer_energy_internal(target, amount))
+    }
 }
 
 impl HasCooldown for StructureLink {

--- a/src/objects/impls/structure_link.rs
+++ b/src/objects/impls/structure_link.rs
@@ -52,7 +52,7 @@ impl StructureLink {
         target: &StructureLink,
         amount: Option<u32>,
     ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.transfer_energy_internal(target, amount))
+        ErrorCode::result_from_i8(self.transfer_energy_internal(target, amount))
     }
 }
 

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ReturnCode,
+    constants::ErrorCode,
     objects::{OwnedStructure, RoomObject, RoomPosition, Store, Structure},
     prelude::*,
 };
@@ -32,13 +32,17 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn store(this: &StructureNuker) -> Store;
 
-    /// Transfer energy from this [`StructureNuker`] to another, losing
-    /// [`LINK_LOSS_RATIO`] and incurring a cooldown of [`LINK_COOLDOWN`] per
-    /// range to the target.
+    #[wasm_bindgen(method, js_name = launchNuke)]
+    fn launch_nuke_internal(this: &StructureNuker, target: &RoomPosition) -> i8;
+}
+
+impl StructureNuker {
+    /// Launch a nuke at a target [`RoomPosition`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureNuker.launchNuke)
-    #[wasm_bindgen(method, js_name = launchNuke)]
-    pub fn launch_nuke(this: &StructureNuker, target: &RoomPosition) -> ReturnCode;
+    pub fn launch_nuke(&self, target: &RoomPosition) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.launch_nuke_internal(target))
+    }
 }
 
 impl HasCooldown for StructureNuker {

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -41,7 +41,7 @@ impl StructureNuker {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureNuker.launchNuke)
     pub fn launch_nuke(&self, target: &RoomPosition) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.launch_nuke_internal(target))
+        ErrorCode::result_from_i8(self.launch_nuke_internal(target))
     }
 }
 

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -30,6 +30,6 @@ impl StructureObserver {
     pub fn observe_room(&self, target: RoomName) -> Result<(), ErrorCode> {
         let target = target.into();
 
-        ErrorCode::result_from_i8_unchecked(self.observe_room_internal(&target))
+        ErrorCode::result_from_i8(self.observe_room_internal(&target))
     }
 }

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -2,9 +2,10 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ReturnCode,
+    constants::ErrorCode,
+    local::RoomName,
     objects::{OwnedStructure, RoomObject, Structure},
-    RoomName,
+    prelude::*,
 };
 
 #[wasm_bindgen]
@@ -22,13 +23,13 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureObserver.observeRoom)
     #[wasm_bindgen(method, js_name = observeRoom)]
-    fn observe_room_internal(this: &StructureObserver, target: &JsString) -> ReturnCode;
+    fn observe_room_internal(this: &StructureObserver, target: &JsString) -> i8;
 }
 
 impl StructureObserver {
-    pub fn observe_room(&self, target: RoomName) -> ReturnCode {
+    pub fn observe_room(&self, target: RoomName) -> Result<(), ErrorCode> {
         let target = target.into();
 
-        Self::observe_room_internal(self, &target)
+        ErrorCode::result_from_i8_unchecked(self.observe_room_internal(&target))
     }
 }

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ReturnCode,
+    constants::ErrorCode,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -30,7 +30,20 @@ extern "C" {
     /// [`POWER_SPAWN_ENERGY_RATIO`]:
     /// crate::constants::numbers::POWER_SPAWN_ENERGY_RATIO
     #[wasm_bindgen(method, js_name = processPower)]
-    pub fn process_power(this: &StructurePowerSpawn) -> ReturnCode;
+    fn process_power_internal(this: &StructurePowerSpawn) -> i8;
+}
+
+impl StructurePowerSpawn {
+    /// Process power, consuming 1 power and [`POWER_SPAWN_ENERGY_RATIO`] energy
+    /// and increasing your GPL by one point.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructurePowerSpawn.processPower)
+    ///
+    /// [`POWER_SPAWN_ENERGY_RATIO`]:
+    /// crate::constants::numbers::POWER_SPAWN_ENERGY_RATIO
+    pub fn process_power(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.process_power_internal())
+    }
 }
 
 impl HasStore for StructurePowerSpawn {

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -42,7 +42,7 @@ impl StructurePowerSpawn {
     /// [`POWER_SPAWN_ENERGY_RATIO`]:
     /// crate::constants::numbers::POWER_SPAWN_ENERGY_RATIO
     pub fn process_power(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.process_power_internal())
+        ErrorCode::result_from_i8(self.process_power_internal())
     }
 }
 

--- a/src/objects/impls/structure_rampart.rs
+++ b/src/objects/impls/structure_rampart.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ReturnCode,
+    constants::ErrorCode,
     objects::{OwnedStructure, RoomObject, Structure},
     prelude::*,
 };
@@ -33,12 +33,18 @@ extern "C" {
     #[wasm_bindgen(method, getter = ticksToDecay)]
     pub fn ticks_to_decay(this: &StructureRampart) -> u32;
 
+    #[wasm_bindgen(method, js_name = setPublic)]
+    fn set_public_internal(this: &StructureRampart, val: bool) -> i8;
+}
+
+impl StructureRampart {
     /// Set whether [`StructureRampart`] is public, allowing hostile creeps to
     /// walk on it.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureRampart.setPublic)
-    #[wasm_bindgen(method, js_name = setPublic)]
-    pub fn set_public(this: &StructureRampart, val: bool) -> ReturnCode;
+    pub fn set_public(&self, public: bool) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.set_public_internal(public))
+    }
 }
 
 impl CanDecay for StructureRampart {

--- a/src/objects/impls/structure_rampart.rs
+++ b/src/objects/impls/structure_rampart.rs
@@ -43,7 +43,7 @@ impl StructureRampart {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureRampart.setPublic)
     pub fn set_public(&self, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.set_public_internal(public))
+        ErrorCode::result_from_i8(self.set_public_internal(public))
     }
 }
 

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -75,7 +75,7 @@ impl StructureSpawn {
     pub fn spawn_creep(&self, body: &[Part], name: &str) -> Result<(), ErrorCode> {
         let body = body.iter().cloned().map(JsValue::from).collect();
 
-        ErrorCode::result_from_i8_unchecked(Self::spawn_creep_internal(self, &body, name, None))
+        ErrorCode::result_from_i8(Self::spawn_creep_internal(self, &body, name, None))
     }
 
     /// Create a new creep with the specified body part [`Array`], name
@@ -113,7 +113,7 @@ impl StructureSpawn {
             ObjectExt::set(&js_opts, "directions", array);
         }
 
-        ErrorCode::result_from_i8_unchecked(Self::spawn_creep_internal(
+        ErrorCode::result_from_i8(Self::spawn_creep_internal(
             self,
             &body,
             name,
@@ -127,7 +127,7 @@ impl StructureSpawn {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.recycleCreep)
     pub fn recycle_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.recycle_creep_internal(creep))
+        ErrorCode::result_from_i8(self.recycle_creep_internal(creep))
     }
 
     /// Renew a [`Creep`] in melee range, removing all boosts adding to its TTL.
@@ -135,7 +135,7 @@ impl StructureSpawn {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.renewCreep)
     pub fn renew_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.renew_creep_internal(creep))
+        ErrorCode::result_from_i8(self.renew_creep_internal(creep))
     }
 }
 
@@ -257,7 +257,7 @@ impl Spawning {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.Spawning.cancel)
     pub fn cancel(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.cancel_internal())
+        ErrorCode::result_from_i8(self.cancel_internal())
     }
 
     /// Change allowed directions for the creep to leave the spawn once it's
@@ -265,6 +265,6 @@ impl Spawning {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections)
     pub fn set_directions(&self, directions: &Array) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.set_directions_internal(directions))
+        ErrorCode::result_from_i8(self.set_directions_internal(directions))
     }
 }

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -2,7 +2,7 @@ use js_sys::{Array, JsString, Object};
 use wasm_bindgen::{prelude::*, JsCast};
 
 use crate::{
-    constants::{Direction, Part, ReturnCode},
+    constants::{Direction, ErrorCode, Part},
     objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -47,6 +47,22 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn store(this: &StructureSpawn) -> Store;
 
+    #[wasm_bindgen(method, js_name = spawnCreep)]
+    fn spawn_creep_internal(
+        this: &StructureSpawn,
+        body: &Array,
+        name: &str,
+        options: Option<&Object>,
+    ) -> i8;
+
+    #[wasm_bindgen(method, js_name = recycleCreep)]
+    fn recycle_creep_internal(this: &StructureSpawn, creep: &Creep) -> i8;
+
+    #[wasm_bindgen(method, js_name = renewCreep)]
+    fn renew_creep_internal(this: &StructureSpawn, creep: &Creep) -> i8;
+}
+
+impl StructureSpawn {
     /// Create a new creep with the specified body part [`Array`], name
     /// [`JsString`], and optional spawning options. Note that successfully
     /// spawning will store data in `Memory.creeps[creep_name]` _regardless
@@ -56,43 +72,27 @@ extern "C" {
     /// about how to replace Memory and/or delete RawMemory._parsed
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.spawnCreep)
-    #[wasm_bindgen(method, js_name = spawnCreep)]
-    fn spawn_creep_internal(
-        this: &StructureSpawn,
-        body: &Array,
-        name: &str,
-        options: Option<&Object>,
-    ) -> ReturnCode;
-
-    /// Kill a [`Creep`] in melee range, returning 100% of its TTL-adjusted
-    /// resources (5x more than if the creep is killed another way). Can be used
-    /// while spawning.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.recycleCreep)
-    #[wasm_bindgen(method, js_name = recycleCreep)]
-    pub fn recycle_creep(this: &StructureSpawn, creep: &Creep) -> ReturnCode;
-
-    /// Renew a [`Creep`] in melee range, removing all boosts adding to its TTL.
-    /// Cannot be used while spawning.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.renewCreep)
-    #[wasm_bindgen(method, js_name = renewCreep)]
-    pub fn renew_creep(this: &StructureSpawn, creep: &Creep) -> ReturnCode;
-}
-
-impl StructureSpawn {
-    pub fn spawn_creep(&self, body: &[Part], name: &str) -> ReturnCode {
+    pub fn spawn_creep(&self, body: &[Part], name: &str) -> Result<(), ErrorCode> {
         let body = body.iter().cloned().map(JsValue::from).collect();
 
-        Self::spawn_creep_internal(self, &body, name, None)
+        ErrorCode::result_from_i8_unchecked(Self::spawn_creep_internal(self, &body, name, None))
     }
 
+    /// Create a new creep with the specified body part [`Array`], name
+    /// [`JsString`], and optional spawning options. Note that successfully
+    /// spawning will store data in `Memory.creeps[creep_name]` _regardless
+    /// of whether any memory data was passed in the options object_ and enable
+    /// the default serialization behavior of the `Memory` object, which may
+    /// hamper attempts to directly use `RawMemory`. todo, add note+docs
+    /// about how to replace Memory and/or delete RawMemory._parsed
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.spawnCreep)
     pub fn spawn_creep_with_options(
         &self,
         body: &[Part],
         name: &str,
         opts: &SpawnOptions,
-    ) -> ReturnCode {
+    ) -> Result<(), ErrorCode> {
         let body = body.iter().cloned().map(JsValue::from).collect();
 
         let js_opts = ObjectExt::unchecked_from_js(JsValue::from(Object::new()));
@@ -113,7 +113,29 @@ impl StructureSpawn {
             ObjectExt::set(&js_opts, "directions", array);
         }
 
-        Self::spawn_creep_internal(self, &body, name, Some(&js_opts))
+        ErrorCode::result_from_i8_unchecked(Self::spawn_creep_internal(
+            self,
+            &body,
+            name,
+            Some(&js_opts),
+        ))
+    }
+
+    /// Kill a [`Creep`] in melee range, returning 100% of its TTL-adjusted
+    /// resources (5x more than if the creep is killed another way). Can be used
+    /// while spawning.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.recycleCreep)
+    pub fn recycle_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.recycle_creep_internal(creep))
+    }
+
+    /// Renew a [`Creep`] in melee range, removing all boosts adding to its TTL.
+    /// Cannot be used while spawning.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.renewCreep)
+    pub fn renew_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.renew_creep_internal(creep))
     }
 }
 
@@ -223,16 +245,26 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn spawn(this: &Spawning) -> Structure;
 
+    #[wasm_bindgen(method, js_name = cancel)]
+    fn cancel_internal(this: &Spawning) -> i8;
+
+    #[wasm_bindgen(method, js_name = setDirections)]
+    fn set_directions_internal(this: &Spawning, directions: &Array) -> i8;
+}
+
+impl Spawning {
     /// Cancel spawning this creep, without refunding any energy.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.Spawning.cancel)
-    #[wasm_bindgen(method)]
-    pub fn cancel(this: &Spawning) -> ReturnCode;
+    pub fn cancel(&self) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.cancel_internal())
+    }
 
     /// Change allowed directions for the creep to leave the spawn once it's
     /// ready.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections)
-    #[wasm_bindgen(method, js_name = setDirections)]
-    pub fn set_directions(this: &Spawning, directions: &Array) -> ReturnCode;
+    pub fn set_directions(&self, directions: &Array) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.set_directions_internal(directions))
+    }
 }

--- a/src/objects/impls/structure_terminal.rs
+++ b/src/objects/impls/structure_terminal.rs
@@ -56,7 +56,7 @@ impl StructureTerminal {
         let desination = destination.into();
         let description = description.map(JsString::from);
 
-        ErrorCode::result_from_i8_unchecked(self.send_internal(
+        ErrorCode::result_from_i8(self.send_internal(
             resource_type,
             amount,
             &desination,

--- a/src/objects/impls/structure_terminal.rs
+++ b/src/objects/impls/structure_terminal.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ResourceType, ReturnCode},
+    constants::{ErrorCode, ResourceType},
     local::RoomName,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
@@ -39,7 +39,7 @@ extern "C" {
         amount: u32,
         destination: &JsString,
         description: Option<&JsString>,
-    ) -> ReturnCode;
+    ) -> i8;
 }
 
 impl StructureTerminal {
@@ -52,17 +52,16 @@ impl StructureTerminal {
         amount: u32,
         destination: RoomName,
         description: Option<&str>,
-    ) -> ReturnCode {
+    ) -> Result<(), ErrorCode> {
         let desination = destination.into();
         let description = description.map(JsString::from);
 
-        Self::send_internal(
-            self,
+        ErrorCode::result_from_i8_unchecked(self.send_internal(
             resource_type,
             amount,
             &desination,
             description.as_ref(),
-        )
+        ))
     }
 }
 

--- a/src/objects/impls/structure_tower.rs
+++ b/src/objects/impls/structure_tower.rs
@@ -45,7 +45,7 @@ impl StructureTower {
     where
         T: ?Sized + Attackable,
     {
-        ErrorCode::result_from_i8_unchecked(self.attack_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.attack_internal(target.as_ref()))
     }
 
     /// Heal a [`Creep`] or [`PowerCreep`] in the room, adding hit points
@@ -59,7 +59,7 @@ impl StructureTower {
     where
         T: ?Sized + Healable,
     {
-        ErrorCode::result_from_i8_unchecked(self.heal_internal(target.as_ref()))
+        ErrorCode::result_from_i8(self.heal_internal(target.as_ref()))
     }
 
     /// Repair a [`Structure`] in the room, adding hit points depending on
@@ -67,7 +67,7 @@ impl StructureTower {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureTower.repair)
     pub fn repair(&self, target: &Structure) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8_unchecked(self.repair_internal(target))
+        ErrorCode::result_from_i8(self.repair_internal(target))
     }
 }
 

--- a/src/objects/impls/structure_tower.rs
+++ b/src/objects/impls/structure_tower.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ReturnCode,
+    constants::ErrorCode,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -24,17 +24,13 @@ extern "C" {
     pub fn store(this: &StructureTower) -> Store;
 
     #[wasm_bindgen(method, js_name = attack)]
-    fn attack_internal(this: &StructureTower, target: &RoomObject) -> ReturnCode;
+    fn attack_internal(this: &StructureTower, target: &RoomObject) -> i8;
 
     #[wasm_bindgen(method, js_name = heal)]
-    fn heal_internal(this: &StructureTower, target: &RoomObject) -> ReturnCode;
+    fn heal_internal(this: &StructureTower, target: &RoomObject) -> i8;
 
-    /// Repair a [`Structure`] in the room, adding hit points depending on
-    /// range.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#StructureTower.repair)
     #[wasm_bindgen(method, js_name = repair)]
-    pub fn repair(this: &StructureTower, target: &Structure) -> ReturnCode;
+    fn repair_internal(this: &StructureTower, target: &Structure) -> i8;
 }
 
 impl StructureTower {
@@ -45,11 +41,11 @@ impl StructureTower {
     ///
     /// [`Creep`]: crate::objects::Creep
     /// [`PowerCreep`]: crate::objects::PowerCreep
-    pub fn attack<T>(&self, target: &T) -> ReturnCode
+    pub fn attack<T>(&self, target: &T) -> Result<(), ErrorCode>
     where
         T: ?Sized + Attackable,
     {
-        Self::attack_internal(self, target.as_ref())
+        ErrorCode::result_from_i8_unchecked(self.attack_internal(target.as_ref()))
     }
 
     /// Heal a [`Creep`] or [`PowerCreep`] in the room, adding hit points
@@ -59,11 +55,19 @@ impl StructureTower {
     ///
     /// [`Creep`]: crate::objects::Creep
     /// [`PowerCreep`]: crate::objects::PowerCreep
-    pub fn heal<T>(&self, target: &T) -> ReturnCode
+    pub fn heal<T>(&self, target: &T) -> Result<(), ErrorCode>
     where
         T: ?Sized + Healable,
     {
-        Self::heal_internal(self, target.as_ref())
+        ErrorCode::result_from_i8_unchecked(self.heal_internal(target.as_ref()))
+    }
+
+    /// Repair a [`Structure`] in the room, adding hit points depending on
+    /// range.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureTower.repair)
+    pub fn repair(&self, target: &Structure) -> Result<(), ErrorCode> {
+        ErrorCode::result_from_i8_unchecked(self.repair_internal(target))
     }
 }
 

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -15,7 +15,7 @@ use js_sys::{Array, JsString, Object};
 
 use wasm_bindgen::prelude::*;
 
-use crate::js_collections::JsHashMap;
+use crate::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -54,7 +54,6 @@ pub trait HasNativeId {
 }
 
 pub trait MaybeHasNativeId {
-
     fn try_native_id(&self) -> Option<JsString>;
 }
 
@@ -356,12 +355,22 @@ pub trait SharedCreepProperties {
 
     /// Transfer a resource from the creep's store to [`Structure`],
     /// [`PowerCreep`], or another [`Creep`].
-    fn transfer<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode>
+    fn transfer<T>(
+        &self,
+        target: &T,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> Result<(), ErrorCode>
     where
         T: Transferable;
 
     /// Withdraw a resource from a [`Structure`], [`Tombstone`], or [`Ruin`].
-    fn withdraw<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode>
+    fn withdraw<T>(
+        &self,
+        target: &T,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> Result<(), ErrorCode>
     where
         T: Withdrawable;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,11 +10,23 @@ use wasm_bindgen::prelude::*;
 use crate::{
     constants::*,
     enums::*,
-    js_collections::JsObjectId,
     local::{ObjectId, Position, RawObjectId, RoomName},
     objects::*,
     pathfinder::SingleRoomCostResult,
+    prelude::*,
 };
+
+pub trait FromReturnCode {
+    type Error;
+
+    fn result_from_i8_unchecked(val: i8) -> Result<(), Self::Error>;
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>>;
+
+    fn try_result_from_jsvalue(val: &JsValue) -> Option<Result<(), Self::Error>> {
+        val.as_f64().and_then(|f| Self::try_result_from_i8(f as i8))
+    }
+}
 
 #[enum_dispatch]
 pub trait HasHits {
@@ -292,24 +304,24 @@ pub trait SharedCreepProperties {
     /// Cancel an a successfully called creep function from earlier in the tick,
     /// with a [`JsString`] that must contain the JS version of the function
     /// name.
-    fn cancel_order(&self, target: &JsString) -> ReturnCode;
+    fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode>;
 
     /// Drop a resource on the ground from the creep's [`Store`].
-    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> ReturnCode;
+    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode>;
 
     /// Move one square in the specified direction.
-    fn move_direction(&self, direction: Direction) -> ReturnCode;
+    fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode>;
 
     /// Move the creep along a previously determined path returned from a
     /// pathfinding function, in array or serialized string form.
-    fn move_by_path(&self, path: &JsValue) -> ReturnCode;
+    fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode>;
 
     /// Move the creep toward the specified goal, either a [`RoomPosition`] or
     /// [`RoomObject`]. Note that using this function will store data in
     /// `Memory.creeps[creep_name]` and enable the default serialization
     /// behavior of the `Memory` object, which may hamper attempts to directly
     /// use `RawMemory`.
-    fn move_to<T>(&self, target: T) -> ReturnCode
+    fn move_to<T>(&self, target: T) -> Result<(), ErrorCode>
     where
         T: HasPosition;
 
@@ -322,33 +334,43 @@ pub trait SharedCreepProperties {
         &self,
         target: T,
         options: Option<MoveToOptions<F>>,
-    ) -> ReturnCode
+    ) -> Result<(), ErrorCode>
     where
         T: HasPosition,
         F: FnMut(RoomName, CostMatrix) -> SingleRoomCostResult;
 
     /// Whether to send an email notification when this creep is attacked.
-    fn notify_when_attacked(&self, enabled: bool) -> ReturnCode;
+    fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode>;
 
     /// Pick up a [`Resource`] in melee range (or at the same position as the
     /// creep).
-    fn pickup(&self, target: &Resource) -> ReturnCode;
+    fn pickup(&self, target: &Resource) -> Result<(), ErrorCode>;
 
     /// Display a string in a bubble above the creep next tick. 10 character
     /// limit.
-    fn say(&self, message: &str, public: bool) -> ReturnCode;
+    fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode>;
 
     /// Immediately kill the creep.
-    fn suicide(&self) -> ReturnCode;
+    fn suicide(&self) -> Result<(), ErrorCode>;
 
     /// Transfer a resource from the creep's store to [`Structure`],
     /// [`PowerCreep`], or another [`Creep`].
-    fn transfer<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> ReturnCode
+    fn transfer<T>(
+        &self,
+        target: &T,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> Result<(), ErrorCode>
     where
         T: Transferable;
 
     /// Withdraw a resource from a [`Structure`], [`Tombstone`], or [`Ruin`].
-    fn withdraw<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> ReturnCode
+    fn withdraw<T>(
+        &self,
+        target: &T,
+        ty: ResourceType,
+        amount: Option<u32>,
+    ) -> Result<(), ErrorCode>
     where
         T: Withdrawable;
 }
@@ -357,11 +379,11 @@ pub trait SharedCreepProperties {
 pub trait StructureProperties {
     fn structure_type(&self) -> StructureType;
 
-    fn destroy(&self) -> ReturnCode;
+    fn destroy(&self) -> Result<(), ErrorCode>;
 
     fn is_active(&self) -> bool;
 
-    fn notify_when_attacked(&self, val: bool) -> ReturnCode;
+    fn notify_when_attacked(&self, val: bool) -> Result<(), ErrorCode>;
 }
 
 /// Trait for all wrappers over Screeps JavaScript objects which can be the

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,7 +19,7 @@ use crate::{
 pub trait FromReturnCode {
     type Error;
 
-    fn result_from_i8_unchecked(val: i8) -> Result<(), Self::Error>;
+    fn result_from_i8(val: i8) -> Result<(), Self::Error>;
 
     fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>>;
 
@@ -54,6 +54,7 @@ pub trait HasNativeId {
 }
 
 pub trait MaybeHasNativeId {
+
     fn try_native_id(&self) -> Option<JsString>;
 }
 
@@ -355,22 +356,12 @@ pub trait SharedCreepProperties {
 
     /// Transfer a resource from the creep's store to [`Structure`],
     /// [`PowerCreep`], or another [`Creep`].
-    fn transfer<T>(
-        &self,
-        target: &T,
-        ty: ResourceType,
-        amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    fn transfer<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode>
     where
         T: Transferable;
 
     /// Withdraw a resource from a [`Structure`], [`Tombstone`], or [`Ruin`].
-    fn withdraw<T>(
-        &self,
-        target: &T,
-        ty: ResourceType,
-        amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    fn withdraw<T>(&self, target: &T, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode>
     where
         T: Withdrawable;
 }


### PR DESCRIPTION
Resolves #3 🎊 

We've discussed in discord replacing `ErrorCode` with per-result-set error types to allow for exhaustive matching, but saving that for a separate PR since this is already a big change