### PR TITLE
Add ?Sized to withdraw and transfer methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Add `?Sized` to `SharedCreepProperties::withdraw` and `transfer` methods to allow dynamic use
+
 0.13.0 (2023-06-27)
 ===================
 

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -631,7 +631,7 @@ impl SharedCreepProperties for Creep {
         amount: Option<u32>,
     ) -> Result<(), ErrorCode>
     where
-        T: Transferable,
+        T: Transferable + ?Sized,
     {
         ErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
     }
@@ -643,7 +643,7 @@ impl SharedCreepProperties for Creep {
         amount: Option<u32>,
     ) -> Result<(), ErrorCode>
     where
-        T: Withdrawable,
+        T: Withdrawable + ?Sized,
     {
         ErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
     }

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -436,7 +436,7 @@ impl SharedCreepProperties for PowerCreep {
         amount: Option<u32>,
     ) -> Result<(), ErrorCode>
     where
-        T: Transferable,
+        T: Transferable + ?Sized,
     {
         ErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
     }
@@ -448,7 +448,7 @@ impl SharedCreepProperties for PowerCreep {
         amount: Option<u32>,
     ) -> Result<(), ErrorCode>
     where
-        T: Withdrawable,
+        T: Withdrawable + ?Sized,
     {
         ErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -362,7 +362,7 @@ pub trait SharedCreepProperties {
         amount: Option<u32>,
     ) -> Result<(), ErrorCode>
     where
-        T: Transferable;
+        T: Transferable + ?Sized;
 
     /// Withdraw a resource from a [`Structure`], [`Tombstone`], or [`Ruin`].
     fn withdraw<T>(
@@ -372,7 +372,7 @@ pub trait SharedCreepProperties {
         amount: Option<u32>,
     ) -> Result<(), ErrorCode>
     where
-        T: Withdrawable;
+        T: Withdrawable + ?Sized;
 }
 
 #[enum_dispatch]


### PR DESCRIPTION
We've already got `?Sized` on most creep methods that take trait-based inputs; this was missing from withdraw and transfer.