### PR TITLE
Minor documentation improvements

### DIFF
--- a/src/constants/extra.rs
+++ b/src/constants/extra.rs
@@ -1,8 +1,12 @@
 //! Additional constants representing internal game mechanics that aren't
 //! included in the game's constants
 
-/// Percentage of energy spent on construction that is left in a [`Resource`] if the construction
-/// site is destroyed by [`ConstructionSite::remove`] or being stepped on by a hostile creep
+/// Percentage of energy spent on construction that is left in a [`Resource`] if
+/// the construction site is destroyed by [`ConstructionSite::remove`] or being
+/// stepped on by a hostile creep
+///
+/// [`Resource`]: crate::objects::Resource
+/// [`ConstructionSite::remove`]: crate::objects::ConstructionSite::remove
 pub const CONSTRUCTION_SITE_STOMP_RATIO: f32 = 0.5;
 
 /// Maximum length of signs on controllers.

--- a/src/constants/extra.rs
+++ b/src/constants/extra.rs
@@ -1,8 +1,8 @@
 //! Additional constants representing internal game mechanics that aren't
 //! included in the game's constants
 
-/// Percentage of energy spent on construction that is list if the construction
-/// site is destroyed by being stepped on by a hostile creep.
+/// Percentage of energy spent on construction that is left in a [`Resource`] if the construction
+/// site is destroyed by [`ConstructionSite::remove`] or being stepped on by a hostile creep
 pub const CONSTRUCTION_SITE_STOMP_RATIO: f32 = 0.5;
 
 /// Maximum length of signs on controllers.
@@ -23,11 +23,6 @@ pub const CPU_SET_SHARD_LIMITS_COOLDOWN: u32 = 12 * 3600 * 1000;
 /// [`cpu::tick_limit`]: crate::game::cpu::tick_limit
 pub const CPU_TICK_LIMIT_MAX: u32 = 500;
 
-/// The cost of a single intent, i.e., an action that changes the game state, in
-/// the fraction of CPU. Note that 1 CPU is 1 ms of execution time on the
-/// official server.
-pub const INTENT_CPU_COST: f64 = 0.2;
-
 /// Hits per creep body part.
 pub const CREEP_HITS_PER_PART: u32 = 100;
 
@@ -39,6 +34,11 @@ pub const CREEP_SAY_MAX_LENGTH: u32 = 10;
 
 /// Maximum length of names of flag objects.
 pub const FLAG_NAME_MAX_LENGTH: u32 = 60;
+
+/// The cost of a single intent, i.e., an action that changes the game state, in
+/// the fraction of CPU. Note that 1 CPU is 1 ms of execution time on the
+/// official server.
+pub const INTENT_CPU_COST: f64 = 0.2;
 
 /// Maximum size in UTF-16 units of data allowed to be sent to
 /// [`inter_shard_memory::set_local`]

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -153,7 +153,7 @@ impl PowerCreep {
     }
 
     /// Current level of the power creep, which can be increased with
-    /// [`PowerCreep::upgrade`] if you have unspent GPL.
+    /// [`AccountPowerCreep::upgrade`] if you have unspent GPL.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.level)
     pub fn level(&self) -> u32 {
@@ -222,6 +222,8 @@ impl PowerCreep {
     /// renewed at a [`StructurePowerSpawn`] or [`StructurePowerBank`]
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.ticksToLive)
+    ///
+    /// [`StructurePowerBank`]: crate::objects::StructurePowerBank
     pub fn ticks_to_live(&self) -> Option<u32> {
         self.ticks_to_live_internal()
     }
@@ -284,6 +286,8 @@ impl PowerCreep {
     /// [`StructurePowerBank`] in melee range.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.renew)
+    ///
+    /// [`StructurePowerBank`]: crate::objects::StructurePowerBank
     pub fn renew(&self, target: &RoomObject) -> Result<(), ErrorCode> {
         ErrorCode::result_from_i8(self.renew_internal(target))
     }
@@ -507,8 +511,8 @@ impl AccountPowerCreep {
 
     // todo should be u64 but seems to panic at the moment, follow up
     /// The timestamp, in milliseconds since epoch, when the [`PowerCreep`] will
-    /// be permanently deleted due to [`PowerCreep::delete`]. Can be cancelled
-    /// with the same function until then.
+    /// be permanently deleted due to [`AccountPowerCreep::delete`]. Can be
+    /// cancelled with the same function until then.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.deleteTime)
     pub fn delete_time(&self) -> Option<f64> {
@@ -516,7 +520,7 @@ impl AccountPowerCreep {
     }
 
     /// Current level of the power creep, which can be increased with
-    /// [`PowerCreep::upgrade`] if you have unspent GPL.
+    /// [`AccountPowerCreep::upgrade`] if you have unspent GPL.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.level)
     pub fn level(&self) -> u32 {

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -219,6 +219,7 @@ impl RoomPosition {
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomPosition.createConstructionSite)
     ///
     /// [`ConstructionSite`]: crate::objects::ConstructionSite
+    /// [`StructureSpawn`]: crate::objects::StructureSpawn
     pub fn create_construction_site(
         &self,
         ty: StructureType,

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -62,8 +62,8 @@ impl StructureLab {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.boostCreep)
     ///
-    /// [`LAB_BOOST_ENERGY`]: crate::constants::numbers::LAB_BOOST_ENERGY
-    /// [`LAB_BOOST_MINERAL`]: crate::constants::numbers::LAB_BOOST_MINERAL
+    /// [`LAB_BOOST_ENERGY`]: crate::constants::LAB_BOOST_ENERGY
+    /// [`LAB_BOOST_MINERAL`]: crate::constants::LAB_BOOST_MINERAL
     pub fn boost_creep(
         &self,
         creep: &Creep,
@@ -98,7 +98,7 @@ impl StructureLab {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.unboostCreep)
     ///
-    /// [`LAB_UNBOOST_ENERGY`]: crate::constants::numbers::LAB_UNBOOST_ENERGY
+    /// [`LAB_UNBOOST_MINERAL`]: crate::constants::LAB_UNBOOST_MINERAL
     pub fn unboost_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
         ErrorCode::result_from_i8(self.unboost_creep_internal(creep))
     }

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -39,8 +39,7 @@ impl StructurePowerSpawn {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructurePowerSpawn.processPower)
     ///
-    /// [`POWER_SPAWN_ENERGY_RATIO`]:
-    /// crate::constants::numbers::POWER_SPAWN_ENERGY_RATIO
+    /// [`POWER_SPAWN_ENERGY_RATIO`]: crate::constants::POWER_SPAWN_ENERGY_RATIO
     pub fn process_power(&self) -> Result<(), ErrorCode> {
         ErrorCode::result_from_i8(self.process_power_internal())
     }


### PR DESCRIPTION
- Clarify comments on `CONSTRUCTION_SITE_STOMP_RATIO` since it applies to removed as well as stomped construction sites (maybe we should rename it, but not worrying about that now).
- Fix a handful of bad references within docs