### PR TITLE
Revert RoomTerrain::get_raw_buffer to return Uint8Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Unreleased
 ==========
 
 - Add `?Sized` to `SharedCreepProperties::withdraw` and `transfer` methods to allow dynamic use
+- Revert `RoomTerrain::get_raw_buffer` return type from `Result<Uint8Array, ErrorCode>` back to
+  pre-0.13 `Uint8Array`, since it can't error when called with no destination (breaking)
 
 0.13.0 (2023-06-27)
 ===================

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -130,7 +130,7 @@ impl StructureType {
                 _ => 1,
             },
             Tower => match current_rcl {
-                0 | 1 | 2 => 0,
+                0..=2 => 0,
                 3 | 4 => 1,
                 5 | 6 => 2,
                 7 => 3,

--- a/src/local/object_id.rs
+++ b/src/local/object_id.rs
@@ -69,10 +69,7 @@ pub struct ObjectId<T> {
 impl<T> Copy for ObjectId<T> {}
 impl<T> Clone for ObjectId<T> {
     fn clone(&self) -> ObjectId<T> {
-        ObjectId {
-            raw: self.raw,
-            phantom: PhantomData,
-        }
+        *self
     }
 }
 impl<T> fmt::Debug for ObjectId<T> {

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -31,8 +31,7 @@ extern "C" {
     #[wasm_bindgen(method, js_name = getRawBuffer)]
     fn get_raw_buffer_internal(this: &RoomTerrain) -> Uint8Array;
 
-    // and when run with a destination array, it can only ever return a return code
-    // int
+    // and when called with a destination, it can only ever return a return code int
     #[wasm_bindgen(method, js_name = getRawBuffer)]
     fn get_raw_buffer_to_array_internal(this: &RoomTerrain, destination: &Uint8Array) -> i8;
 }

--- a/src/objects/impls/room_terrain.rs
+++ b/src/objects/impls/room_terrain.rs
@@ -27,9 +27,12 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn get(this: &RoomTerrain, x: u8, y: u8) -> Terrain;
 
+    // when called without a destination array, can't fail - no error code possible
     #[wasm_bindgen(method, js_name = getRawBuffer)]
-    fn get_raw_buffer_internal(this: &RoomTerrain) -> JsValue;
+    fn get_raw_buffer_internal(this: &RoomTerrain) -> Uint8Array;
 
+    // and when run with a destination array, it can only ever return a return code
+    // int
     #[wasm_bindgen(method, js_name = getRawBuffer)]
     fn get_raw_buffer_to_array_internal(this: &RoomTerrain, destination: &Uint8Array) -> i8;
 }
@@ -39,17 +42,15 @@ impl RoomTerrain {
     /// terrain.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer)
-    pub fn get_raw_buffer(&self) -> Result<Uint8Array, ErrorCode> {
-        // the only possible error for this function is invalid args, so simply return
-        // that directly instead of further checks if it's not a Uint8Array
+    #[inline]
+    pub fn get_raw_buffer(&self) -> Uint8Array {
         self.get_raw_buffer_internal()
-            .dyn_into()
-            .map_err(|_| ErrorCode::InvalidArgs)
     }
 
     /// Copy the data about the room's terrain into an existing [`Uint8Array`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.Terrain.getRawBuffer)
+    #[inline]
     pub fn get_raw_buffer_to_array(&self, destination: &Uint8Array) -> Result<(), ErrorCode> {
         ErrorCode::result_from_i8(self.get_raw_buffer_to_array_internal(destination))
     }


### PR DESCRIPTION
Made a mistake in the big `Result<_, ErrorCode>` change and mistakenly added handling for a potential error case to `RoomTerrain::get_raw_buffer` which can only happen when passing a destination array. Return this behavior back to how it was in prior releases.