### PR TITLE
Add `sim` feature to enable sim room name override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Unreleased
 - Add `?Sized` to `SharedCreepProperties::withdraw` and `transfer` methods to allow dynamic use
 - Revert `RoomTerrain::get_raw_buffer` return type from `Result<Uint8Array, ErrorCode>` back to
   pre-0.13 `Uint8Array`, since it can't error when called with no destination (breaking)
-- Add `sim` feature which enables the sim-related special cases in room names, allowing for bots
-  to be built to skip those checks if not needed
+- Add `sim` feature which enables the sim-related special case name of `sim` for a room at the
+  coordinates of W127N127, allowing for bots to be built to not include that support
 
 0.13.0 (2023-06-27)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Unreleased
 - Add `?Sized` to `SharedCreepProperties::withdraw` and `transfer` methods to allow dynamic use
 - Revert `RoomTerrain::get_raw_buffer` return type from `Result<Uint8Array, ErrorCode>` back to
   pre-0.13 `Uint8Array`, since it can't error when called with no destination (breaking)
+- Add `sim` feature which enables the sim-related special cases in room names, allowing for bots
+  to be built to skip those checks if not needed
 
 0.13.0 (2023-06-27)
 ===================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ bincode = "1.3"
 [features]
 ## Specific features to enable conditional API endpoints
 
+# enable compatibility with the sim environment for positions
+sim = []
+
 # Enable the function call for pixel generation - only present on official MMO servers
 generate-pixel = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,12 @@
 //!
 //! # Cargo Features
 //!
+//! ## `sim`
+//!
+//! Enables special-case handling of the unique room name present in the
+//! simulator - must be enabled to build code that is compatible with that
+//! environment
+//!
 //! ## `generate-pixel`
 //!
 //! Enables the function to generate pixels, which is only present on the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
 //!
 //! Enables special-case handling of the unique room name present in the
 //! simulator - must be enabled to build code that is compatible with that
-//! environment
+//! environment. If this is enabled, the top-left valid room coordinate has the
+//! name `sim`, otherwise it's named `W127N127`.
 //!
 //! ## `generate-pixel`
 //!

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -530,10 +530,11 @@ mod test {
                     (
                         RoomCoordinate::unchecked_new(5),
                         RoomCoordinate::unchecked_new(5),
-                        #[cfg(feature = "sim")]
-                        "sim",
-                        #[cfg(not(feature = "sim"))]
-                        "W127N127",
+                        if cfg!(feature = "sim") {
+                            "sim"
+                        } else {
+                            "W127N127"
+                        },
                     ),
                 ),
             ]

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -516,19 +516,24 @@ mod test {
                     ),
                 ),
                 (
-                    1285u32,
-                    (
-                        RoomCoordinate::unchecked_new(5),
-                        RoomCoordinate::unchecked_new(5),
-                        "sim",
-                    ),
-                ),
-                (
                     2021333800u32,
                     (
                         RoomCoordinate::unchecked_new(27),
                         RoomCoordinate::unchecked_new(40),
                         "W7N4",
+                    ),
+                ),
+                // this one is in the top left room - which is either sim, or W127N127 if the
+                // sim position overrides are inactive
+                (
+                    1285u32,
+                    (
+                        RoomCoordinate::unchecked_new(5),
+                        RoomCoordinate::unchecked_new(5),
+                        #[cfg(feature = "sim")]
+                        "sim",
+                        #[cfg(not(feature = "sim"))]
+                        "W127N127",
                     ),
                 ),
             ]

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -56,7 +56,8 @@ impl fmt::Display for RoomName {
     /// Resulting string will be `(E|W)[0-9]+(N|S)[0-9]+`, and will result
     /// in the same RoomName if passed into [`RoomName::new`].
     ///
-    /// If the `sim` feature is enabled, the result may also be `sim`.
+    /// If the `sim` feature is enabled, the room corresponding to W127N127
+    /// outputs `sim` instead.
     ///
     /// [`RoomName::new`]: struct.RoomName.html#method.new
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -558,10 +558,11 @@ mod test {
     #[test]
     fn test_string_equality() {
         use super::RoomName;
-        #[cfg(feature = "sim")]
-        let top_left_room = "sim";
-        #[cfg(not(feature = "sim"))]
-        let top_left_room = "W127N127";
+        let top_left_room = if cfg!(feature = "sim") {
+            "sim"
+        } else {
+            "W127N127"
+        };
         let room_names = vec!["E21N4", "w6S42", "W17s5", "e2n5", top_left_room];
         for room_name in room_names {
             assert_eq!(room_name, RoomName::new(room_name).unwrap());

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -56,13 +56,14 @@ impl fmt::Display for RoomName {
     /// Resulting string will be `(E|W)[0-9]+(N|S)[0-9]+`, and will result
     /// in the same RoomName if passed into [`RoomName::new`].
     ///
+    /// If the `sim` feature is enabled, the result may also be `sim`.
+    ///
     /// [`RoomName::new`]: struct.RoomName.html#method.new
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let x_coord = self.x_coord();
         let y_coord = self.y_coord();
 
-        #[cfg(feature = "sim")]
-        if self.packed == 0 {
+        if cfg!(feature = "sim") && self.packed == 0 {
             write!(f, "sim")?;
             return Ok(());
         }
@@ -99,7 +100,9 @@ impl RoomName {
     /// invalid room name.
     ///
     /// The expected format can be represented by the regex
-    /// `[ewEW][0-9]+[nsNS][0-9]+`.
+    /// `[ewEW][0-9]+[nsNS][0-9]+`. If the `sim` feature is enabled, `sim` is
+    /// also valid and uses the packed position of W127N127 (0), matching the
+    /// game's internal implementation of the sim room's packed positions.
     #[inline]
     pub fn new<T>(x: &T) -> Result<Self, RoomNameParseError>
     where
@@ -330,8 +333,7 @@ impl FromStr for RoomName {
 }
 
 fn parse_to_coords(s: &str) -> Result<(i32, i32), ()> {
-    #[cfg(feature = "sim")]
-    if s == "sim" {
+    if cfg!(feature = "sim") && s == "sim" {
         return Ok((-HALF_WORLD_SIZE, -HALF_WORLD_SIZE));
     }
 

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -61,20 +61,22 @@ impl fmt::Display for RoomName {
         let x_coord = self.x_coord();
         let y_coord = self.y_coord();
 
+        #[cfg(feature = "sim")]
         if self.packed == 0 {
             write!(f, "sim")?;
-        } else {
-            if x_coord >= 0 {
-                write!(f, "E{x_coord}")?;
-            } else {
-                write!(f, "W{}", -x_coord - 1)?;
-            }
+            return Ok(());
+        }
 
-            if y_coord >= 0 {
-                write!(f, "S{y_coord}")?;
-            } else {
-                write!(f, "N{}", -y_coord - 1)?;
-            }
+        if x_coord >= 0 {
+            write!(f, "E{}", x_coord)?;
+        } else {
+            write!(f, "W{}", -x_coord - 1)?;
+        }
+
+        if y_coord >= 0 {
+            write!(f, "S{}", y_coord)?;
+        } else {
+            write!(f, "N{}", -y_coord - 1)?;
         }
 
         Ok(())
@@ -328,6 +330,7 @@ impl FromStr for RoomName {
 }
 
 fn parse_to_coords(s: &str) -> Result<(i32, i32), ()> {
+    #[cfg(feature = "sim")]
     if s == "sim" {
         return Ok((-HALF_WORLD_SIZE, -HALF_WORLD_SIZE));
     }
@@ -555,7 +558,11 @@ mod test {
     #[test]
     fn test_string_equality() {
         use super::RoomName;
-        let room_names = vec!["E21N4", "w6S42", "W17s5", "e2n5", "sim"];
+        #[cfg(feature = "sim")]
+        let top_left_room = "sim";
+        #[cfg(not(feature = "sim"))]
+        let top_left_room = "W127N127";
+        let room_names = vec!["E21N4", "w6S42", "W17s5", "e2n5", top_left_room];
         for room_name in room_names {
             assert_eq!(room_name, RoomName::new(room_name).unwrap());
             assert_eq!(RoomName::new(room_name).unwrap(), room_name);


### PR DESCRIPTION
The special case for the `sim` room going into and out of positions/room names is always on, at the moment - though for most mature bots, the ability to run in the sim room is unimportant. Add the `sim` feature, which must be enabled to retain support for the special cases encountered there.