### PR TITLE
Add `const` to most functions representing constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Add `const` to most functions representing constants, so they can be evaluated during compile
+
 0.14.0 (2023-07-03)
 ===================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Add `RoomName::checked_add` to allow a math to be done on the position of the room on the map
+  without the potential to panic that the `ops::Add` implementation has
 - Add `const` to most functions representing constants, so they can be evaluated during compile
 
 0.14.0 (2023-07-03)
@@ -16,8 +18,6 @@ Unreleased
 ### Additions:
 
 - Add `?Sized` to `SharedCreepProperties::withdraw` and `transfer` methods to allow dynamic use
-- Add `RoomName::checked_add` to allow a math to be done on the position of the room on the map
-  without the potential to panic that the `ops::Add` implementation has
 
 0.13.0 (2023-06-27)
 ===================

--- a/src/constants/find.rs
+++ b/src/constants/find.rs
@@ -207,27 +207,27 @@ pub enum Exit {
 
 impl Exit {
     #[inline]
-    pub fn top() -> Self {
+    pub const fn top() -> Self {
         Exit::Top
     }
 
     #[inline]
-    pub fn right() -> Self {
+    pub const fn right() -> Self {
         Exit::Right
     }
 
     #[inline]
-    pub fn bottom() -> Self {
+    pub const fn bottom() -> Self {
         Exit::Bottom
     }
 
     #[inline]
-    pub fn left() -> Self {
+    pub const fn left() -> Self {
         Exit::Left
     }
 
     #[inline]
-    pub fn all() -> Self {
+    pub const fn all() -> Self {
         Exit::All
     }
 }

--- a/src/constants/numbers.rs
+++ b/src/constants/numbers.rs
@@ -115,7 +115,7 @@ pub const RAMPART_HITS_MAX_RCL8: u32 = 300_000_000;
 /// Translates the `RAMPART_HITS_MAX` constant, the maximum rampart hits for a
 /// given room control level.
 #[inline]
-pub fn rampart_hits_max(rcl: u32) -> u32 {
+pub const fn rampart_hits_max(rcl: u32) -> u32 {
     match rcl {
         r if r < 2 => 0,
         2 => RAMPART_HITS_MAX_RCL2,
@@ -192,7 +192,7 @@ pub const EXTENSION_HITS: u32 = 1000;
 /// Translates the `EXTENSION_ENERGY_CAPACITY` constant, the energy capacity of
 /// each source structure at a given room control level.
 #[inline]
-pub fn extension_energy_capacity(rcl: u32) -> u32 {
+pub const fn extension_energy_capacity(rcl: u32) -> u32 {
     match rcl {
         r if r < 7 => 50,
         7 => 100,
@@ -259,7 +259,7 @@ pub const CONSTRUCTION_COST_ROAD_WALL_RATIO: u32 = 150;
 ///
 /// Returns `Some` for levels 1-7, `None` for all others.
 #[inline]
-pub fn controller_levels(current_rcl: u32) -> Option<u32> {
+pub const fn controller_levels(current_rcl: u32) -> Option<u32> {
     match current_rcl {
         1 => Some(200),
         2 => Some(45_000),
@@ -286,7 +286,7 @@ pub fn controller_levels(current_rcl: u32) -> Option<u32> {
 /// [`StructureController::ticks_to_downgrade`]:
 /// crate::objects::StructureController::ticks_to_downgrade
 #[inline]
-pub fn controller_downgrade(rcl: u8) -> Option<u32> {
+pub const fn controller_downgrade(rcl: u8) -> Option<u32> {
     match rcl {
         1 => Some(20_000),
         2 => Some(10_000),
@@ -533,7 +533,7 @@ pub const MINERAL_REGEN_TIME: u32 = 50_000;
 ///
 /// [`Density::amount`]: crate::constants::Density::amount
 #[inline]
-pub fn mineral_min_amount(mineral: ResourceType) -> Option<u32> {
+pub const fn mineral_min_amount(mineral: ResourceType) -> Option<u32> {
     match mineral {
         ResourceType::Hydrogen => Some(35_000),
         ResourceType::Oxygen => Some(35_000),
@@ -648,7 +648,7 @@ pub const RUIN_DECAY: u32 = 500;
 /// Structures with special rules for their ruins' ticks to live, currently only
 /// power banks.
 #[inline]
-pub fn ruin_decay_structures(structure_type: StructureType) -> Option<u32> {
+pub const fn ruin_decay_structures(structure_type: StructureType) -> Option<u32> {
     match structure_type {
         StructureType::PowerBank => Some(10),
         _ => None,
@@ -773,7 +773,7 @@ pub const INVADER_CORE_HITS: u32 = 100_000;
 /// Ticks per body part that invader cores of each level take to spawn defensive
 /// creeps.
 #[inline]
-pub fn invader_core_creep_spawn_time(core_level: u32) -> Option<u32> {
+pub const fn invader_core_creep_spawn_time(core_level: u32) -> Option<u32> {
     match core_level {
         1 => Some(0),
         2 => Some(6),
@@ -787,7 +787,7 @@ pub fn invader_core_creep_spawn_time(core_level: u32) -> Option<u32> {
 /// Ticks between creation of invader cores in rooms in the sector for each
 /// level of stronghold.
 #[inline]
-pub fn invader_core_expand_time(core_level: u32) -> Option<u32> {
+pub const fn invader_core_expand_time(core_level: u32) -> Option<u32> {
     match core_level {
         1 => Some(4000),
         2 => Some(3500),
@@ -808,7 +808,7 @@ pub const INVADER_CORE_CONTROLLER_DOWNGRADE: u32 = 5000;
 
 /// Rampart hits for each level of stronghold.
 #[inline]
-pub fn stronghold_rampart_hits(core_level: u32) -> Option<u32> {
+pub const fn stronghold_rampart_hits(core_level: u32) -> Option<u32> {
     match core_level {
         1 => Some(100_000),
         2 => Some(200_000),

--- a/src/constants/recipes.rs
+++ b/src/constants/recipes.rs
@@ -20,7 +20,7 @@ pub struct FactoryRecipe {
 impl ResourceType {
     /// Translates the `REACTIONS` constant.
     #[inline]
-    pub fn reaction_components(self) -> Option<[ResourceType; 2]> {
+    pub const fn reaction_components(self) -> Option<[ResourceType; 2]> {
         use ResourceType::*;
         let components = match self {
             // OH: O + H,
@@ -99,7 +99,7 @@ impl ResourceType {
 
     /// Translates the `REACTION_TIME` constant.
     #[inline]
-    pub fn reaction_time(self) -> Option<u32> {
+    pub const fn reaction_time(self) -> Option<u32> {
         use ResourceType::*;
         let time = match self {
             // these comments copied directly from JavaScript 'constants.js' file.

--- a/src/constants/seasonal.rs
+++ b/src/constants/seasonal.rs
@@ -96,7 +96,7 @@ pub mod season_2 {
     ///
     /// [`SymbolDecoder`]: crate::objects::SymbolDecoder
     #[inline]
-    pub fn controller_level_score_multiplers(rcl: u32) -> u32 {
+    pub const fn controller_level_score_multiplers(rcl: u32) -> u32 {
         match rcl {
             4 => 3,
             5 => 9,
@@ -135,7 +135,7 @@ pub mod season_5 {
         ///
         /// [`Thorium`]: crate::constants::ResourceType::Thorium
         #[inline]
-        pub fn thorium_amount(self) -> u32 {
+        pub const fn thorium_amount(self) -> u32 {
             match self {
                 Density::Low => 10_000,
                 Density::Moderate => 22_000,
@@ -149,7 +149,7 @@ pub mod season_5 {
     /// [`Thorium`] is present on the same tile.
     ///
     /// [`Thorium`]: crate::constants::ResourceType::Thorium
-    pub fn thorium_decay(thorium_amount: u32) -> u32 {
+    pub const fn thorium_decay(thorium_amount: u32) -> u32 {
         // Math.floor(Math.log10([total Thorium on the tile]))
         (thorium_amount as f64).log10().floor() as u32
     }
@@ -159,7 +159,7 @@ pub mod season_5 {
     ///
     /// [`Thorium`]: crate::constants::ResourceType::Thorium
     /// [`Reactor`]: crate::objects::Reactor
-    pub fn reactor_points_per_tick(continuous_work_ticks: u32) -> u32 {
+    pub const fn reactor_points_per_tick(continuous_work_ticks: u32) -> u32 {
         // 1 + Math.floor(Math.log10([ticks of continuous operating]))
         1 + (continuous_work_ticks as f64).log10().floor() as u32
     }

--- a/src/constants/seasonal.rs
+++ b/src/constants/seasonal.rs
@@ -149,7 +149,7 @@ pub mod season_5 {
     /// [`Thorium`] is present on the same tile.
     ///
     /// [`Thorium`]: crate::constants::ResourceType::Thorium
-    pub const fn thorium_decay(thorium_amount: u32) -> u32 {
+    pub fn thorium_decay(thorium_amount: u32) -> u32 {
         // Math.floor(Math.log10([total Thorium on the tile]))
         (thorium_amount as f64).log10().floor() as u32
     }
@@ -159,7 +159,7 @@ pub mod season_5 {
     ///
     /// [`Thorium`]: crate::constants::ResourceType::Thorium
     /// [`Reactor`]: crate::objects::Reactor
-    pub const fn reactor_points_per_tick(continuous_work_ticks: u32) -> u32 {
+    pub fn reactor_points_per_tick(continuous_work_ticks: u32) -> u32 {
         // 1 + Math.floor(Math.log10([ticks of continuous operating]))
         1 + (continuous_work_ticks as f64).log10().floor() as u32
     }

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -332,7 +332,7 @@ pub enum Part {
 impl Part {
     /// Translates the `BODYPART_COST` constant.
     #[inline]
-    pub fn cost(self) -> u32 {
+    pub const fn cost(self) -> u32 {
         match self {
             Part::Move => 50,
             Part::Work => 100,
@@ -393,7 +393,7 @@ impl Density {
     /// Translates the `MINERAL_DENSITY` constant, the amount of mineral
     /// generated for each density level
     #[inline]
-    pub fn amount(self) -> u32 {
+    pub const fn amount(self) -> u32 {
         match self {
             Density::Low => 15_000,
             Density::Moderate => 35_000,
@@ -420,7 +420,7 @@ impl Density {
     /// [source]: https://github.com/screeps/engine/blob/c0cfac8f746f26c660501686f16a1fcdb0396d8d/src/processor/intents/minerals/tick.js#L19
     /// [`MINERAL_DENSITY_CHANGE`]: crate::constants::MINERAL_DENSITY_CHANGE
     #[inline]
-    pub fn probability(self) -> f32 {
+    pub const fn probability(self) -> f32 {
         match self {
             Density::Low => 0.1,
             Density::Moderate => 0.5,

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -62,7 +62,7 @@ named_enum_serialize_deserialize!(StructureType);
 impl StructureType {
     /// Translates the `CONSTRUCTION_COST` constant.
     #[inline]
-    pub fn construction_cost(self) -> Option<u32> {
+    pub const fn construction_cost(self) -> Option<u32> {
         use self::StructureType::*;
 
         let cost = match self {
@@ -89,7 +89,7 @@ impl StructureType {
 
     /// Translates the `CONTROLLER_STRUCTURES` constant
     #[inline]
-    pub fn controller_structures(self, current_rcl: u32) -> u32 {
+    pub const fn controller_structures(self, current_rcl: u32) -> u32 {
         use self::StructureType::*;
 
         match self {
@@ -173,7 +173,7 @@ impl StructureType {
 
     /// Translates the `*_HITS` constants, initial hits for structures
     #[inline]
-    pub fn initial_hits(self) -> Option<u32> {
+    pub const fn initial_hits(self) -> Option<u32> {
         use self::StructureType::*;
         use super::numbers::*;
 
@@ -359,7 +359,7 @@ named_enum_serialize_deserialize!(ResourceType);
 impl ResourceType {
     /// Translates the `BOOSTS` constant.
     #[inline]
-    pub fn boost(self) -> Option<Boost> {
+    pub const fn boost(self) -> Option<Boost> {
         use ResourceType::*;
         let boost = match self {
             // these comments copied directly from JavaScript 'constants.js' file.

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -43,7 +43,7 @@ pub fn progress_total() -> f64 {
 /// given Global Power Level. The resulting value for your current level, added
 /// to your [`progress`], would calculate your total lifetime power
 /// points.
-pub fn total_for_level(level: u32) -> u64 {
+pub const fn total_for_level(level: u32) -> u64 {
     // formula from
     // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L120
     (level as u64).pow(POWER_LEVEL_POW) * POWER_LEVEL_MULTIPLY as u64

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -240,7 +240,7 @@ where
 
 impl Default for FindRouteOptions<fn(RoomName, RoomName) -> f64> {
     fn default() -> Self {
-        fn room_cost(_to_room: RoomName, _from_room: RoomName) -> f64 {
+        const fn room_cost(_to_room: RoomName, _from_room: RoomName) -> f64 {
             1.0
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // warn when functions can safely be given the const keyword, see
 // https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn
-// unfortunately this warns for bindgen-attached functions so we can't leave it enabled
+// unfortunately this warns for bindgen-attached functions so we can't leave it
+// enabled
+
 // #![warn(clippy::missing_const_for_fn)]
 
 pub mod console;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,10 @@
 // to build locally with doc_cfg enabled, run:
 // `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+// warn when functions can safely be given the const keyword, see
+// https://rust-lang.github.io/rust-clippy/master/index.html#/missing_const_for_fn
+// unfortunately this warns for bindgen-attached functions so we can't leave it enabled
+// #![warn(clippy::missing_const_for_fn)]
 
 pub mod console;
 pub mod constants;

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -25,7 +25,7 @@ impl Default for LocalCostMatrix {
 
 impl LocalCostMatrix {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         LocalCostMatrix {
             bits: [0; ROOM_AREA],
         }
@@ -47,7 +47,7 @@ impl LocalCostMatrix {
         self[xy]
     }
 
-    pub fn get_bits(&self) -> &[u8; ROOM_AREA] {
+    pub const fn get_bits(&self) -> &[u8; ROOM_AREA] {
         &self.bits
     }
 

--- a/src/local/object_id/errors.rs
+++ b/src/local/object_id/errors.rs
@@ -37,7 +37,7 @@ impl From<ParseIntError> for RawObjectIdParseError {
 }
 
 impl RawObjectIdParseError {
-    pub(crate) fn value_too_large(val: u128) -> Self {
+    pub(crate) const fn value_too_large(val: u128) -> Self {
         RawObjectIdParseError::LargeValue(val)
     }
 }

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -140,7 +140,7 @@ impl RawObjectId {
     ///
     /// The input to this function is the bytes representing the up-to-24 hex
     /// digits in the object id.
-    pub fn from_packed(packed: u128) -> Self {
+    pub const fn from_packed(packed: u128) -> Self {
         RawObjectId { packed }
     }
 

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -265,7 +265,7 @@ impl Position {
     ///
     /// Non-public as this doesn't check the bounds for any of these values.
     #[inline]
-    fn from_coords_and_world_coords_adjusted(x: u8, y: u8, room_x: u32, room_y: u32) -> Self {
+    const fn from_coords_and_world_coords_adjusted(x: u8, y: u8, room_x: u32, room_y: u32) -> Self {
         Position {
             packed: (room_x << 24) | (room_y << 16) | ((x as u32) << 8) | (y as u32),
         }
@@ -276,14 +276,14 @@ impl Position {
     ///
     /// Non-public as this doesn't check the bounds for any of these values.
     #[inline]
-    fn from_coords_adjusted_and_room_packed(x: u8, y: u8, room_repr_packed: u16) -> Self {
+    const fn from_coords_adjusted_and_room_packed(x: u8, y: u8, room_repr_packed: u16) -> Self {
         Position {
             packed: ((room_repr_packed as u32) << 16) | ((x as u32) << 8) | (y as u32),
         }
     }
 
     #[inline]
-    pub fn packed_repr(self) -> u32 {
+    pub const fn packed_repr(self) -> u32 {
         self.packed
     }
 

--- a/src/local/position/world_utils.rs
+++ b/src/local/position/world_utils.rs
@@ -155,7 +155,7 @@ mod test {
                     let x = corner_x + x;
                     let y = corner_y + y;
 
-                    if x < -6400 || x > 6399 || y < -6400 || y > 6399 {
+                    if !(-6400..=6399).contains(&x) || !(-6400..=6399).contains(&y) {
                         assert_eq!(
                             Err(WorldPositionOutOfBoundsError(x, y)),
                             Position::checked_from_world_coords(x, y)

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -18,7 +18,7 @@ impl fmt::Display for OutOfBoundsError {
 impl Error for OutOfBoundsError {}
 
 #[inline]
-pub fn xy_to_linear_index(xy: RoomXY) -> usize {
+pub const fn xy_to_linear_index(xy: RoomXY) -> usize {
     ((xy.x.0 as usize) * (ROOM_SIZE as usize)) + (xy.y.0 as usize)
 }
 
@@ -60,7 +60,7 @@ impl RoomCoordinate {
         RoomCoordinate(coord)
     }
 
-    pub fn u8(self) -> u8 {
+    pub const fn u8(self) -> u8 {
         self.0
     }
 }

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -113,7 +113,7 @@ impl RoomName {
     }
 
     #[inline]
-    pub(crate) fn from_packed(packed: u16) -> Self {
+    pub(crate) const fn from_packed(packed: u16) -> Self {
         RoomName { packed }
     }
 
@@ -145,7 +145,7 @@ impl RoomName {
     ///
     /// For `Wxx` rooms, returns `-xx - 1`. For `Exx` rooms, returns `xx`.
     #[inline]
-    pub(super) fn x_coord(&self) -> i32 {
+    pub(super) const fn x_coord(&self) -> i32 {
         ((self.packed >> 8) & 0xFF) as i32 - HALF_WORLD_SIZE
     }
 
@@ -153,12 +153,12 @@ impl RoomName {
     ///
     /// For `Nyy` rooms, returns `-yy - 1`. For `Syy` rooms, returns `yy`.
     #[inline]
-    pub(super) fn y_coord(&self) -> i32 {
+    pub(super) const fn y_coord(&self) -> i32 {
         (self.packed & 0xFF) as i32 - HALF_WORLD_SIZE
     }
 
     #[inline]
-    pub(super) fn packed_repr(&self) -> u16 {
+    pub(super) const fn packed_repr(&self) -> u16 {
         self.packed
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -201,7 +201,7 @@ pub trait CostMatrixSet {
 }
 
 #[inline]
-fn pos_as_idx(x: u8, y: u8) -> usize {
+const fn pos_as_idx(x: u8, y: u8) -> usize {
     (x as usize) * ROOM_SIZE as usize + (y as usize)
 }
 


### PR DESCRIPTION
Add `const` to functions that represent constants (and are compatible with doing so - sorry `ResourceType::commodity_recipe` but no hashmaps!), so that users can use these values at compile time (eg the case where I ran into this being an issue):
```rust
pub const HAULER_COST_PER_MULTIPLIER: u32 = Part::Carry.cost() * 2 + Part::Move.cost();
```