### PR TITLE
Move GCL/GPL functions to new module, change return type, and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@ Unreleased
 - Add `RoomName::checked_add` to allow a math to be done on the position of the room on the map
   without the potential to panic that the `ops::Add` implementation has
 - Add `const` to most functions representing constants, so they can be evaluated during compile
-- Change `game::gpl::total_for_level` to return `u128` to allow for valid values to be calculated
-  for all possible input `u32` values (breaking)
+- Move `game::gcl::total_for_level` to `constants::math::control_points_for_gcl` and move 
+  `game::gpl::total_for_level` to `constants::math::power_for_gpl` (breaking)
+- Change `constants::math::power_for_gpl` to return `u128` to allow for valid values to be
+  calculated for all possible input `u32` values (breaking)
 
 0.14.0 (2023-07-03)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- Change `game::gpl::total_for_level` to return `u128` to allow for valid values to be calculated
+  for all possible input `u32` values (breaking)
+
 0.14.0 (2023-07-03)
 ===================
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,9 @@ wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.5"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+assert_approx_eq = "1.1"
 bincode = "1.3"
+wasm-bindgen-test = "0.3"
 
 [features]
 ## Specific features to enable conditional API endpoints

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,6 +13,7 @@
 pub mod extra;
 pub mod find;
 pub mod look;
+pub mod math;
 mod numbers;
 mod recipes;
 pub mod seasonal;
@@ -20,7 +21,7 @@ mod small_enums;
 mod types;
 
 pub use self::{
-    extra::*, find::FindConstant, look::LookConstant, numbers::*, recipes::FactoryRecipe,
+    extra::*, find::FindConstant, look::LookConstant, math::*, numbers::*, recipes::FactoryRecipe,
     small_enums::*, types::*,
 };
 

--- a/src/constants/math.rs
+++ b/src/constants/math.rs
@@ -1,0 +1,119 @@
+//! Functions allowing calculation of the resulting values of formulas used by
+//! game mechanics related to constant values.
+
+use crate::constants::*;
+
+/// Provides the total number of control points needed to achieve a given Global
+/// Control Level
+///
+/// Calculates the total number of control points needed to achieve a given
+/// Global Control Level. The game's API only exposes current level plus
+/// progress toward the next level; this allows you to see much many points
+/// you've spent to achieve your current level
+pub fn control_points_for_gcl(level: u32) -> f64 {
+    // formula from
+    // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L117
+    ((level - 1) as f64).powf(GCL_POW) * GCL_MULTIPLY as f64
+}
+
+/// Provides the total number of processed power needed to achieve a given
+/// Global Power Level
+///
+/// Calculates the total number of power that need to be processed to achieve a
+/// given Global Power Level. The game's API only exposes current level plus
+/// progress toward the next level; this allows you to see how much you
+/// processed to achieve your current level
+pub const fn power_for_gpl(level: u32) -> u128 {
+    // formula from
+    // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L120
+    (level as u128).pow(POWER_LEVEL_POW) * POWER_LEVEL_MULTIPLY as u128
+}
+
+#[cfg(test)]
+mod test {
+    use assert_approx_eq::assert_approx_eq;
+
+    use super::{control_points_for_gcl, power_for_gpl};
+
+    #[test]
+    fn gcl_formula() {
+        // the sanity of these values has been validated up to GCL 33
+        // on the MMO game server
+        assert_approx_eq!(control_points_for_gcl(1), 0.);
+        assert_approx_eq!(control_points_for_gcl(2), 1000000.);
+        assert_approx_eq!(control_points_for_gcl(3), 5278031.643091577);
+        assert_approx_eq!(control_points_for_gcl(4), 13966610.165238237);
+        assert_approx_eq!(control_points_for_gcl(5), 27857618.025475968);
+        assert_approx_eq!(control_points_for_gcl(6), 47591348.46789695);
+        assert_approx_eq!(control_points_for_gcl(7), 73716210.39885189);
+        assert_approx_eq!(control_points_for_gcl(8), 106717414.7996562);
+        assert_approx_eq!(control_points_for_gcl(9), 147033389.43962047);
+        assert_approx_eq!(control_points_for_gcl(10), 195066199.50773603);
+        assert_approx_eq!(control_points_for_gcl(11), 251188643.15095797);
+        assert_approx_eq!(control_points_for_gcl(12), 315749334.8687436);
+        assert_approx_eq!(control_points_for_gcl(13), 389076491.09393656);
+        assert_approx_eq!(control_points_for_gcl(14), 471480836.66525537);
+        assert_approx_eq!(control_points_for_gcl(15), 563257892.1815147);
+        assert_approx_eq!(control_points_for_gcl(16), 664689811.2891247);
+        assert_approx_eq!(control_points_for_gcl(17), 776046882.0533236);
+        assert_approx_eq!(control_points_for_gcl(18), 897588771.9617443);
+        assert_approx_eq!(control_points_for_gcl(19), 1029565573.4994452);
+        assert_approx_eq!(control_points_for_gcl(20), 1172218691.9999762);
+        assert_approx_eq!(control_points_for_gcl(25), 2053558031.5768352);
+        assert_approx_eq!(control_points_for_gcl(30), 3234113036.1951885);
+        assert_approx_eq!(control_points_for_gcl(31), 3508253856.824569);
+        assert_approx_eq!(control_points_for_gcl(32), 3795491867.4194345);
+        assert_approx_eq!(control_points_for_gcl(33), 4095999999.9999986);
+        assert_approx_eq!(control_points_for_gcl(34), 4409947870.045006);
+        assert_approx_eq!(control_points_for_gcl(35), 4737501940.897796);
+        assert_approx_eq!(control_points_for_gcl(40), 6584989046.083984);
+        assert_approx_eq!(control_points_for_gcl(45), 8796024362.57156);
+        assert_approx_eq!(control_points_for_gcl(50), 11388606621.52188);
+        assert_approx_eq!(control_points_for_gcl(100), 61592022749.941284);
+        assert_approx_eq!(control_points_for_gcl(1000), 15810921110646.998);
+        assert_approx_eq!(control_points_for_gcl(u32::MAX), 1.3155388150906982e29);
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_gcl_formula_input() {
+        // players cannot be GCL 0, and subtracting 1 (as the formula does)
+        // overflows the u32 - this should panic.
+        control_points_for_gcl(0);
+    }
+
+    #[test]
+    fn gpl_formula() {
+        // the sanity of these values has been validated up to GCL 33
+        // on the MMO game server
+        assert_eq!(power_for_gpl(0), 0);
+        assert_eq!(power_for_gpl(1), 1_000);
+        assert_eq!(power_for_gpl(2), 4_000);
+        assert_eq!(power_for_gpl(3), 9_000);
+        assert_eq!(power_for_gpl(4), 16_000);
+        assert_eq!(power_for_gpl(5), 25_000);
+        assert_eq!(power_for_gpl(6), 36_000);
+        assert_eq!(power_for_gpl(7), 49_000);
+        assert_eq!(power_for_gpl(8), 64_000);
+        assert_eq!(power_for_gpl(9), 81_000);
+        assert_eq!(power_for_gpl(10), 100_000);
+        assert_eq!(power_for_gpl(50), 2_500_000);
+        assert_eq!(power_for_gpl(100), 10_000_000);
+        assert_eq!(power_for_gpl(1_000), 1_000_000_000);
+        assert_eq!(power_for_gpl(5_000), 25_000_000_000);
+        assert_eq!(power_for_gpl(10_000), 100_000_000_000);
+        assert_eq!(power_for_gpl(50_000), 2_500_000_000_000);
+        assert_eq!(power_for_gpl(100_000), 10_000_000_000_000);
+        assert_eq!(power_for_gpl(1_000_000), 1_000_000_000_000_000);
+        assert_eq!(power_for_gpl(5_000_000), 25_000_000_000_000_000);
+        assert_eq!(power_for_gpl(10_000_000), 100_000_000_000_000_000);
+        assert_eq!(power_for_gpl(100_000_000), 10_000_000_000_000_000_000);
+        // beyond this value the return overflows a u64
+        assert_eq!(power_for_gpl(135_818_791), 18_446_743_988_701_681_000);
+        // must be u128 return to fit this one!
+        assert_eq!(power_for_gpl(135_818_792), 18_446_744_260_339_264_000);
+        assert_eq!(power_for_gpl(1_000_000_000), 1_000_000_000_000_000_000_000);
+        assert_eq!(power_for_gpl(4_000_000_000), 16_000_000_000_000_000_000_000);
+        assert_eq!(power_for_gpl(u32::MAX), 18_446_744_065_119_617_025_000);
+    }
+}

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -48,3 +48,57 @@ pub fn total_for_level(level: u32) -> f64 {
     // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L117
     ((level - 1) as f64).powf(GCL_POW) * GCL_MULTIPLY as f64
 }
+
+#[cfg(test)]
+mod test {
+    use assert_approx_eq::assert_approx_eq;
+
+    use super::total_for_level;
+
+    #[test]
+    fn level_formula() { 
+        // the sanity of these values has been validated up to GCL 33
+        // on the MMO game server
+        assert_approx_eq!(total_for_level(1), 0.);
+        assert_approx_eq!(total_for_level(2), 1000000.);
+        assert_approx_eq!(total_for_level(3), 5278031.643091577);
+        assert_approx_eq!(total_for_level(4), 13966610.165238237);
+        assert_approx_eq!(total_for_level(5), 27857618.025475968);
+        assert_approx_eq!(total_for_level(6), 47591348.46789695);
+        assert_approx_eq!(total_for_level(7), 73716210.39885189);
+        assert_approx_eq!(total_for_level(8), 106717414.7996562);
+        assert_approx_eq!(total_for_level(9), 147033389.43962047);
+        assert_approx_eq!(total_for_level(10), 195066199.50773603);
+        assert_approx_eq!(total_for_level(11), 251188643.15095797);
+        assert_approx_eq!(total_for_level(12), 315749334.8687436);
+        assert_approx_eq!(total_for_level(13), 389076491.09393656);
+        assert_approx_eq!(total_for_level(14), 471480836.66525537);
+        assert_approx_eq!(total_for_level(15), 563257892.1815147);
+        assert_approx_eq!(total_for_level(16), 664689811.2891247);
+        assert_approx_eq!(total_for_level(17), 776046882.0533236);
+        assert_approx_eq!(total_for_level(18), 897588771.9617443);
+        assert_approx_eq!(total_for_level(19), 1029565573.4994452);
+        assert_approx_eq!(total_for_level(20), 1172218691.9999762);
+        assert_approx_eq!(total_for_level(25), 2053558031.5768352);
+        assert_approx_eq!(total_for_level(30), 3234113036.1951885);
+        assert_approx_eq!(total_for_level(31), 3508253856.824569);
+        assert_approx_eq!(total_for_level(32), 3795491867.4194345);
+        assert_approx_eq!(total_for_level(33), 4095999999.9999986);
+        assert_approx_eq!(total_for_level(34), 4409947870.045006);
+        assert_approx_eq!(total_for_level(35), 4737501940.897796);
+        assert_approx_eq!(total_for_level(40), 6584989046.083984);
+        assert_approx_eq!(total_for_level(45), 8796024362.57156);
+        assert_approx_eq!(total_for_level(50), 11388606621.52188);
+        assert_approx_eq!(total_for_level(100), 61592022749.941284);
+        assert_approx_eq!(total_for_level(1000), 15810921110646.998);
+        assert_approx_eq!(total_for_level(u32::MAX), 1.3155388150906982e29);
+    }
+
+    #[test]
+    #[should_panic]
+    fn bad_level_formula_input() {
+        // players cannot be GCL 0, and subtracting 1 (as the formula does)
+        // overflows the u32 - this should panic.
+        total_for_level(0);
+    }
+}

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -56,7 +56,7 @@ mod test {
     use super::total_for_level;
 
     #[test]
-    fn level_formula() { 
+    fn level_formula() {
         // the sanity of these values has been validated up to GCL 33
         // on the MMO game server
         assert_approx_eq!(total_for_level(1), 0.);

--- a/src/game/gcl.rs
+++ b/src/game/gcl.rs
@@ -3,8 +3,6 @@
 //! [Screeps documentation](https://docs.screeps.com/api/#Game.gcl)
 use wasm_bindgen::prelude::*;
 
-use crate::constants::{GCL_MULTIPLY, GCL_POW};
-
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = "gcl")]
@@ -34,71 +32,4 @@ pub fn progress() -> f64 {
 /// Total progress needed to reach the next Global Control Level.
 pub fn progress_total() -> f64 {
     Gcl::progress_total()
-}
-
-/// Provides the total number of control points needed to achieve each level of
-/// GCL.
-///
-/// Calculates the total number of control points needed to achieve a given
-/// Global Control Level. The resulting value for your current level, added to
-/// your [`progress`], would calculate your total lifetime control
-/// points.
-pub fn total_for_level(level: u32) -> f64 {
-    // formula from
-    // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L117
-    ((level - 1) as f64).powf(GCL_POW) * GCL_MULTIPLY as f64
-}
-
-#[cfg(test)]
-mod test {
-    use assert_approx_eq::assert_approx_eq;
-
-    use super::total_for_level;
-
-    #[test]
-    fn level_formula() {
-        // the sanity of these values has been validated up to GCL 33
-        // on the MMO game server
-        assert_approx_eq!(total_for_level(1), 0.);
-        assert_approx_eq!(total_for_level(2), 1000000.);
-        assert_approx_eq!(total_for_level(3), 5278031.643091577);
-        assert_approx_eq!(total_for_level(4), 13966610.165238237);
-        assert_approx_eq!(total_for_level(5), 27857618.025475968);
-        assert_approx_eq!(total_for_level(6), 47591348.46789695);
-        assert_approx_eq!(total_for_level(7), 73716210.39885189);
-        assert_approx_eq!(total_for_level(8), 106717414.7996562);
-        assert_approx_eq!(total_for_level(9), 147033389.43962047);
-        assert_approx_eq!(total_for_level(10), 195066199.50773603);
-        assert_approx_eq!(total_for_level(11), 251188643.15095797);
-        assert_approx_eq!(total_for_level(12), 315749334.8687436);
-        assert_approx_eq!(total_for_level(13), 389076491.09393656);
-        assert_approx_eq!(total_for_level(14), 471480836.66525537);
-        assert_approx_eq!(total_for_level(15), 563257892.1815147);
-        assert_approx_eq!(total_for_level(16), 664689811.2891247);
-        assert_approx_eq!(total_for_level(17), 776046882.0533236);
-        assert_approx_eq!(total_for_level(18), 897588771.9617443);
-        assert_approx_eq!(total_for_level(19), 1029565573.4994452);
-        assert_approx_eq!(total_for_level(20), 1172218691.9999762);
-        assert_approx_eq!(total_for_level(25), 2053558031.5768352);
-        assert_approx_eq!(total_for_level(30), 3234113036.1951885);
-        assert_approx_eq!(total_for_level(31), 3508253856.824569);
-        assert_approx_eq!(total_for_level(32), 3795491867.4194345);
-        assert_approx_eq!(total_for_level(33), 4095999999.9999986);
-        assert_approx_eq!(total_for_level(34), 4409947870.045006);
-        assert_approx_eq!(total_for_level(35), 4737501940.897796);
-        assert_approx_eq!(total_for_level(40), 6584989046.083984);
-        assert_approx_eq!(total_for_level(45), 8796024362.57156);
-        assert_approx_eq!(total_for_level(50), 11388606621.52188);
-        assert_approx_eq!(total_for_level(100), 61592022749.941284);
-        assert_approx_eq!(total_for_level(1000), 15810921110646.998);
-        assert_approx_eq!(total_for_level(u32::MAX), 1.3155388150906982e29);
-    }
-
-    #[test]
-    #[should_panic]
-    fn bad_level_formula_input() {
-        // players cannot be GCL 0, and subtracting 1 (as the formula does)
-        // overflows the u32 - this should panic.
-        total_for_level(0);
-    }
 }

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -54,7 +54,7 @@ mod test {
     use super::total_for_level;
 
     #[test]
-    fn level_formula() { 
+    fn level_formula() {
         // the sanity of these values has been validated up to GCL 33
         // on the MMO game server
         assert_eq!(total_for_level(0), 0);
@@ -83,8 +83,14 @@ mod test {
         assert_eq!(total_for_level(135_818_791), 18_446_743_988_701_681_000);
         // must be u128 return to fit this one!
         assert_eq!(total_for_level(135_818_792), 18_446_744_260_339_264_000);
-        assert_eq!(total_for_level(1_000_000_000), 1_000_000_000_000_000_000_000);
-        assert_eq!(total_for_level(4_000_000_000), 16_000_000_000_000_000_000_000);
+        assert_eq!(
+            total_for_level(1_000_000_000),
+            1_000_000_000_000_000_000_000
+        );
+        assert_eq!(
+            total_for_level(4_000_000_000),
+            16_000_000_000_000_000_000_000
+        );
         assert_eq!(total_for_level(u32::MAX), 18_446_744_065_119_617_025_000);
     }
 }

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -43,8 +43,48 @@ pub fn progress_total() -> f64 {
 /// given Global Power Level. The resulting value for your current level, added
 /// to your [`progress`], would calculate your total lifetime power
 /// points.
-pub fn total_for_level(level: u32) -> u64 {
+pub fn total_for_level(level: u32) -> u128 {
     // formula from
     // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L120
-    (level as u64).pow(POWER_LEVEL_POW) * POWER_LEVEL_MULTIPLY as u64
+    (level as u128).pow(POWER_LEVEL_POW) * POWER_LEVEL_MULTIPLY as u128
+}
+
+#[cfg(test)]
+mod test {
+    use super::total_for_level;
+
+    #[test]
+    fn level_formula() { 
+        // the sanity of these values has been validated up to GCL 33
+        // on the MMO game server
+        assert_eq!(total_for_level(0), 0);
+        assert_eq!(total_for_level(1), 1_000);
+        assert_eq!(total_for_level(2), 4_000);
+        assert_eq!(total_for_level(3), 9_000);
+        assert_eq!(total_for_level(4), 16_000);
+        assert_eq!(total_for_level(5), 25_000);
+        assert_eq!(total_for_level(6), 36_000);
+        assert_eq!(total_for_level(7), 49_000);
+        assert_eq!(total_for_level(8), 64_000);
+        assert_eq!(total_for_level(9), 81_000);
+        assert_eq!(total_for_level(10), 100_000);
+        assert_eq!(total_for_level(50), 2_500_000);
+        assert_eq!(total_for_level(100), 10_000_000);
+        assert_eq!(total_for_level(1_000), 1_000_000_000);
+        assert_eq!(total_for_level(5_000), 25_000_000_000);
+        assert_eq!(total_for_level(10_000), 100_000_000_000);
+        assert_eq!(total_for_level(50_000), 2_500_000_000_000);
+        assert_eq!(total_for_level(100_000), 10_000_000_000_000);
+        assert_eq!(total_for_level(1_000_000), 1_000_000_000_000_000);
+        assert_eq!(total_for_level(5_000_000), 25_000_000_000_000_000);
+        assert_eq!(total_for_level(10_000_000), 100_000_000_000_000_000);
+        assert_eq!(total_for_level(100_000_000), 10_000_000_000_000_000_000);
+        // beyond this value the return overflows a u64
+        assert_eq!(total_for_level(135_818_791), 18_446_743_988_701_681_000);
+        // must be u128 return to fit this one!
+        assert_eq!(total_for_level(135_818_792), 18_446_744_260_339_264_000);
+        assert_eq!(total_for_level(1_000_000_000), 1_000_000_000_000_000_000_000);
+        assert_eq!(total_for_level(4_000_000_000), 16_000_000_000_000_000_000_000);
+        assert_eq!(total_for_level(u32::MAX), 18_446_744_065_119_617_025_000);
+    }
 }

--- a/src/game/gpl.rs
+++ b/src/game/gpl.rs
@@ -3,8 +3,6 @@
 //! [Screeps documentation](http://docs.screeps.com/api/#Game.gpl)
 use wasm_bindgen::prelude::*;
 
-use crate::constants::{POWER_LEVEL_MULTIPLY, POWER_LEVEL_POW};
-
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = "gpl")]
@@ -34,63 +32,4 @@ pub fn progress() -> f64 {
 /// Total progress needed to reach the next Global Power Level.
 pub fn progress_total() -> f64 {
     Gpl::progress_total()
-}
-
-/// Provides the total number of processed power needed to achieve each level
-/// of GPL.
-///
-/// Calculates the total number of power that need to be processed to achieve a
-/// given Global Power Level. The resulting value for your current level, added
-/// to your [`progress`], would calculate your total lifetime power
-/// points.
-pub const fn total_for_level(level: u32) -> u128 {
-    // formula from
-    // https://github.com/screeps/engine/blob/6d498f2f0db4e0744fa6bf8563836d36b49b6a29/src/game/game.js#L120
-    (level as u128).pow(POWER_LEVEL_POW) * POWER_LEVEL_MULTIPLY as u128
-}
-
-#[cfg(test)]
-mod test {
-    use super::total_for_level;
-
-    #[test]
-    fn level_formula() {
-        // the sanity of these values has been validated up to GCL 33
-        // on the MMO game server
-        assert_eq!(total_for_level(0), 0);
-        assert_eq!(total_for_level(1), 1_000);
-        assert_eq!(total_for_level(2), 4_000);
-        assert_eq!(total_for_level(3), 9_000);
-        assert_eq!(total_for_level(4), 16_000);
-        assert_eq!(total_for_level(5), 25_000);
-        assert_eq!(total_for_level(6), 36_000);
-        assert_eq!(total_for_level(7), 49_000);
-        assert_eq!(total_for_level(8), 64_000);
-        assert_eq!(total_for_level(9), 81_000);
-        assert_eq!(total_for_level(10), 100_000);
-        assert_eq!(total_for_level(50), 2_500_000);
-        assert_eq!(total_for_level(100), 10_000_000);
-        assert_eq!(total_for_level(1_000), 1_000_000_000);
-        assert_eq!(total_for_level(5_000), 25_000_000_000);
-        assert_eq!(total_for_level(10_000), 100_000_000_000);
-        assert_eq!(total_for_level(50_000), 2_500_000_000_000);
-        assert_eq!(total_for_level(100_000), 10_000_000_000_000);
-        assert_eq!(total_for_level(1_000_000), 1_000_000_000_000_000);
-        assert_eq!(total_for_level(5_000_000), 25_000_000_000_000_000);
-        assert_eq!(total_for_level(10_000_000), 100_000_000_000_000_000);
-        assert_eq!(total_for_level(100_000_000), 10_000_000_000_000_000_000);
-        // beyond this value the return overflows a u64
-        assert_eq!(total_for_level(135_818_791), 18_446_743_988_701_681_000);
-        // must be u128 return to fit this one!
-        assert_eq!(total_for_level(135_818_792), 18_446_744_260_339_264_000);
-        assert_eq!(
-            total_for_level(1_000_000_000),
-            1_000_000_000_000_000_000_000
-        );
-        assert_eq!(
-            total_for_level(4_000_000_000),
-            16_000_000_000_000_000_000_000
-        );
-        assert_eq!(total_for_level(u32::MAX), 18_446_744_065_119_617_025_000);
-    }
 }


### PR DESCRIPTION
Added tests for the GCL and GPL formulas we have in the game module - in the course of doing this I realized `u128` was a more appropriate return type for `game::gpl::total_for_level`, so that the entire `u32` input space can be passed without risk of panic on large values.