### PR TITLE
Rename RoomObject::pos to js_pos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Unreleased
   calculated for all possible input `u32` values (breaking)
 - Fix incorrect value of `constants::extras::FLAG_NAME_MAX_LENGTH` - now 100, previously 60
 - Add new extra constant `constants::extras::POWER_CREEP_CARRY_CAPACITY_PER_LEVEL`
+- Rename `RoomObject::pos` to `RoomObject::js_pos` to avoid confusion with `HasPosition::pos`
+  and remove the possibiliy for differing behavior based on whether the trait was imported
 
 0.14.0 (2023-07-03)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 - Add new extra constant `constants::extras::POWER_CREEP_CARRY_CAPACITY_PER_LEVEL`
 - Rename `RoomObject::pos` to `RoomObject::js_pos` to avoid confusion with `HasPosition::pos`
   and remove the possibiliy for differing behavior based on whether the trait was imported
+  (breaking)
 
 0.14.0 (2023-07-03)
 ===================

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -36,7 +36,7 @@ mod world_utils;
 /// # Using Position
 ///
 /// You can retrieve a `Position` by getting the position of a game object using
-/// [`RoomObject::pos`], or by creating one from coordinates with
+/// [`HasPosition::pos`], or by creating one from coordinates with
 /// [`Position::new`].
 ///
 /// You can use any of the math methods available on this page to manipulate

--- a/src/objects/impls/room_object.rs
+++ b/src/objects/impls/room_object.rs
@@ -22,11 +22,16 @@ extern "C" {
     #[wasm_bindgen(method, getter = effects)]
     fn effects_internal(this: &RoomObject) -> Option<Array>;
 
-    /// Position of the object.
+    /// Gets the [`RoomPosition`] of an object, which is a reference to an
+    /// object in the javascript heap. In most cases, you'll likely want a
+    /// native [`Position`] instead of using this function (see
+    /// [`HasPosition::pos`]), there may be cases where this can provide
+    /// some slight performance benefits due to reducing object churn in the js
+    /// heap, so this is kept public.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#RoomObject.pos)
-    #[wasm_bindgen(method, getter)]
-    pub fn pos(this: &RoomObject) -> RoomPosition;
+    #[wasm_bindgen(method, getter = pos)]
+    pub fn js_pos(this: &RoomObject) -> RoomPosition;
 
     /// A link to the room that the object is currently in, or `None` if the
     /// object is a power creep not spawned on the current shard, or a flag or
@@ -58,7 +63,7 @@ where
     T: AsRef<RoomObject>,
 {
     fn pos(&self) -> Position {
-        RoomObject::pos(self.as_ref()).into()
+        self.as_ref().js_pos().into()
     }
 }
 


### PR DESCRIPTION
Currently the return type of `.pos()` on an room object can be `RoomPosition` from the `Deref<Target = RoomObject>` auto-impl, or `Position` if `HasPosition` trait is in scope (possibly from the crate prelude). This behavior's a bad developer experience, renaming the getter for the js version of the object to `js_pos` to match the current convention for `js_id`