### PR TITLE
Wrap raw store functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Unreleased
 - Rename `RoomObject::pos` to `RoomObject::js_pos` to avoid confusion with `HasPosition::pos`
   and remove the possibiliy for differing behavior based on whether the trait was imported
   (breaking)
+- Fix potential for panic in store functions when called with resource types that the store
+  isn't currently valid for
 
 0.14.0 (2023-07-03)
 ===================

--- a/src/objects/impls/store.rs
+++ b/src/objects/impls/store.rs
@@ -22,13 +22,13 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Store.getCapacity)
     #[wasm_bindgen(method, js_name = getCapacity)]
-    pub fn get_capacity(this: &Store, ty: Option<ResourceType>) -> u32;
+    fn get_capacity_internal(this: &Store, ty: Option<ResourceType>) -> Option<u32>;
 
     /// Return the free capacity of the [`Store`] for the specified resource.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Store.getFreeCapacity)
     #[wasm_bindgen(method, js_name = getFreeCapacity)]
-    pub fn get_free_capacity(this: &Store, ty: Option<ResourceType>) -> i32;
+    fn get_free_capacity_internal(this: &Store, ty: Option<ResourceType>) -> Option<i32>;
 
     /// Return the used capacity of the [`Store`] for the specified resource. If
     /// the [`Store`] can contain any resource, passing `None` as the type will
@@ -36,7 +36,7 @@ extern "C" {
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Store.getUsedCapacity)
     #[wasm_bindgen(method, js_name = getUsedCapacity)]
-    pub fn get_used_capacity(this: &Store, ty: Option<ResourceType>) -> u32;
+    fn get_used_capacity_internal(this: &Store, ty: Option<ResourceType>) -> Option<u32>;
 }
 
 impl Store {
@@ -45,5 +45,17 @@ impl Store {
             .iter()
             .filter_map(|v| ResourceType::from_js_value(&v))
             .collect()
+    }
+
+    pub fn get_capacity(&self, ty: Option<ResourceType>) -> u32 {
+        self.get_capacity_internal(ty).unwrap_or(0)
+    }
+
+    pub fn get_free_capacity(&self, ty: Option<ResourceType>) -> i32 {
+        self.get_free_capacity_internal(ty).unwrap_or(0)
+    }
+
+    pub fn get_used_capacity(&self, ty: Option<ResourceType>) -> u32 {
+        self.get_used_capacity_internal(ty).unwrap_or(0)
     }
 }


### PR DESCRIPTION
The get_ functions on Store can return null if the resource type is not valid for that store. This can cause unexpected panics if, e.g. a creep tries to check its store when all of its Carry parts have been destroyed.

Renamed the raw functions with _internal, following the pattern used elsewhere, made them accept Option<i/u32>s, and had the public functions unwrap those options. 0 is used as a default value, which makes conceptual sense for all funcitons: a store that can't take a resource has no capacity for it and currently stores none.

Resolves #429