### PR TITLE
Change return type to `Option<u32>` on `ticks_to_regeneration` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Unreleased
   (breaking)
 - Fix potential for panic in store functions when called with resource types that the store
   isn't currently valid for
+- Change `Source::ticks_to_regeneration` and `Mineral::ticks_to_regeneration` return types to
+  `Option<u32>`, returning `None` when the timer isn't active instead of panic (breaking)
 
 0.14.0 (2023-07-03)
 ===================

--- a/src/objects/impls/mineral.rs
+++ b/src/objects/impls/mineral.rs
@@ -41,11 +41,12 @@ extern "C" {
     #[wasm_bindgen(method, getter = id)]
     fn id_internal(this: &Mineral) -> JsString;
 
-    /// The number of ticks until this mineral regenerates from depletion.
+    /// The number of ticks until this mineral regenerates from depletion, or
+    /// `None` if it's not currently regenerating.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Mineral.ticksToRegeneration)
     #[wasm_bindgen(method, getter = ticksToRegeneration)]
-    pub fn ticks_to_regeneration(this: &Mineral) -> u32;
+    pub fn ticks_to_regeneration(this: &Mineral) -> Option<u32>;
 }
 
 impl HasNativeId for Mineral {

--- a/src/objects/impls/source.rs
+++ b/src/objects/impls/source.rs
@@ -45,11 +45,12 @@ extern "C" {
     fn id_internal(this: &Source) -> JsString;
 
     /// The number of ticks until this source regenerates to its
-    /// [`Source::energy_capacity`], or 0 if the timer has not started yet.
+    /// [`Source::energy_capacity`], or `None` if the source has not started to
+    /// regenerate.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Source.ticksToRegeneration)
     #[wasm_bindgen(method, getter = ticksToRegeneration)]
-    pub fn ticks_to_regeneration(this: &Source) -> u32;
+    pub fn ticks_to_regeneration(this: &Source) -> Option<u32>;
 }
 
 impl HasNativeId for Source {


### PR DESCRIPTION
Fixes #433 as well as equivalent issue with `Mineral`