### PR TITLE
Add module for serde's `with` attribute to serialize `Position` as packed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ==========
 
+- Add `local::serde_position_packed` module, for use with the `with` serde attribute, allowing
+  serialized positions to be stored as packed even with human-readable serializers
+
 0.15.0 (2023-08-03)
 ===================
 

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -460,6 +460,31 @@ mod serde {
     }
 }
 
+/// Module for use with `serde`'s [`with` attribute] to allow serialization of
+/// positions as their packed representation, even when using a human-readable
+/// serializer.
+///
+/// [`with` attribute]: https://serde.rs/field-attrs.html#with
+pub mod serde_position_packed {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    use super::Position;
+
+    pub fn serialize<S>(pos: &Position, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        pos.packed_repr().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Position, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        u32::deserialize(deserializer).map(Position::from_packed)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{Position, RoomCoordinate};


### PR DESCRIPTION
Add a module to serialize positions in structs as packed instead of the readable RoomPosition-compatible representation, by doing eg `#[serde(with = "screeps::local::serde_position_packed")]` for the field.