### PR TITLE
update rustfmt config

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,64 +1,32 @@
+edition = "2021"
+version = "One"
+
+# General
 max_width = 100
 hard_tabs = false
 tab_spaces = 4
-newline_style = "Auto"
-use_small_heuristics = "Default"
-indent_style = "Block"
+
+# Comments
+comment_width = 80
 wrap_comments = true
 format_code_in_doc_comments = true
-comment_width = 80
-normalize_comments = false
-normalize_doc_attributes = false
-format_strings = false
-format_macro_matchers = false
-format_macro_bodies = true
-empty_item_single_line = true
-struct_lit_single_line = true
-fn_single_line = false
-where_single_line = false
-imports_indent = "Block"
-imports_layout = "Mixed"
-merge_imports = true
+
+# Imports
+imports_granularity = "Crate"
 reorder_imports = true
+
+# `mod` declarations
 reorder_modules = true
+
+# Items
 reorder_impl_items = false
-type_punctuation_density = "Wide"
-space_before_colon = false
-space_after_colon = true
-spaces_around_ranges = false
-binop_separator = "Front"
-remove_nested_parens = true
-combine_control_expr = true
-overflow_delimited_expr = false
-struct_field_align_threshold = 0
-enum_discrim_align_threshold = 0
-match_arm_blocks = true
-force_multiline_blocks = false
-fn_args_layout = "Tall"
-brace_style = "SameLineWhere"
-control_brace_style = "AlwaysSameLine"
-trailing_semicolon = true
-trailing_comma = "Vertical"
-match_block_trailing_comma = false
-blank_lines_upper_bound = 1
-blank_lines_lower_bound = 0
-edition = "2021"
-version = "One"
-inline_attribute_width = 0
-merge_derives = true
-use_try_shorthand = false
-use_field_init_shorthand = false
-force_explicit_abi = true
-condense_wildcard_suffixes = false
-color = "Auto"
-unstable_features = false
-disable_all_formatting = false
-skip_children = false
-hide_parse_errors = false
+
+# fns
+fn_params_layout = "Tall"
+
+# Report bugs (bugs may cause other formatting issues)
 error_on_line_overflow = false
 error_on_unformatted = false
-report_todo = "Never"
-report_fixme = "Never"
-ignore = []
-emit_mode = "Files"
-make_backup = false
+
+# Use `MyStruct { x }` instead of `MyStruct { x: x }`
+use_field_init_shorthand = false


### PR DESCRIPTION
Moves some deprecated options, deletes many settings that were at their default values and not worth being explicit about, and enables the `use_field_init_shorthand` option.