### PR TITLE
[BREAKING CHANGE] Split out map visual style because it's different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 Unreleased
 ==========
 
+### Breaking:
+
+- `MapVisualShape::text` and `MapVisual::text` `style` arguments changed to be type `Option<MapTextStyle>`.
+  - The map visual APIs use a different set of options than room visuals, so they need to be a different type to express those options.
+  - Note that all color settings for map visuals are much more restrictive: they only accept colors of the form `#FF22DD`, no web-style color names.
+
+### Additions:
+
 - Add `local::serde_position_packed` module, for use with the `with` serde attribute, allowing
   serialized positions to be stored as packed even with human-readable serializers
+- New types `MapFontStyle`, `MapFontVariant`, `MapTextStyle` for use in the changes to map visuals.
+
+### Bugfixes:
+
 - Fix incorrect return values in `StructureType::initial_hits` and `ResourceType::boost` constant
   functions
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -68,7 +68,8 @@ mod room_objects {
 /// game world.
 pub mod visual {
     pub use super::impls::{
-        CircleStyle, FontStyle, LineDrawStyle, LineStyle, MapVisual, MapVisualShape, PolyStyle,
-        RectStyle, RoomVisual, TextAlign, TextStyle, Visual,
+        CircleStyle, FontStyle, LineDrawStyle, LineStyle, MapFontStyle, MapFontVariant,
+        MapTextStyle, MapVisual, MapVisualShape, PolyStyle, RectStyle, RoomVisual, TextAlign,
+        TextStyle, Visual,
     };
 }

--- a/src/objects/impls.rs
+++ b/src/objects/impls.rs
@@ -109,7 +109,7 @@ pub use self::room_visual::{
     TextStyle, Visual,
 };
 
-pub use self::map_visual::{MapVisual, MapVisualShape};
+pub use self::map_visual::{MapFontStyle, MapFontVariant, MapTextStyle, MapVisual, MapVisualShape};
 
 #[cfg(feature = "score")]
 pub use self::{score_collector::ScoreCollector, score_container::ScoreContainer};

--- a/src/objects/impls/map_visual.rs
+++ b/src/objects/impls/map_visual.rs
@@ -3,7 +3,8 @@ use serde::Serialize;
 
 use crate::{
     local::{Position, RoomCoordinate, RoomName},
-    objects::{CircleStyle, LineStyle, PolyStyle, RectStyle, TextStyle},
+    objects::{CircleStyle, LineStyle, PolyStyle, RectStyle},
+    TextAlign,
 };
 
 #[derive(Clone, Serialize)]
@@ -64,6 +65,273 @@ pub struct MapPolyData {
     style: Option<PolyStyle>,
 }
 
+/// The font style for map text visuals.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MapFontStyle {
+    /// Use the normal font face.
+    #[default]
+    Normal,
+    /// Use the italic font face.
+    Italic,
+    /// Use the oblique font face.
+    Oblique,
+}
+
+/// The font variant for map text visuals.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum MapFontVariant {
+    /// No variant for the font, text rendered normally.
+    #[default]
+    Normal,
+    /// Render all lowercase characters in small caps.
+    SmallCaps,
+}
+
+/// Settings for text visuals on the map, used with [`MapVisual::text`].
+///
+/// This is different than [`TextStyle`] which is used with [`RoomVisual::text`]
+/// because the two methods take data in a slightly different format. Notably,
+/// room visuals accept colors in any web format and take use a shorthond for
+/// font data, where map visuals require stricter color formats and have
+/// different font options.
+///
+/// See also: [Screeps docs](https://docs.screeps.com/api/#Game.map-visual.text).
+///
+/// [`TextStyle`]: crate::objects::visual::TextStyle
+/// [`RoomVisual::text`]: crate::objects::visual::RoomVisual::text
+#[derive(Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MapTextStyle {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_family: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    font_size: Option<f32>,
+    font_style: MapFontStyle,
+    font_variant: MapFontVariant,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stroke_width: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    background_padding: Option<f32>,
+    #[serde(skip_serializing_if = "TextAlign::is_center")]
+    align: TextAlign,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opacity: Option<f32>,
+}
+
+impl MapTextStyle {
+    /// Sets the color of the text style.
+    ///
+    /// **Unlike room visuals, only hex triplets with a leading `#` are valid.**
+    ///
+    /// The default value is `#FFFFFF`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use screeps::MapTextStyle;
+    ///
+    /// // Bright pink! We really need to see this text!
+    /// let style = MapTextStyle::default().color("#FF00FF");
+    /// ```
+    pub fn color(mut self, val: impl Into<String>) -> Self {
+        self.color = Some(val.into());
+        self
+    }
+
+    /// Sets the font family of the text style. Font families with spaces in
+    /// their name must be quoted. Normally this involves escaping quotes in a
+    /// string literal.
+    ///
+    /// The default value is `sans-serif`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use screeps::MapTextStyle;
+    /// let monospace_style = MapTextStyle::default().font_family("monospace");
+    ///
+    /// let font_family_style = MapTextStyle::default().font_family("\"Comic Sans MS\"");
+    ///
+    /// let fallback_style = MapTextStyle::default().font_family("\"Comic Sans MS\", Times, serif");
+    /// ```
+    ///
+    /// For more information about font families, see the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family).
+    pub fn font_family(mut self, val: impl Into<String>) -> Self {
+        self.font_family = Some(val.into());
+        self
+    }
+
+    /// Sets the size of the font, in *game coordinates*. This means that a
+    /// `font_size` of 1 corresponds to the same size as one coordinate on the
+    /// map. This does **not** support any other units for size.
+    ///
+    /// The default value is `10`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use screeps::MapTextStyle;
+    ///
+    /// let tiny_text = MapTextStyle::default().font_size(2_f32);
+    ///
+    /// let room_height = MapTextStyle::default().font_size(50_f32);
+    /// ```
+    pub fn font_size(mut self, val: f32) -> Self {
+        self.font_size = Some(val);
+        self
+    }
+
+    /// Sets the style of the font. This controls whether a font should be
+    /// styled with a normal, italic, or oblique face.
+    ///
+    /// The default value is [`MapFontStyle::Normal`].
+    ///
+    /// `oblique <angle>` is not supported.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use screeps::{MapFontStyle, MapTextStyle};
+    ///
+    /// let normal = MapTextStyle::default().font_style(MapFontStyle::Normal);
+    /// let italic = MapTextStyle::default().font_style(MapFontStyle::Italic);
+    /// ```
+    ///
+    /// For more information about font styles, see the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style).
+    ///
+    /// [`MapFontStyle::Normal`]: self::MapFontStyle#variant.Normal
+    pub fn font_style(mut self, val: MapFontStyle) -> Self {
+        self.font_style = val;
+        self
+    }
+
+    /// Sets the variant of the font. This controls whether or not text is
+    /// rendered as small caps.
+    ///
+    /// The default value is [`MapFontVariant::Normal`].
+    ///
+    /// # Examples
+    /// ```rust
+    /// use screeps::{MapFontVariant, MapTextStyle};
+    ///
+    /// let normal = MapTextStyle::default().font_variant(MapFontVariant::Normal);
+    /// let small_caps = MapTextStyle::default().font_variant(MapFontVariant::SmallCaps);
+    /// ```
+    ///
+    /// [`MapFontVariant::Normal`]: self::MapFontVariant#variant.Normal
+    pub fn font_variant(mut self, val: MapFontVariant) -> Self {
+        self.font_variant = val;
+        self
+    }
+
+    /// **Unlike room visuals, only hex triplets with a leading `#` are valid.**
+    pub fn stroke_color(mut self, val: Option<impl Into<String>>) -> Self {
+        self.stroke = val.map(Into::into);
+        self
+    }
+
+    /// Sets the width of the stroke for the text, if the stroke is enabled.
+    ///
+    /// A stroke width of `0` results in no stroke. Negative values are invalid.
+    ///
+    /// The default value is `0.15`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use screeps::MapTextStyle;
+    ///
+    /// let thin = MapTextStyle::default().stroke_width(0.05_f32);
+    /// let wide = MapTextStyle::default().stroke_width(2.0_f32);
+    /// ```
+    pub fn stroke_width(mut self, val: f32) -> Self {
+        self.stroke_width = Some(val);
+        self
+    }
+
+    /// Sets or removes the background color for the text visual. When a
+    /// background is enabled, the text's vertical align is set to `middle`
+    /// instead of `baseline`.
+    ///
+    /// **Unlike room visuals, only hex triplets with a leading `#` are valid.**
+    ///
+    /// The default value is `None`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use screeps::MapTextStyle;
+    ///
+    /// let lavender = MapTextStyle::default().background_color(Some("#b373de"));
+    /// // Even though this is the default, it's possible to unset the background color.
+    /// let unset = MapTextStyle::default().background_color(None);
+    /// ```
+    // This only takes `&str` to avoid issues where passing `None` fails to infer a
+    // type.
+    pub fn background_color(mut self, val: Option<&str>) -> Self {
+        self.background_color = val.map(String::from);
+        self
+    }
+
+    /// ⚠️⚠️⚠️ This API does not appear to work ⚠️⚠️⚠️
+    /// TODO: More investigation is needed, it has only been tested on private
+    /// servers.
+    ///
+    /// Sets the padding of the background's rectangle.
+    ///
+    /// The default value is `0.3`.
+    ///
+    /// # Examples
+    /// ```rust
+    /// use screeps::MapTextStyle;
+    ///
+    /// let thick = MapTextStyle::default().background_padding(10.0_f32);
+    /// ```
+    pub fn background_padding(mut self, val: f32) -> Self {
+        self.background_padding = Some(val);
+        self
+    }
+
+    /// Sets the horizontal alignment of the text.
+    ///
+    /// The default value is [`TextAlign::Center`].
+    ///
+    /// # Examples
+    /// ```rust
+    /// use screeps::{MapTextStyle, TextAlign};
+    ///
+    /// let left = MapTextStyle::default().align(TextAlign::Left);
+    /// ```
+    ///
+    /// [`TextAlign::Center`]: crate::objects::visual::TextAlign#variant.Center
+    pub fn align(mut self, val: TextAlign) -> Self {
+        self.align = val;
+        self
+    }
+
+    /// Sets the opacity of the text visual. Valid values are in the range
+    /// `0.0..=1.0`.
+    ///
+    /// The default value is `0.5`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use screeps::MapTextStyle;
+    ///
+    /// let opaque = MapTextStyle::default().opacity(1.0_f32);
+    /// let ghost = MapTextStyle::default().opacity(0.05_f32);
+    /// ```
+    pub fn opacity(mut self, val: f32) -> Self {
+        self.opacity = Some(val);
+        self
+    }
+}
+
 #[derive(Clone, Serialize)]
 pub struct MapTextData {
     text: String,
@@ -71,7 +339,7 @@ pub struct MapTextData {
     y: RoomCoordinate,
     n: RoomName,
     #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
-    style: Option<TextStyle>,
+    style: Option<MapTextStyle>,
 }
 
 #[derive(Clone, Serialize)]
@@ -131,7 +399,7 @@ impl MapVisualShape {
         MapVisualShape::Poly(MapPolyData { points, style })
     }
 
-    pub fn text(pos: Position, text: String, style: Option<TextStyle>) -> MapVisualShape {
+    pub fn text(pos: Position, text: String, style: Option<MapTextStyle>) -> MapVisualShape {
         MapVisualShape::Text(MapTextData {
             x: pos.x(),
             y: pos.y(),
@@ -176,7 +444,7 @@ impl MapVisual {
         Self::draw(&MapVisualShape::poly(points, style));
     }
 
-    pub fn text(pos: Position, text: String, style: Option<TextStyle>) {
+    pub fn text(pos: Position, text: String, style: Option<MapTextStyle>) {
         Self::draw(&MapVisualShape::text(pos, text, style));
     }
 }

--- a/src/objects/impls/map_visual.rs
+++ b/src/objects/impls/map_visual.rs
@@ -97,6 +97,13 @@ pub enum MapFontVariant {
 /// font data, where map visuals require stricter color formats and have
 /// different font options.
 ///
+/// <div class="warning">
+/// <b>Warning</b>
+///
+/// The `backgroundPadding` setting in the Screeps docs does not function in
+/// game so it is not present in this API.
+/// </div><br/>
+///
 /// See also: [Screeps docs](https://docs.screeps.com/api/#Game.map-visual.text).
 ///
 /// [`TextStyle`]: crate::objects::visual::TextStyle

--- a/src/objects/impls/map_visual.rs
+++ b/src/objects/impls/map_visual.rs
@@ -118,8 +118,9 @@ pub struct MapTextStyle {
     stroke_width: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     background_color: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    background_padding: Option<f32>,
+    // This setting does not do anything, even though it's documented.
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // background_padding: Option<f32>,
     #[serde(skip_serializing_if = "TextAlign::is_center")]
     align: TextAlign,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -274,25 +275,6 @@ impl MapTextStyle {
     // type.
     pub fn background_color(mut self, val: Option<&str>) -> Self {
         self.background_color = val.map(String::from);
-        self
-    }
-
-    /// ⚠️⚠️⚠️ This API does not appear to work ⚠️⚠️⚠️
-    /// TODO: More investigation is needed, it has only been tested on private
-    /// servers.
-    ///
-    /// Sets the padding of the background's rectangle.
-    ///
-    /// The default value is `0.3`.
-    ///
-    /// # Examples
-    /// ```rust
-    /// use screeps::MapTextStyle;
-    ///
-    /// let thick = MapTextStyle::default().background_padding(10.0_f32);
-    /// ```
-    pub fn background_padding(mut self, val: f32) -> Self {
-        self.background_padding = Some(val);
         self
     }
 


### PR DESCRIPTION
Mp visuals need to use a different options struct because it takes data in a slightly different format.

The `backgroundPadding` setting does not work. This is noted in the docs with a callout that has emphasis.