### PR TITLE
Fix deserialization of constant types with string representations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,22 @@ Unreleased
 
 ### Breaking:
 
-- `MapVisualShape::text` and `MapVisual::text` `style` arguments changed to be type `Option<MapTextStyle>`.
-  - The map visual APIs use a different set of options than room visuals, so they need to be a different type to express those options.
-  - Note that all color settings for map visuals are much more restrictive: they only accept colors of the form `#FF22DD`, no web-style color names.
+- `MapVisualShape::text` and `MapVisual::text` `style` arguments changed to be type
+  `Option<MapTextStyle>`
+  - The map visual APIs use a different set of options than room visuals, so they need to be a
+    different type to express those options
+  - Note that all color settings for map visuals are much more restrictive: they only accept colors
+    of the form `#FF22DD`, no web-style color names
+- Removed `std::FromStr` impl on `Part` which unnecessarily duplicates the generated `from_str`
+  from wasm-bindgen
+- Use constant values compatible with the game for serializing `PowerCreepClass`, and
+  `IntershardResourceType`, and `Part` as string
 
 ### Additions:
 
 - Add `local::serde_position_packed` module, for use with the `with` serde attribute, allowing
   serialized positions to be stored as packed even with human-readable serializers
-- New types `MapFontStyle`, `MapFontVariant`, `MapTextStyle` for use in the changes to map visuals.
+- New types `MapFontStyle`, `MapFontVariant`, `MapTextStyle` for use in the changes to map visuals
 
 ### Bugfixes:
 
@@ -19,10 +26,6 @@ Unreleased
   functions
 - Use `std::Cow` in custom deserialization process for `StructureType` and `ResourceType` to fix
   failures when deserializing in some cases, like from `serde_json::Value`
-- Use constant values compatible with the game for serializing `PowerCreepClass`, and
-  `IntershardResourceType`, and `Part` as string (breaking)
-- Removed `std::FromStr` impl on `Part` which unnecessarily duplicates the generated `from_str`
-  from wasm-bindgen.
 
 0.15.0 (2023-08-03)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ Unreleased
   functions
 - Use `std::Cow` in custom deserialization process for `StructureType` and `ResourceType` to fix
   failures when deserializing in some cases, like from `serde_json::Value`
-- Use constant values compatible with the game for serializing `PowerCreepClass` and
-  `IntershardResourceType` as string (breaking)
+- Use constant values compatible with the game for serializing `PowerCreepClass`, and
+  `IntershardResourceType`, and `Part` as string (breaking)
+- Removed `std::FromStr` impl on `Part` which unnecessarily duplicates the generated `from_str`
+  from wasm-bindgen.
 
 0.15.0 (2023-08-03)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,17 @@ Unreleased
 
 ### Breaking:
 
+- Use constant values compatible with the game for serializing `PowerCreepClass`, and
+  `IntershardResourceType`, and `Part` as string - note that if you've stored any of these values,
+  they will fail to parse after updating!
 - `MapVisualShape::text` and `MapVisual::text` `style` arguments changed to be type
   `Option<MapTextStyle>`
   - The map visual APIs use a different set of options than room visuals, so they need to be a
     different type to express those options
   - Note that all color settings for map visuals are much more restrictive: they only accept colors
     of the form `#FF22DD`, no web-style color names
-- Removed `std::FromStr` impl on `Part` which unnecessarily duplicates the generated `from_str`
-  from wasm-bindgen
-- Use constant values compatible with the game for serializing `PowerCreepClass`, and
-  `IntershardResourceType`, and `Part` as string
+- Removed `FromStr` impl on `Part` and replace with automatically-generated implementations for all
+  string-represented constant enums, as well as adding `Display` implementation.
 
 ### Additions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Unreleased
   functions
 - Use `std::Cow` in custom deserialization process for `StructureType` and `ResourceType` to fix
   failures when deserializing in some cases, like from `serde_json::Value`
+- Use constant values compatible with the game for serializing `PowerCreepClass` and
+  `IntershardResourceType` as string (breaking)
 
 0.15.0 (2023-08-03)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Unreleased
   serialized positions to be stored as packed even with human-readable serializers
 - Fix incorrect return values in `StructureType::initial_hits` and `ResourceType::boost` constant
   functions
+- Use `std::Cow` in custom deserialization process for `StructureType` and `ResourceType` to fix
+  failures when deserializing in some cases, like from `serde_json::Value`
 
 0.15.0 (2023-08-03)
 ===================

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -11,7 +11,7 @@ use serde::{
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use wasm_bindgen::prelude::*;
 
-use super::types::named_enum_serialize_deserialize;
+use super::{macros::named_enum_serialize_deserialize, InvalidConstantString};
 use crate::{
     constants::find::{Exit, Find},
     prelude::*,

--- a/src/constants/small_enums.rs
+++ b/src/constants/small_enums.rs
@@ -1,13 +1,17 @@
 //! Various constants translated as small enums.
-use std::{convert::Infallible, fmt, str::FromStr};
+use std::{borrow::Cow, fmt};
 
 use enum_iterator::Sequence;
 use js_sys::JsString;
 use num_derive::FromPrimitive;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{Error as _, Unexpected},
+    Deserialize, Serialize,
+};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use wasm_bindgen::prelude::*;
 
+use super::types::named_enum_serialize_deserialize;
 use crate::{
     constants::find::{Exit, Find},
     prelude::*,
@@ -317,7 +321,7 @@ impl Terrain {
 
 /// Translates body part type and `BODYPARTS_ALL` constants
 #[wasm_bindgen]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Deserialize, Serialize, Sequence)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, Sequence)]
 pub enum Part {
     Move = "move",
     Work = "work",
@@ -328,6 +332,8 @@ pub enum Part {
     Heal = "heal",
     Claim = "claim",
 }
+
+named_enum_serialize_deserialize!(Part);
 
 impl Part {
     /// Translates the `BODYPART_COST` constant.
@@ -345,24 +351,6 @@ impl Part {
             // I guess bindgen is adding a `#[non_exhaustive]` onto the enum and forcing us to do
             // this:
             _ => 0,
-        }
-    }
-}
-
-impl FromStr for Part {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "move" => Ok(Part::Move),
-            "work" => Ok(Part::Work),
-            "carry" => Ok(Part::Carry),
-            "attack" => Ok(Part::Attack),
-            "ranged_attack" => Ok(Part::RangedAttack),
-            "tough" => Ok(Part::Tough),
-            "heal" => Ok(Part::Heal),
-            "claim" => Ok(Part::Claim),
-            _ => panic!("unknown part type"),
         }
     }
 }

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -701,4 +701,18 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn rust_vec_to_serde_json_from_serde_json_roundtrip() {
+        let mut resources = vec![];
+        for resource in enum_iterator::all::<ResourceType>() {
+            if resource != ResourceType::__Nonexhaustive {
+                resources.push(resource);
+            }
+        }
+        let serialized = serde_json::to_string(&resources).unwrap();
+        //panic!("{}", serialized);
+        let resources_reparsed: Vec<ResourceType> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(resources, resources_reparsed);
+    }
 }

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -37,6 +37,7 @@ macro_rules! named_enum_serialize_deserialize {
         }
     };
 }
+pub(crate) use named_enum_serialize_deserialize;
 
 /// Translates `STRUCTURE_*` constants.
 #[wasm_bindgen]

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -212,7 +212,7 @@ impl StructureType {
 
 /// Translates `SUBSCRIPTION_TOKEN` and `INTERSHARD_RESOURCES` constants.
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Sequence)]
 pub enum IntershardResourceType {
     // no longer used, not implemented
     // SubscriptionToken = "token",
@@ -220,6 +220,8 @@ pub enum IntershardResourceType {
     Pixel = "pixel",
     AccessKey = "accessKey",
 }
+
+named_enum_serialize_deserialize!(IntershardResourceType);
 
 /// Translates `RESOURCES_ALL` constant, representing all possible in-game
 /// (non-intershard) resources.
@@ -575,10 +577,12 @@ impl wasm_bindgen::describe::WasmDescribe for MarketResourceType {
 
 /// Translates the `POWER_CLASS` constants, which are classes of power creeps
 #[wasm_bindgen]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Sequence)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Sequence)]
 pub enum PowerCreepClass {
     Operator = "operator",
 }
+
+named_enum_serialize_deserialize!(PowerCreepClass);
 
 /// Translates the `PWR_*` constants, which are types of powers used by power
 /// creeps

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -1,8 +1,10 @@
 //! `*Type` constants.
+use std::borrow::Cow;
+
 use enum_iterator::Sequence;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::*};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use wasm_bindgen::prelude::*;
 
@@ -15,8 +17,8 @@ macro_rules! named_enum_serialize_deserialize {
             where
                 D: serde::Deserializer<'de>,
             {
-                let str = <&'de str>::deserialize(deserializer)?;
-                Ok(<$ty>::from_str(str).unwrap_or(<$ty>::__Nonexhaustive))
+                let s: Cow<'de, str> = Cow::deserialize(deserializer)?;
+                <$ty>::from_str(&s).ok_or(D::Error::invalid_value(serde::de::Unexpected::Str(&s), &"a valid {$ty} constant string"))
             }
         }
         impl serde::Serialize for $ty {

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -23,7 +23,7 @@ macro_rules! named_enum_serialize_deserialize {
                 let s: Cow<'de, str> = Cow::deserialize(deserializer)?;
                 <$ty>::from_str(&s).ok_or(D::Error::invalid_value(
                     Unexpected::Str(&s),
-                    &"a valid {$ty} constant string",
+                    &stringify!($ty),
                 ))
             }
         }

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -697,7 +697,7 @@ impl wasm_bindgen::describe::WasmDescribe for EffectType {
 
 #[cfg(test)]
 mod test {
-    use crate::ResourceType;
+    use super::*;
 
     #[test]
     fn resources_rust_to_serde_json_from_serde_json_roundtrip() {
@@ -735,6 +735,107 @@ mod test {
         let resources_reparsed_values: Vec<serde_json::Value> =
             serde_json::from_str(&serialized).unwrap();
         let resources_reparsed_native: Vec<ResourceType> = resources_reparsed_values
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()).unwrap())
+            .collect();
+        assert_eq!(resources, resources_reparsed_native);
+    }
+
+    #[test]
+    fn intershard_resources_rust_to_serde_json_from_serde_json_roundtrip() {
+        for resource in enum_iterator::all::<IntershardResourceType>() {
+            if resource != IntershardResourceType::__Nonexhaustive {
+                let serialized = serde_json::to_string(&resource).unwrap();
+                let parsed: IntershardResourceType = serde_json::from_str(&serialized).unwrap();
+                assert_eq!(resource, parsed);
+            }
+        }
+    }
+
+    #[test]
+    fn intershard_resources_rust_vec_to_serde_json_from_serde_json_roundtrip() {
+        let mut resources = vec![];
+        for resource in enum_iterator::all::<IntershardResourceType>() {
+            if resource != IntershardResourceType::__Nonexhaustive {
+                resources.push(resource);
+            }
+        }
+        let serialized = serde_json::to_string(&resources).unwrap();
+        let resources_reparsed: Vec<IntershardResourceType> =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(resources, resources_reparsed);
+    }
+
+    #[test]
+    fn intershard_resources_rust_vec_to_serde_json_from_serde_json_roundtrip_via_values() {
+        let mut resources = vec![];
+        for resource in enum_iterator::all::<IntershardResourceType>() {
+            if resource != IntershardResourceType::__Nonexhaustive {
+                resources.push(resource);
+            }
+        }
+        let serialized = serde_json::to_string(&resources).unwrap();
+        let resources_reparsed_values: Vec<serde_json::Value> =
+            serde_json::from_str(&serialized).unwrap();
+        let resources_reparsed_native: Vec<IntershardResourceType> = resources_reparsed_values
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()).unwrap())
+            .collect();
+        assert_eq!(resources, resources_reparsed_native);
+    }
+
+    #[test]
+    fn market_resources_rust_to_serde_json_from_serde_json_roundtrip() {
+        for resource in enum_iterator::all::<MarketResourceType>() {
+            if resource != MarketResourceType::Resource(ResourceType::__Nonexhaustive)
+                && resource
+                    != MarketResourceType::IntershardResource(
+                        IntershardResourceType::__Nonexhaustive,
+                    )
+            {
+                let serialized = serde_json::to_string(&resource).unwrap();
+                let parsed: MarketResourceType = serde_json::from_str(&serialized).unwrap();
+                assert_eq!(resource, parsed);
+            }
+        }
+    }
+
+    #[test]
+    fn market_resources_rust_vec_to_serde_json_from_serde_json_roundtrip() {
+        let mut resources = vec![];
+        for resource in enum_iterator::all::<MarketResourceType>() {
+            if resource != MarketResourceType::Resource(ResourceType::__Nonexhaustive)
+                && resource
+                    != MarketResourceType::IntershardResource(
+                        IntershardResourceType::__Nonexhaustive,
+                    )
+            {
+                resources.push(resource);
+            }
+        }
+        let serialized = serde_json::to_string(&resources).unwrap();
+        let resources_reparsed: Vec<MarketResourceType> =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(resources, resources_reparsed);
+    }
+
+    #[test]
+    fn market_resources_rust_vec_to_serde_json_from_serde_json_roundtrip_via_values() {
+        let mut resources = vec![];
+        for resource in enum_iterator::all::<MarketResourceType>() {
+            if resource != MarketResourceType::Resource(ResourceType::__Nonexhaustive)
+                && resource
+                    != MarketResourceType::IntershardResource(
+                        IntershardResourceType::__Nonexhaustive,
+                    )
+            {
+                resources.push(resource);
+            }
+        }
+        let serialized = serde_json::to_string(&resources).unwrap();
+        let resources_reparsed_values: Vec<serde_json::Value> =
+            serde_json::from_str(&serialized).unwrap();
+        let resources_reparsed_native: Vec<MarketResourceType> = resources_reparsed_values
             .iter()
             .map(|v| serde_json::from_value(v.clone()).unwrap())
             .collect();

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -694,9 +694,11 @@ mod test {
     #[test]
     fn rust_to_serde_json_from_serde_json_roundtrip() {
         for resource in enum_iterator::all::<ResourceType>() {
-            let serialized = serde_json::to_string(&resource).unwrap();
-            let parsed: ResourceType = serde_json::from_str(&serialized).unwrap();
-            assert_eq!(resource, parsed);
+            if resource != ResourceType::__Nonexhaustive {
+                let serialized = serde_json::to_string(&resource).unwrap();
+                let parsed: ResourceType = serde_json::from_str(&serialized).unwrap();
+                assert_eq!(resource, parsed);
+            }
         }
     }
 }

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -686,3 +686,17 @@ impl wasm_bindgen::describe::WasmDescribe for EffectType {
         wasm_bindgen::describe::inform(wasm_bindgen::describe::U32)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::ResourceType;
+
+    #[test]
+    fn rust_to_serde_json_from_serde_json_roundtrip() {
+        for resource in enum_iterator::all::<ResourceType>() {
+            let serialized = serde_json::to_string(&resource).unwrap();
+            let parsed: ResourceType = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(resource, parsed);
+        }
+    }
+}

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -692,7 +692,7 @@ mod test {
     use crate::ResourceType;
 
     #[test]
-    fn rust_to_serde_json_from_serde_json_roundtrip() {
+    fn resources_rust_to_serde_json_from_serde_json_roundtrip() {
         for resource in enum_iterator::all::<ResourceType>() {
             if resource != ResourceType::__Nonexhaustive {
                 let serialized = serde_json::to_string(&resource).unwrap();
@@ -703,7 +703,7 @@ mod test {
     }
 
     #[test]
-    fn rust_vec_to_serde_json_from_serde_json_roundtrip() {
+    fn resources_rust_vec_to_serde_json_from_serde_json_roundtrip() {
         let mut resources = vec![];
         for resource in enum_iterator::all::<ResourceType>() {
             if resource != ResourceType::__Nonexhaustive {
@@ -711,8 +711,21 @@ mod test {
             }
         }
         let serialized = serde_json::to_string(&resources).unwrap();
-        //panic!("{}", serialized);
         let resources_reparsed: Vec<ResourceType> = serde_json::from_str(&serialized).unwrap();
         assert_eq!(resources, resources_reparsed);
+    }
+
+    #[test]
+    fn resources_rust_vec_to_serde_json_from_serde_json_roundtrip_via_values() {
+        let mut resources = vec![];
+        for resource in enum_iterator::all::<ResourceType>() {
+            if resource != ResourceType::__Nonexhaustive {
+                resources.push(resource);
+            }
+        }
+        let serialized = serde_json::to_string(&resources).unwrap();
+        let resources_reparsed_values: Vec<serde_json::Value> = serde_json::from_str(&serialized).unwrap();
+        let resources_reparsed_native: Vec<ResourceType> = resources_reparsed_values.iter().map(|v| serde_json::from_value(v.clone()).unwrap()).collect();
+        assert_eq!(resources, resources_reparsed_native);
     }
 }


### PR DESCRIPTION
Fixes some cases when deserializing was failing, notably when using `serde_json::from_value`.  Switched back to the `Cow` based deserialization we used a bunch back in stdweb-days, and improve our failure message when invalid stuff is passed instead of going for `__Nonexhaustive` - which *might* be a breaking change.