### PR TITLE
Add native terrain data wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Unreleased
 - Add `local::serde_position_packed` module, for use with the `with` serde attribute, allowing
   serialized positions to be stored as packed even with human-readable serializers
 - New types `MapFontStyle`, `MapFontVariant`, `MapTextStyle` for use in the changes to map visuals
+- Add `LocalRoomTerrain`, a wrapper in wasm memory of the data in a `RoomTerrain` object.
 
 ### Bugfixes:
 

--- a/src/local.rs
+++ b/src/local.rs
@@ -7,6 +7,7 @@ mod object_id;
 mod position;
 mod room_coordinate;
 mod room_name;
+mod terrain;
 
 /// Represents two constants related to room names.
 ///
@@ -31,4 +32,5 @@ use crate::ROOM_SIZE;
 
 pub use self::{
     cost_matrix::*, lodash_filter::*, object_id::*, position::*, room_coordinate::*, room_name::*,
+    terrain::*,
 };

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -17,11 +17,16 @@ impl fmt::Display for OutOfBoundsError {
 
 impl Error for OutOfBoundsError {}
 
+/// Converts a [`RoomXY`] coordinate pair to a linear index appropriate for use
+/// with the internal representation of a [`CostMatrix`] or [`LocalCostMatrix`].
 #[inline]
 pub const fn xy_to_linear_index(xy: RoomXY) -> usize {
-    ((xy.x.0 as usize) * (ROOM_SIZE as usize)) + (xy.y.0 as usize)
+    xy.x.u8() as usize * ROOM_SIZE as usize + xy.y.u8() as usize
 }
 
+/// Converts a linear index from the internal representation of a [`CostMatrix`]
+/// or [`LocalCostMatrix`] to a [`RoomXY`] coordinate pair for the position the
+/// index represents.
 #[inline]
 pub fn linear_index_to_xy(idx: usize) -> RoomXY {
     assert!(idx < ROOM_AREA, "Out of bounds index: {idx}");
@@ -29,6 +34,26 @@ pub fn linear_index_to_xy(idx: usize) -> RoomXY {
     RoomXY {
         x: unsafe { RoomCoordinate::unchecked_new((idx / (ROOM_SIZE as usize)) as u8) },
         y: unsafe { RoomCoordinate::unchecked_new((idx % (ROOM_SIZE as usize)) as u8) },
+    }
+}
+
+/// Converts a [`RoomXY`] coordinate pair to a terrain index appropriate for use
+/// with the internal representation of [`RoomTerrain`] or [`LocalRoomTerrain`].
+#[inline]
+pub const fn xy_to_terrain_index(xy: RoomXY) -> usize {
+    xy.y.u8() as usize * ROOM_SIZE as usize + xy.x.u8() as usize
+}
+
+/// Converts a terrain index from the internal representation of a
+/// [`RoomTerrain`] or [`LocalRoomTerrain`] to a [`RoomXY`] coordinate pair for
+/// the position the index represents.
+#[inline]
+pub fn terrain_index_to_xy(idx: usize) -> RoomXY {
+    assert!(idx < ROOM_AREA, "Out of bounds index: {idx}");
+    // SAFETY: bounds checking above ensures both are within range.
+    RoomXY {
+        x: unsafe { RoomCoordinate::unchecked_new((idx % (ROOM_SIZE as usize)) as u8) },
+        y: unsafe { RoomCoordinate::unchecked_new((idx / (ROOM_SIZE as usize)) as u8) },
     }
 }
 

--- a/src/local/terrain.rs
+++ b/src/local/terrain.rs
@@ -53,6 +53,7 @@ impl From<RoomTerrain> for LocalRoomTerrain {
         // again
         drop(js_buffer);
         // we've got the data in our boxed array, change to the needed type
-        LocalRoomTerrain::new_from_bits(unsafe { std::mem::transmute(data) })
+        // SAFETY: `Box` has the same layout for sized types. `MaybeUninit<u8>` has the same layout as `u8`. The arrays are the same size. The `MaybeUninit<u8>` are all initialized because JS wrote to them.
+        LocalRoomTerrain::new_from_bits(unsafe { std::mem::transmute::<Box<[MaybeUninit<u8>; ROOM_AREA]>, Box<[u8; ROOM_AREA]>>(data) })
     }
 }

--- a/src/local/terrain.rs
+++ b/src/local/terrain.rs
@@ -28,6 +28,9 @@ impl LocalRoomTerrain {
         }
     }
 
+    /// Creates a `LocalRoomTerrain` from the bytes that correspond to the room's terrain data.  This is like the `RoomTerrain` type but performs all operations on data stored in wasm.
+    /// Each byte in the array corresponds to the value of the `Terrain` at the given position.
+    /// The bytes are in row-major order, that is they start at the top left, then move to the top right, and then start at the left of the next row. This is different from `LocalCostMatrix`, which is column-major.
     pub fn new_from_bits(bits: Box<[u8; ROOM_AREA]>) -> Self {
         Self { bits }
     }

--- a/src/local/terrain.rs
+++ b/src/local/terrain.rs
@@ -6,6 +6,7 @@ use crate::{constants::Terrain, objects::RoomTerrain};
 
 use super::{xy_to_terrain_index, RoomXY, ROOM_AREA};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalRoomTerrain {
     bits: Box<[u8; ROOM_AREA]>,
 }

--- a/src/local/terrain.rs
+++ b/src/local/terrain.rs
@@ -18,11 +18,12 @@ impl LocalRoomTerrain {
         // not using Terrain::from_u8() because `0b11` value, wall+swamp, happens
         // in commonly used server environments (notably the private server default
         // map), and is special-cased in the engine code; we special-case it here
-        match byte {
+        match byte & 0b11 {
             0b00 => Terrain::Plain,
             0b01 | 0b11 => Terrain::Wall,
             0b10 => Terrain::Swamp,
-            _ => panic!("unexpected terrain"),
+            // Should be optimized out
+            _ => unreachable!("all combinations of 2 bits are covered"),
         }
     }
 

--- a/src/local/terrain.rs
+++ b/src/local/terrain.rs
@@ -1,0 +1,58 @@
+use std::mem::MaybeUninit;
+
+use js_sys::Uint8Array;
+
+use crate::{constants::Terrain, objects::RoomTerrain};
+
+use super::{xy_to_terrain_index, RoomXY, ROOM_AREA};
+
+pub struct LocalRoomTerrain {
+    bits: Box<[u8; ROOM_AREA]>,
+}
+
+impl LocalRoomTerrain {
+    /// Gets the terrain at the specified position in this room.
+    pub fn get(&self, xy: RoomXY) -> Terrain {
+        // SAFETY: RoomXY is always a valid coordinate.
+        let byte = unsafe { self.bits.get_unchecked(xy_to_terrain_index(xy)) };
+        // not using Terrain::from_u8() because `0b11` value, wall+swamp, happens
+        // in commonly used server environments (notably the private server default
+        // map), and is special-cased in the engine code; we special-case it here
+        match byte {
+            0b00 => Terrain::Plain,
+            0b01 | 0b11 => Terrain::Wall,
+            0b10 => Terrain::Swamp,
+            _ => panic!("unexpected terrain"),
+        }
+    }
+
+    pub fn new_from_bits(bits: Box<[u8; ROOM_AREA]>) -> Self {
+        Self { bits }
+    }
+}
+
+impl From<RoomTerrain> for LocalRoomTerrain {
+    fn from(terrain: RoomTerrain) -> LocalRoomTerrain {
+        // create an uninitialized array of the correct size
+        let mut data: Box<[MaybeUninit<u8>; ROOM_AREA]> =
+            Box::new([MaybeUninit::uninit(); ROOM_AREA]);
+        // create a Uint8Array mapped to the same point in wasm linear memory as our
+        // uninitialized boxed array
+        let js_buffer =
+            unsafe { Uint8Array::view_mut_raw(data.as_mut_ptr() as *mut u8, ROOM_AREA) };
+        // SAFETY: it's important to not allocate _anything_ in rust memory now that
+        // we've created the Uint8Array pointed at an arbitrary wasm memory location;
+        // we'd overwrite the wrong memory if the array moved due to allocation!
+
+        // copy the terrain buffer into the memory backing the Uint8Array - this is the
+        // boxed array, so this initializes it
+        terrain
+            .get_raw_buffer_to_array(&js_buffer)
+            .expect("terrain data to copy");
+        // data copied - explicitly drop the Uint8Array, so there's no chance it's used
+        // again
+        drop(js_buffer);
+        // we've got the data in our boxed array, change to the needed type
+        LocalRoomTerrain::new_from_bits(unsafe { std::mem::transmute(data) })
+    }
+}


### PR DESCRIPTION
Add `LocalRoomTerrain`, a simplified alternative to the packed version in #443 (which we're planning to include in the utils crate for when a more compressed representation is desired) to hold the terrain natively in wasm memory for fast access. Resolves #441 