### PR TITLE
feat: use gloo_utils for parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = "1"
 serde_repr = "0.1"
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.5"
+gloo-utils = "0.2.0"
 
 [dev-dependencies]
 assert_approx_eq = "1.1"

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -710,11 +710,20 @@ pub struct Step {
     pub direction: Direction,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum Path {
     Vectorized(Vec<Step>),
     Serialized(String),
+}
+
+impl ToString for Path {
+    fn to_string(&self) -> String {
+        match self {
+            Path::Vectorized(path) => Room::serialize_path(path),
+            Path::Serialized(path) => path.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -323,7 +323,7 @@ impl RoomPosition {
 
         if let Some(options) = options {
             options.into_js_options(|js_options| {
-                self.find_path_to_internal(&target, None)
+                self.find_path_to_internal(&target, Some(js_options.unchecked_ref()))
                     .into_serde()
                     .expect("invalid path from RoomPosition.findPathTo")
             })

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 
+use gloo_utils::format::JsValueSerdeExt;
 use js_sys::{Array, JsString, Object};
 use num_traits::*;
 use wasm_bindgen::{prelude::*, JsCast};
@@ -322,13 +323,13 @@ impl RoomPosition {
 
         if let Some(options) = options {
             options.into_js_options(|js_options| {
-                serde_wasm_bindgen::from_value(
-                    self.find_path_to_internal(&target, Some(js_options.unchecked_ref())),
-                )
-                .expect("invalid path from RoomPosition.findPathTo")
+                self.find_path_to_internal(&target, None)
+                    .into_serde()
+                    .expect("invalid path from RoomPosition.findPathTo")
             })
         } else {
-            serde_wasm_bindgen::from_value(self.find_path_to_internal(&target, None))
+            self.find_path_to_internal(&target, None)
+                .into_serde()
                 .expect("invalid path from RoomPosition.findPathTo")
         }
     }


### PR DESCRIPTION
This PR does two things:

1. Use `JSValue::.into_serde()` from gloo utils. I was having problems with the `serde_wasm_bindgen::from_value`. More specifically, I kept seeing: `caught exception: SyntaxError: Unexpected token {`
2. By adding `Serialize` to the Path enum, we can easily call `move_by_path` using the serialized/stringified version of the Path.

e.g.
```rs
creep.move_by_path(&JsValue::from_str(&path.to_string()))
```