### PR TITLE
Fix undefined attributes on StructureController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased
 
 ### Bugfixes:
 
-- An undefined `hits` or `hitsMax` value on an unvulnerable wall or certain controllers will no
+- An undefined `hits` or `hitsMax` value on an invulnerable wall or certain controllers will no
   longer cause a panic when building in dev mode
 
 0.18.0 (2023-11-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 Unreleased
 ==========
 
+### Breaking:
 
+- A number of functions on `StructureController` now return `Option<u32>` to account for cases 
+  where they may be undefined: `progress`, `progress_total`, `ticks_to_downgrade`, and
+  `upgrade_blocked`
+
+### Bugfixes:
+
+- An undefined `hits` or `hitsMax` value on an unvulnerable wall or certain controllers will no
+  longer cause a panic when building in dev mode
 
 0.18.0 (2023-11-27)
 ===================

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -17,21 +17,11 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type Structure;
 
-    /// Retrieve the current hits of this structure, or `0` if this structure is
-    /// indestructible, such as a notice area border wall, portal, or room
-    /// controller.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Structure.hits)
-    #[wasm_bindgen(method, getter)]
-    pub fn hits(this: &Structure) -> u32;
+    #[wasm_bindgen(method, getter = hits)]
+    fn hits_internal(this: &Structure) -> Option<u32>;
 
-    /// Retrieve the maximum hits of this structure, or `0` if this structure is
-    /// indestructible, such as a notice area border wall, portal, or room
-    /// controller.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Structure.hitsMax)
     #[wasm_bindgen(method, getter = hitsMax)]
-    pub fn hits_max(this: &Structure) -> u32;
+    fn hits_max_internal(this: &Structure) -> Option<u32>;
 
     /// Object ID of the structure, which can be used to efficiently fetch a
     /// fresh reference to the object on subsequent ticks.
@@ -64,6 +54,26 @@ extern "C" {
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure.notifyWhenAttacked)
     #[wasm_bindgen(method, js_name = notifyWhenAttacked)]
     pub fn notify_when_attacked(this: &Structure, val: bool) -> i8;
+}
+
+impl Structure {
+    /// Retrieve the current hits of this structure, or `0` if this structure is
+    /// indestructible, such as a notice area border wall, portal, or room
+    /// controller.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Structure.hits)
+    pub fn hits(&self) -> u32 {
+        self.hits_internal().unwrap_or(0)
+    }
+
+    /// Retrieve the maximum hits of this structure, or `0` if this structure is
+    /// indestructible, such as a notice area border wall, portal, or room
+    /// controller.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Structure.hitsMax)
+    pub fn hits_max(&self) -> u32 {
+        self.hits_max_internal().unwrap_or(0)
+    }
 }
 
 impl<T> HasNativeId for T

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -29,18 +29,19 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn level(this: &StructureController) -> u8;
 
-    /// The progress toward upgrading the controller to the next level
+    /// The progress toward upgrading the controller to the next level, or
+    /// `None` if the controller is unowned.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.progress)
     #[wasm_bindgen(method, getter)]
-    pub fn progress(this: &StructureController) -> u32;
+    pub fn progress(this: &StructureController) -> Option<u32>;
 
     /// The total [`StructureController::progress`] needed to upgrade the
-    /// controller to the next level.
+    /// controller to the next level, or `None` if the controller is unowned.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.progressTotal)
     #[wasm_bindgen(method, getter = progressTotal)]
-    pub fn progress_total(this: &StructureController) -> u32;
+    pub fn progress_total(this: &StructureController) -> Option<u32>;
 
     /// Information about the reservation of this controller, if it is currently
     /// reserved.
@@ -57,7 +58,7 @@ extern "C" {
     pub fn safe_mode(this: &StructureController) -> Option<u32>;
 
     /// The number of of available safe mode activations, which can be increased
-    /// by using [`Creep::generate_safe_mode`]
+    /// by using [`Creep::generate_safe_mode`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.safeModeAvailable)
     ///
@@ -81,11 +82,12 @@ extern "C" {
     pub fn sign(this: &StructureController) -> Option<Sign>;
 
     /// The number of ticks until the level of the controller will be
-    /// decremented due to a lack of [`Creep::upgrade_controller`] activity.
+    /// decremented due to a lack of [`Creep::upgrade_controller`] activity, or
+    /// `None` if the controller is unowned.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.ticksToDowngrade)
     #[wasm_bindgen(method, getter = ticksToDowngrade)]
-    pub fn ticks_to_downgrade(this: &StructureController) -> u32;
+    pub fn ticks_to_downgrade(this: &StructureController) -> Option<u32>;
 
     /// The number of ticks until the controller can be upgraded, or have safe
     /// mode activated, due to [`Creep::attack_controller`].
@@ -94,27 +96,27 @@ extern "C" {
     ///
     /// [`Creep::attack_controller`]: crate::objects::Creep::attack_controller
     #[wasm_bindgen(method, getter = upgradeBlocked)]
-    pub fn upgrade_blocked(this: &StructureController) -> u32;
+    pub fn upgrade_blocked(this: &StructureController) -> Option<u32>;
 
-    /// Activate safe mode for the room, preventing hostile creep actions in the
-    /// room for 20,000 ticks
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.activateSafeMode)
     #[wasm_bindgen(method, js_name = activateSafeMode)]
     fn activate_safe_mode_internal(this: &StructureController) -> i8;
 
-    /// Relinquish ownership of the controller and its room.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.unclaim)
     #[wasm_bindgen(method, js_name = unclaim)]
     fn unclaim_internal(this: &StructureController) -> i8;
 }
 
 impl StructureController {
+    /// Activate safe mode for the room, preventing hostile creep actions in the
+    /// room for 20,000 ticks
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.activateSafeMode)
     pub fn activate_safe_mode(&self) -> Result<(), ErrorCode> {
         ErrorCode::result_from_i8(self.activate_safe_mode_internal())
     }
 
+    /// Relinquish ownership of the controller and its room.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.unclaim)
     pub fn unclaim(&self) -> Result<(), ErrorCode> {
         ErrorCode::result_from_i8(self.unclaim_internal())
     }


### PR DESCRIPTION
Fixes #458

 - `hits`/`hitMax`: Added coalesce from undefined to 0, as 0 is another value that the game uses for invulnerable structures in addition to undefined. This matches the current behavior when in release mode.
 - `upgradeBlocked`, `progress`, `progressTotal`, `ticksToDowngrade`: 0 values wouldn't make sense for some of these, and all have cases where you'd expect them to be undefined. Added `Option<>` wrap around returns for each.
 - `safeModeAvailable`, `isPowerEnabled`: seems like these already coalesce to sane values when undefined: https://github.com/screeps/engine/blob/204f95545d8946782e65911abbcd020a256f1cd7/src/game/structures.js#L186-L198