### PR TITLE
Fixed portal destinations using a incorrect name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased
 
 - An undefined `hits` or `hitsMax` value on an invulnerable wall or certain controllers will no
   longer cause a panic when building in dev mode
+- Fixed incorrect JavaScript field name on `StructurePortal::destination()` getter
 
 0.18.0 (2023-11-27)
 ===================

--- a/src/objects/impls/structure_portal.rs
+++ b/src/objects/impls/structure_portal.rs
@@ -17,7 +17,7 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type StructurePortal;
 
-    #[wasm_bindgen(method, getter)]
+    #[wasm_bindgen(method, getter = destination)]
     fn destination_internal(this: &StructurePortal) -> JsValue;
 
     /// The number of ticks until the portal will decay, if it's unstable, or 0


### PR DESCRIPTION
Portal destinations where not working as they where using the wrong name, this fixes it