### PR TITLE
fix: set_default_public_segment and set_public_segments are no longer panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Unreleased
 - Remove `Resolvable` trait, moving its functionality to `MaybeHasId`
 - Remove `ObjectWithId` and `ObjectWithMaybeId` enums
 
+### Bugfixes:
+
+- Fix `raw_memory::set_public_segments` and `set_default_public_segment` argument conversion
+
 0.19.0 (2023-12-20)
 ===================
 

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -108,7 +108,11 @@ pub fn set_active_foreign_segment(username: &JsString, segment_id: Option<u8>) {
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setDefaultPublicSegment)
 pub fn set_default_public_segment(segment_id: Option<u8>) {
-    RawMemory::set_default_public_segment(segment_id.map(|f| JsValue::from_f64(f as f64)).unwrap_or(JsValue::null()))
+    RawMemory::set_default_public_segment(
+        segment_id
+            .map(|f| JsValue::from_f64(f as f64))
+            .unwrap_or(JsValue::NULL),
+    )
 }
 
 /// Sets which of your memory segments are readable to other players as

--- a/src/raw_memory.rs
+++ b/src/raw_memory.rs
@@ -40,10 +40,10 @@ extern "C" {
     fn set_active_foreign_segment(username: &JsString, segment_id: Option<u8>);
 
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setDefaultPublicSegment)]
-    fn set_default_public_segment(segment_id: Option<u8>);
+    fn set_default_public_segment(segment_id: JsValue);
 
     #[wasm_bindgen(static_method_of = RawMemory, js_name = setPublicSegments)]
-    fn set_public_segments(segment_ids: &[u8]);
+    fn set_public_segments(segment_ids: &Array);
 }
 
 /// Get a [`JsHashMap<u8, String>`] with all of the segments requested on
@@ -108,7 +108,7 @@ pub fn set_active_foreign_segment(username: &JsString, segment_id: Option<u8>) {
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setDefaultPublicSegment)
 pub fn set_default_public_segment(segment_id: Option<u8>) {
-    RawMemory::set_default_public_segment(segment_id)
+    RawMemory::set_default_public_segment(segment_id.map(|f| JsValue::from_f64(f as f64)).unwrap_or(JsValue::null()))
 }
 
 /// Sets which of your memory segments are readable to other players as
@@ -116,7 +116,13 @@ pub fn set_default_public_segment(segment_id: Option<u8>) {
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#RawMemory.setPublicSegments)
 pub fn set_public_segments(segment_ids: &[u8]) {
-    RawMemory::set_public_segments(segment_ids)
+    let segment_ids: Array = segment_ids
+        .iter()
+        .map(|s| *s as f64)
+        .map(JsValue::from_f64)
+        .collect();
+
+    RawMemory::set_public_segments(&segment_ids)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
This PR fixes 2 functions panicking on normal input
```
raw_memory::set_default_public_segment(None);
raw_memory::set_public_segments(&[0]);
```

I am not sure if my fix for `set_default_public_segment` is great
`None` needs to be translated to `null` on the JS side, previously it would be translated into `undefined` and would throw an error