### PR TITLE
Make `MapVisual` styles mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Unreleased
     other trait functions
 - Remove `Resolvable` trait, moving its functionality to `MaybeHasId`
 - Remove `ObjectWithId` and `ObjectWithMaybeId` enums
+- Remove `Option<_>` for style options on `MapVisual`, fixes all visuals failing to render if
+  one without style was used
 
 ### Bugfixes:
 

--- a/src/objects/impls/map_visual.rs
+++ b/src/objects/impls/map_visual.rs
@@ -78,6 +78,12 @@ pub enum MapFontStyle {
     Oblique,
 }
 
+impl MapFontStyle {
+    pub fn is_normal(&self) -> bool {
+        matches!(self, MapFontStyle::Normal)
+    }
+}
+
 /// The font variant for map text visuals.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -87,6 +93,12 @@ pub enum MapFontVariant {
     Normal,
     /// Render all lowercase characters in small caps.
     SmallCaps,
+}
+
+impl MapFontVariant {
+    pub fn is_normal(&self) -> bool {
+        matches!(self, MapFontVariant::Normal)
+    }
 }
 
 /// Settings for text visuals on the map, used with [`MapVisual::text`].
@@ -117,7 +129,9 @@ pub struct MapTextStyle {
     font_family: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     font_size: Option<f32>,
+    #[serde(skip_serializing_if = "MapFontStyle::is_normal")]
     font_style: MapFontStyle,
+    #[serde(skip_serializing_if = "MapFontVariant::is_normal")]
     font_variant: MapFontVariant,
     #[serde(skip_serializing_if = "Option::is_none")]
     stroke: Option<String>,

--- a/src/objects/impls/map_visual.rs
+++ b/src/objects/impls/map_visual.rs
@@ -12,8 +12,8 @@ pub struct MapCircleData {
     x: RoomCoordinate,
     y: RoomCoordinate,
     n: RoomName,
-    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
-    style: Option<CircleStyle>,
+    #[serde(rename = "s")]
+    style: CircleStyle,
 }
 
 #[derive(Clone, Serialize)]
@@ -24,8 +24,8 @@ pub struct MapLineData {
     x2: RoomCoordinate,
     y2: RoomCoordinate,
     n2: RoomName,
-    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
-    style: Option<LineStyle>,
+    #[serde(rename = "s")]
+    style: LineStyle,
 }
 
 #[derive(Clone, Serialize)]
@@ -37,8 +37,8 @@ pub struct MapRectData {
     width: u32,
     #[serde(rename = "h")]
     height: u32,
-    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
-    style: Option<RectStyle>,
+    #[serde(rename = "s")]
+    style: RectStyle,
 }
 
 #[derive(Clone, Serialize)]
@@ -61,8 +61,8 @@ impl From<&Position> for MapPolyPoint {
 #[derive(Clone, Serialize)]
 pub struct MapPolyData {
     points: Vec<MapPolyPoint>,
-    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
-    style: Option<PolyStyle>,
+    #[serde(rename = "s")]
+    style: PolyStyle,
 }
 
 /// The font style for map text visuals.
@@ -327,8 +327,8 @@ pub struct MapTextData {
     x: RoomCoordinate,
     y: RoomCoordinate,
     n: RoomName,
-    #[serde(rename = "s", skip_serializing_if = "Option::is_none")]
-    style: Option<MapTextStyle>,
+    #[serde(rename = "s")]
+    style: MapTextStyle,
 }
 
 #[derive(Clone, Serialize)]
@@ -347,7 +347,7 @@ pub enum MapVisualShape {
 }
 
 impl MapVisualShape {
-    pub fn circle(center: Position, style: Option<CircleStyle>) -> MapVisualShape {
+    pub fn circle(center: Position, style: CircleStyle) -> MapVisualShape {
         MapVisualShape::Circle(MapCircleData {
             x: center.x(),
             y: center.y(),
@@ -356,7 +356,7 @@ impl MapVisualShape {
         })
     }
 
-    pub fn line(from: Position, to: Position, style: Option<LineStyle>) -> MapVisualShape {
+    pub fn line(from: Position, to: Position, style: LineStyle) -> MapVisualShape {
         MapVisualShape::Line(MapLineData {
             x1: from.x(),
             y1: from.y(),
@@ -372,7 +372,7 @@ impl MapVisualShape {
         top_left: Position,
         width: u32,
         height: u32,
-        style: Option<RectStyle>,
+        style: RectStyle,
     ) -> MapVisualShape {
         MapVisualShape::Rect(MapRectData {
             x: top_left.x(),
@@ -384,11 +384,11 @@ impl MapVisualShape {
         })
     }
 
-    pub fn poly(points: Vec<MapPolyPoint>, style: Option<PolyStyle>) -> MapVisualShape {
+    pub fn poly(points: Vec<MapPolyPoint>, style: PolyStyle) -> MapVisualShape {
         MapVisualShape::Poly(MapPolyData { points, style })
     }
 
-    pub fn text(pos: Position, text: String, style: Option<MapTextStyle>) -> MapVisualShape {
+    pub fn text(pos: Position, text: String, style: MapTextStyle) -> MapVisualShape {
         MapVisualShape::Text(MapTextData {
             x: pos.x(),
             y: pos.y(),
@@ -416,24 +416,24 @@ impl MapVisual {
         }
     }
 
-    pub fn circle(pos: Position, style: Option<CircleStyle>) {
+    pub fn circle(pos: Position, style: CircleStyle) {
         Self::draw(&MapVisualShape::circle(pos, style));
     }
 
-    pub fn line(from: Position, to: Position, style: Option<LineStyle>) {
+    pub fn line(from: Position, to: Position, style: LineStyle) {
         Self::draw(&MapVisualShape::line(from, to, style));
     }
 
-    pub fn rect(top_left: Position, width: u32, height: u32, style: Option<RectStyle>) {
+    pub fn rect(top_left: Position, width: u32, height: u32, style: RectStyle) {
         Self::draw(&MapVisualShape::rect(top_left, width, height, style));
     }
 
-    pub fn poly(points: Vec<Position>, style: Option<PolyStyle>) {
+    pub fn poly(points: Vec<Position>, style: PolyStyle) {
         let points = points.iter().map(Into::into).collect();
         Self::draw(&MapVisualShape::poly(points, style));
     }
 
-    pub fn text(pos: Position, text: String, style: Option<MapTextStyle>) {
+    pub fn text(pos: Position, text: String, style: MapTextStyle) {
         Self::draw(&MapVisualShape::text(pos, text, style));
     }
 }

--- a/src/objects/impls/map_visual.rs
+++ b/src/objects/impls/map_visual.rs
@@ -368,12 +368,7 @@ impl MapVisualShape {
         })
     }
 
-    pub fn rect(
-        top_left: Position,
-        width: u32,
-        height: u32,
-        style: RectStyle,
-    ) -> MapVisualShape {
+    pub fn rect(top_left: Position, width: u32, height: u32, style: RectStyle) -> MapVisualShape {
         MapVisualShape::Rect(MapRectData {
             x: top_left.x(),
             y: top_left.y(),


### PR DESCRIPTION
The game's wrapper for the `MapVisual` functions adds a `{}` as a style if one's unset, eg: https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/map.js#L346

The current `MapVisual` implementation serializes into console's addVisual function directly, and excludes `s` when it's unset, causing all map visuals to fail to display.  Making it mandatory is technically a break from the game's API, but a fairly benign one, and less crufty than other ways I can think to fix this.