### PR TITLE
Make ObjectId Send + Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Unreleased
       which returns a `Result<&'static [ResourceType], StoreObjectConversionError>`
 - Add missing `StoreObject::Reactor` to the `seasonal-season-5` feature.
 
+### Other
+- Change `PhantomData` in `screeps::local::ObjectId` to better model `ObjectId`'s relationship with the wrapped type.
+    - This allows `ObjectId` to be `Send + Sync` regardless of the wrapped type
+
 0.20.1 (2024-01-09)
 ===================
 

--- a/src/local/object_id.rs
+++ b/src/local/object_id.rs
@@ -60,8 +60,12 @@ pub use raw::*;
 #[serde(transparent, bound = "")]
 pub struct ObjectId<T> {
     raw: RawObjectId,
+
+    // Needed to consider the `T` as "used" even though we mostly use it as a marker. Because of
+    // auto traits, `PhantomData<fn() -> T>` is used instead: this struct doesn't *hold* a `T`, it
+    // *produces* one.
     #[serde(skip)]
-    phantom: PhantomData<T>,
+    phantom: PhantomData<fn() -> T>,
 }
 
 // traits implemented manually so they don't depend on `T` implementing them.


### PR DESCRIPTION
As suggested by @asquared31415 in discord, change the `PhantomData` on `ObjectId<T>` from `PhantomData<T>` to `PhantomData<fn() -T>`. This is more accurate since `ObectId` doesn't actually _own_ a `T`, but it can _produce_ a `T`.