### PR TITLE
Remove generate-pixel and inter-shard-memory features, restrict more CPU functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
 - Change name of `LocalRoomTerrain::get` to `get_xy` for consistency with `RoomTerrain`
 - Change name of `constants::extra::CONSTRUCTION_SITE_STOMP_RATIO` to
   `CONSTRUCTION_SITE_DROP_RATIO`
+- Remove features `generate-pixel` and `inter-shard-memory`, use the `mmo` feature instead
+- Place `game::cpu::{shard_limits, unlocked, unlocked_time, set_shard_limits, unlock}` functions
+  behind the `mmo` feature
 
 ### Additions:
 
@@ -35,7 +38,8 @@ Unreleased
 
 ### Misc:
 
-- Change `PhantomData` in `screeps::local::ObjectId` to better model `ObjectId`'s relationship with the wrapped type.
+- Change `PhantomData` in `screeps::local::ObjectId` to better model `ObjectId`'s relationship with
+  the wrapped type.
     - This allows `ObjectId` to be `Send + Sync` regardless of the wrapped type
 - Update `enum-iterator` to 2.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,8 @@ wasm-bindgen-test = "0.3"
 [features]
 ## Specific features to enable conditional API endpoints
 
-# Enable the function call for pixel generation - only present on official MMO servers
-generate-pixel = []
-
-# Enable the interface for inter-shard memory - only present on official MMO servers
-inter-shard-memory = []
+# Official MMO server features, not present on other environments
+mmo = []
 
 # Seasonal server, season 1 - enable score container, collector, and resource
 seasonal-season-1 = []
@@ -69,8 +66,3 @@ sim = []
 # Enable unsafe conversions of return codes with undefined behavior when values
 # aren't in the expected range
 unsafe-return-conversion = []
-
-## Sets of the above features for different server environments
-
-# Official MMO server features, not present on other environments
-mmo = ["generate-pixel", "inter-shard-memory"]

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -20,12 +20,15 @@ extern "C" {
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = bucket)]
     fn bucket() -> i32;
 
+    #[cfg(feature = "mmo")]
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = shardLimits)]
     fn shard_limits() -> Object;
 
+    #[cfg(feature = "mmo")]
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = unlocked)]
     fn unlocked() -> bool;
 
+    #[cfg(feature = "mmo")]
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, getter, js_name = unlockedTime)]
     fn unlocked_time() -> Option<u64>;
 
@@ -38,13 +41,15 @@ extern "C" {
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = halt)]
     fn halt();
 
+    #[cfg(feature = "mmo")]
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = setShardLimits)]
     fn set_shard_limits(limits: &Object) -> i8;
 
+    #[cfg(feature = "mmo")]
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = unlock)]
     fn unlock() -> i8;
 
-    #[cfg(feature = "generate-pixel")]
+    #[cfg(feature = "mmo")]
     #[wasm_bindgen(js_namespace = ["Game"], js_class = "cpu", static_method_of = Cpu, js_name = generatePixel)]
     fn generate_pixel() -> i8;
 }
@@ -71,17 +76,20 @@ pub fn bucket() -> i32 {
 /// Your assigned CPU limits for each shard in an [`Object`], with shard
 /// names in [`JsString`] form as keys and numbers as values. This is the
 /// same format accepted by [`set_shard_limits`].
+#[cfg(feature = "mmo")]
 pub fn shard_limits() -> JsHashMap<JsString, u32> {
     Cpu::shard_limits().into()
 }
 
 /// Whether your account is unlocked to have full CPU.
+#[cfg(feature = "mmo")]
 pub fn unlocked() -> bool {
     Cpu::unlocked()
 }
 
 /// If your account has been unlocked for a limited time, contains the time
 /// it's unlocked until in milliseconds since epoch.
+#[cfg(feature = "mmo")]
 pub fn unlocked_time() -> Option<u64> {
     Cpu::unlocked_time()
 }
@@ -122,6 +130,7 @@ pub fn halt() {
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.setShardLimits)
 ///
 /// [`CPU_SET_SHARD_LIMITS_COOLDOWN`]: crate::constants::CPU_SET_SHARD_LIMITS_COOLDOWN
+#[cfg(feature = "mmo")]
 pub fn set_shard_limits(limits: &Object) -> Result<(), ErrorCode> {
     ErrorCode::result_from_i8(Cpu::set_shard_limits(limits))
 }
@@ -131,6 +140,7 @@ pub fn set_shard_limits(limits: &Object) -> Result<(), ErrorCode> {
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.cpu.unlock)
 ///
 /// [`CpuUnlock`]: crate::constants::IntershardResourceType::CpuUnlock
+#[cfg(feature = "mmo")]
 pub fn unlock() -> Result<(), ErrorCode> {
     ErrorCode::result_from_i8(Cpu::unlock())
 }
@@ -141,7 +151,7 @@ pub fn unlock() -> Result<(), ErrorCode> {
 ///
 /// [`Pixel`]: crate::constants::IntershardResourceType::Pixel
 /// [`PIXEL_CPU_COST`]: crate::constants::PIXEL_CPU_COST
-#[cfg(feature = "generate-pixel")]
+#[cfg(feature = "mmo")]
 pub fn generate_pixel() -> Result<(), ErrorCode> {
     ErrorCode::result_from_i8(Cpu::generate_pixel())
 }

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -1,10 +1,12 @@
 //! Information about, and functions to manage, your code's resource utilization
 //!
 //! [Screeps documentation](http://docs.screeps.com/api/#Game.cpu)
-use js_sys::{JsString, Object};
 use wasm_bindgen::prelude::*;
 
+#[cfg(feature = "mmo")]
 use crate::{constants::ErrorCode, prelude::*};
+#[cfg(feature = "mmo")]
+use js_sys::{JsString, Object};
 
 #[wasm_bindgen]
 extern "C" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,15 +50,11 @@
 //!
 //! # Cargo Features
 //!
-//! ## `generate-pixel`
+//! ## `mmo`
 //!
-//! Enables the function to generate pixels, which is only present on the
-//! Screeps: World official servers.
-//!
-//! ## `inter-shard-memory`
-//!
-//! Enables interacting with `IntershardMemory`, which is not present in most
-//! private server environments.
+//! Enables a number of functions for CPU management and inter-shard
+//! communication present on the Screeps: World official servers but not on
+//! private servers.
 //!
 //! ## `seasonal-season-1`
 //!
@@ -87,11 +83,6 @@
 //! Enables return code conversion from game functions that presumes all return
 //! code values are in the expected ranges skipping checks, and risks undefined
 //! behavior if they are not.
-//!
-//! ## `mmo`
-//!
-//! Enables the `generate-pixel` and `inter-shard-memory` features, which are
-//! present on the Screeps: World official servers but not on private servers.
 #![recursion_limit = "128"]
 // to build locally with doc_cfg enabled, run:
 // `RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features`
@@ -107,7 +98,7 @@ pub mod console;
 pub mod constants;
 pub mod enums;
 pub mod game;
-#[cfg(feature = "inter-shard-memory")]
+#[cfg(feature = "mmo")]
 pub mod inter_shard_memory;
 pub mod js_collections;
 pub mod local;


### PR DESCRIPTION
CPU functions and data related to using CPU unlocks are missing on private servers, and attempting to use the interfaces will cause a panic - they should be behind a feature.

Instead of adding one or two more granular sub-features of `mmo`, it seemed better to just consolidate `generate-pixel` and `inter-shard-memory` down into the `mmo` feature. If a practical case arises where a private server supports some of the mmo-like interfaces but not all of 'em, it might make sense to re-add that level of granularity, but for now it seems like overkill.