### PR TITLE
Fixed the AttackController event not deserializing correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Unreleased
 
 - Implement `JsCollectionFromValue` for `Direction`, `ObjectId<_>`
 - Implement `Debug` for `RouteStep`
+- Made the `AttackController` event deserialize correctly
 
 ### Misc:
 


### PR DESCRIPTION
The AttackController event does not contain a `data` field, however the deserializer was expecting one causing it to incorrectly return a error.
This was causing panics when getting the event log of a room whenever it contained a AttackController event.