### PR TITLE
(Improvement) Add builder function LocalCostMatrix::new_with_value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Unreleased
 - Add function `Direction::iter` which returns an iterator over all the `Direction` enum values
 - Add function `RoomXY::neighbors` which returns an iterator over all the valid neighbors of
   a given `RoomXY` position
+- Add static function `LocalCostMatrix::new_with_value` which returns a `LocalCostMatrix` with
+  every position set to a given `u8` value
 
 0.21.0 (2024-05-14)
 ===================

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -27,10 +27,37 @@ impl Default for LocalCostMatrix {
 }
 
 impl LocalCostMatrix {
+    /// Create a `LocalCostMatrix` with a default value of 0 for all positions.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use screeps::local::{ LocalCostMatrix, RoomXY };
+    ///
+    /// let lcm = LocalCostMatrix::new();
+    /// let pos = unsafe { RoomXY::unchecked_new(10, 10) };
+    /// assert_eq!(lcm.get(pos), 0);
+    /// ```
     #[inline]
     pub const fn new() -> Self {
+        LocalCostMatrix::new_with_value(0)
+    }
+
+    /// Create a `LocalCostMatrix` with a default value for all positions.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use screeps::local::{ LocalCostMatrix, RoomXY };
+    ///
+    /// let lcm = LocalCostMatrix::new_with_value(u8::MAX);
+    /// let pos = unsafe { RoomXY::unchecked_new(10, 10) };
+    /// assert_eq!(lcm.get(pos), u8::MAX);
+    /// ```
+    #[inline]
+    pub const fn new_with_value(value: u8) -> Self {
         LocalCostMatrix {
-            bits: [0; ROOM_AREA],
+            bits: [value; ROOM_AREA],
         }
     }
 

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -32,7 +32,7 @@ impl LocalCostMatrix {
     /// # Example
     ///
     /// ```rust
-    /// use screeps::local::{ LocalCostMatrix, RoomXY };
+    /// use screeps::local::{LocalCostMatrix, RoomXY};
     ///
     /// let lcm = LocalCostMatrix::new();
     /// let pos = unsafe { RoomXY::unchecked_new(10, 10) };
@@ -48,7 +48,7 @@ impl LocalCostMatrix {
     /// # Example
     ///
     /// ```rust
-    /// use screeps::local::{ LocalCostMatrix, RoomXY };
+    /// use screeps::local::{LocalCostMatrix, RoomXY};
     ///
     /// let lcm = LocalCostMatrix::new_with_value(u8::MAX);
     /// let pos = unsafe { RoomXY::unchecked_new(10, 10) };


### PR DESCRIPTION
This update adds a helper function that creates a `LocalCostMatrix` with all positions initialized to a default value.

This also updates the `LocalCostMatrix::new` function to use `LocalCostMatrix::new_with_value`, with a given default value of 0 to mimic existing behavior.