### PR TITLE
Prep 0.21.3 release, downgrading wasm-bindgen to compatible version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 Unreleased
 ==========
 
+### Bugfixes:
+
+- Temporarily pin to wasm-bindgen 0.2.92 due to incompatible generated javascript
+
 0.21.2 (2024-08-14)
 ===================
 
 ### Bugfixes:
 
-- Update for new string enum implementation's implementation in wasm-bindgen 0.2.93
+- Update for new string enum implementation in wasm-bindgen 0.2.93
 
 ### Misc:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screeps-game-api"
-version = "0.21.2"
+version = "0.21.3"
 authors = ["David Ross <daboross@daboross.net>"]
 documentation = "https://docs.rs/screeps-game-api/"
 edition = "2021"
@@ -39,7 +39,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"
 serde-wasm-bindgen = "0.6"
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.92"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/src/constants/types.rs
+++ b/src/constants/types.rs
@@ -834,7 +834,7 @@ mod test {
     #[test]
     fn resources_rust_to_serde_json_from_serde_json_roundtrip() {
         for resource in enum_iterator::all::<ResourceType>() {
-            if resource != ResourceType::__Invalid {
+            if resource != ResourceType::__Nonexhaustive {
                 let serialized = serde_json::to_string(&resource).unwrap();
                 let parsed: ResourceType = serde_json::from_str(&serialized).unwrap();
                 assert_eq!(resource, parsed);
@@ -845,7 +845,7 @@ mod test {
     #[test]
     fn resources_rust_to_display_from_str_roundtrip() {
         for resource in enum_iterator::all::<ResourceType>() {
-            if resource != ResourceType::__Invalid {
+            if resource != ResourceType::__Nonexhaustive {
                 let string = format!("{}", resource);
                 let parsed = ResourceType::from_str(&string).unwrap();
                 assert_eq!(resource, parsed);
@@ -857,7 +857,7 @@ mod test {
     fn resources_rust_vec_to_serde_json_from_serde_json_roundtrip() {
         let mut resources = vec![];
         for resource in enum_iterator::all::<ResourceType>() {
-            if resource != ResourceType::__Invalid {
+            if resource != ResourceType::__Nonexhaustive {
                 resources.push(resource);
             }
         }
@@ -870,7 +870,7 @@ mod test {
     fn resources_rust_vec_to_serde_json_from_serde_json_roundtrip_via_values() {
         let mut resources = vec![];
         for resource in enum_iterator::all::<ResourceType>() {
-            if resource != ResourceType::__Invalid {
+            if resource != ResourceType::__Nonexhaustive {
                 resources.push(resource);
             }
         }
@@ -887,7 +887,7 @@ mod test {
     #[test]
     fn intershard_resources_rust_to_serde_json_from_serde_json_roundtrip() {
         for resource in enum_iterator::all::<IntershardResourceType>() {
-            if resource != IntershardResourceType::__Invalid {
+            if resource != IntershardResourceType::__Nonexhaustive {
                 let serialized = serde_json::to_string(&resource).unwrap();
                 let parsed: IntershardResourceType = serde_json::from_str(&serialized).unwrap();
                 assert_eq!(resource, parsed);
@@ -898,7 +898,7 @@ mod test {
     #[test]
     fn intershard_resources_rust_to_display_from_str_roundtrip() {
         for resource in enum_iterator::all::<IntershardResourceType>() {
-            if resource != IntershardResourceType::__Invalid {
+            if resource != IntershardResourceType::__Nonexhaustive {
                 let string = format!("{}", resource);
                 let parsed = IntershardResourceType::from_str(&string).unwrap();
                 assert_eq!(resource, parsed);
@@ -910,7 +910,7 @@ mod test {
     fn intershard_resources_rust_vec_to_serde_json_from_serde_json_roundtrip() {
         let mut resources = vec![];
         for resource in enum_iterator::all::<IntershardResourceType>() {
-            if resource != IntershardResourceType::__Invalid {
+            if resource != IntershardResourceType::__Nonexhaustive {
                 resources.push(resource);
             }
         }
@@ -924,7 +924,7 @@ mod test {
     fn intershard_resources_rust_vec_to_serde_json_from_serde_json_roundtrip_via_values() {
         let mut resources = vec![];
         for resource in enum_iterator::all::<IntershardResourceType>() {
-            if resource != IntershardResourceType::__Invalid {
+            if resource != IntershardResourceType::__Nonexhaustive {
                 resources.push(resource);
             }
         }
@@ -941,9 +941,11 @@ mod test {
     #[test]
     fn market_resources_rust_to_serde_json_from_serde_json_roundtrip() {
         for resource in enum_iterator::all::<MarketResourceType>() {
-            if resource != MarketResourceType::Resource(ResourceType::__Invalid)
+            if resource != MarketResourceType::Resource(ResourceType::__Nonexhaustive)
                 && resource
-                    != MarketResourceType::IntershardResource(IntershardResourceType::__Invalid)
+                    != MarketResourceType::IntershardResource(
+                        IntershardResourceType::__Nonexhaustive,
+                    )
             {
                 let serialized = serde_json::to_string(&resource).unwrap();
                 let parsed: MarketResourceType = serde_json::from_str(&serialized).unwrap();
@@ -956,9 +958,11 @@ mod test {
     fn market_resources_rust_vec_to_serde_json_from_serde_json_roundtrip() {
         let mut resources = vec![];
         for resource in enum_iterator::all::<MarketResourceType>() {
-            if resource != MarketResourceType::Resource(ResourceType::__Invalid)
+            if resource != MarketResourceType::Resource(ResourceType::__Nonexhaustive)
                 && resource
-                    != MarketResourceType::IntershardResource(IntershardResourceType::__Invalid)
+                    != MarketResourceType::IntershardResource(
+                        IntershardResourceType::__Nonexhaustive,
+                    )
             {
                 resources.push(resource);
             }
@@ -973,9 +977,11 @@ mod test {
     fn market_resources_rust_vec_to_serde_json_from_serde_json_roundtrip_via_values() {
         let mut resources = vec![];
         for resource in enum_iterator::all::<MarketResourceType>() {
-            if resource != MarketResourceType::Resource(ResourceType::__Invalid)
+            if resource != MarketResourceType::Resource(ResourceType::__Nonexhaustive)
                 && resource
-                    != MarketResourceType::IntershardResource(IntershardResourceType::__Invalid)
+                    != MarketResourceType::IntershardResource(
+                        IntershardResourceType::__Nonexhaustive,
+                    )
             {
                 resources.push(resource);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,10 +94,6 @@
 
 // #![warn(clippy::missing_const_for_fn)]
 
-// disable deprecation warnings - TODO need to figure out how to get wasm_bindgen's new thread_local
-// attribute working
-#![allow(deprecated)]
-
 pub mod console;
 pub mod constants;
 pub mod enums;


### PR DESCRIPTION
See #529 - temporarily downgrading to a compatible version of bindgen until we're able to make the needed changes to the toolchain to generate compatible javascript bindings.