### PR TITLE
Revert making the inner u8 of RoomCoordinate pub.

### DIFF
--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -21,7 +21,7 @@ impl Error for OutOfBoundsError {}
     Debug, Hash, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]
 #[serde(try_from = "u8", into = "u8")]
-pub struct RoomCoordinate(pub u8);
+pub struct RoomCoordinate(u8);
 
 impl RoomCoordinate {
     /// Create a `RoomCoordinate` from a `u8`, returning an error if the

--- a/src/local/room_xy.rs
+++ b/src/local/room_xy.rs
@@ -265,7 +265,7 @@ impl fmt::Display for RoomXY {
 
 impl From<RoomXY> for (u8, u8) {
     fn from(xy: RoomXY) -> (u8, u8) {
-        (xy.x.u8(), xy.y.())
+        (xy.x.u8(), xy.y.u8())
     }
 }
 

--- a/src/local/room_xy.rs
+++ b/src/local/room_xy.rs
@@ -265,7 +265,7 @@ impl fmt::Display for RoomXY {
 
 impl From<RoomXY> for (u8, u8) {
     fn from(xy: RoomXY) -> (u8, u8) {
-        (xy.x.0, xy.y.0)
+        (xy.x.u8(), xy.y.())
     }
 }
 

--- a/src/local/room_xy/extra_math.rs
+++ b/src/local/room_xy/extra_math.rs
@@ -162,8 +162,8 @@ impl Sub<RoomXY> for RoomXY {
     /// ```
     #[inline]
     fn sub(self, other: RoomXY) -> (i8, i8) {
-        let dx = self.x.0.wrapping_sub(other.x.0) as i8;
-        let dy = self.y.0.wrapping_sub(other.y.0) as i8;
+        let dx = self.x.u8() as i8 - other.x.u8() as i8;
+        let dy = self.y.u8() as i8 - other.y.u8() as i8;
         (dx, dy)
     }
 }


### PR DESCRIPTION
The point of the type is to be an opaque wrapper that represents an in-bounds coordinate. Crucially, we can't allow public access to that inner coordinate, since then anyone with mutable access (possibly transitive via a class holding RoomCoordinates) can do something like `coord.0 = 100;`.