### PR TITLE
Improved `RoomCoordinate` and `RoomXY`, new `RoomOffset` for optimized arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Unreleased
 
 - Add `s7_score_cycle_at_tick` seasonal constant function to reflect the reversed score cycle in
   season 7
+- Add indexing implementations for `RoomCoordinate` and `RoomXY` as well as `XMajor` / `YMajor`
+  wrapper types to control which indexing approach is used; switch to using these for
+  `LocalCostMatrix` and `LocalRoomTerrain`
+- Add `RoomOffset` type representing a difference between coordinates and associated functions
+  for manipulating `RoomCoordinate` and `RoomXY`
 
 0.22.0 (2024-08-27)
 ===================

--- a/src/constants/extra.rs
+++ b/src/constants/extra.rs
@@ -270,10 +270,15 @@ pub const ROOM_VISUAL_PER_ROOM_SIZE_LIMIT: u32 = 500 * 1024;
 /// [`Room`]: crate::objects::Room
 pub const ROOM_SIZE: u8 = 50;
 
+/// ['ROOM_SIZE'] cast into a `usize`, for indexing convenience.
+///
+/// ['ROOM_SIZE']: self::ROOM_SIZE
+pub const ROOM_USIZE: usize = ROOM_SIZE as usize;
+
 /// The number of total tiles in each [`Room`] in the game
 ///
 /// [`Room`]: crate::objects::Room
-pub const ROOM_AREA: usize = (ROOM_SIZE as usize) * (ROOM_SIZE as usize);
+pub const ROOM_AREA: usize = ROOM_USIZE * ROOM_USIZE;
 
 /// Owner username of hostile non-player structures and creeps which occupy
 /// sector center rooms.

--- a/src/local/cost_matrix.rs
+++ b/src/local/cost_matrix.rs
@@ -8,7 +8,7 @@ use crate::{
     traits::{CostMatrixGet, CostMatrixSet},
 };
 
-use super::{linear_index_to_xy, xy_to_linear_index, Position, RoomXY};
+use super::{linear_index_to_xy, Position, RoomXY, XMajor};
 
 /// A matrix of pathing costs for a room, stored in Rust memory.
 ///
@@ -121,19 +121,29 @@ impl From<&CostMatrix> for LocalCostMatrix {
     }
 }
 
+impl AsRef<XMajor<u8>> for LocalCostMatrix {
+    fn as_ref(&self) -> &XMajor<u8> {
+        XMajor::from_flat_ref(&self.bits)
+    }
+}
+
+impl AsMut<XMajor<u8>> for LocalCostMatrix {
+    fn as_mut(&mut self) -> &mut XMajor<u8> {
+        XMajor::from_flat_mut(&mut self.bits)
+    }
+}
+
 impl Index<RoomXY> for LocalCostMatrix {
     type Output = u8;
 
     fn index(&self, xy: RoomXY) -> &Self::Output {
-        // SAFETY: RoomXY is always a valid coordinate.
-        unsafe { self.bits.get_unchecked(xy_to_linear_index(xy)) }
+        &self.bits[xy.x][xy.y]
     }
 }
 
 impl IndexMut<RoomXY> for LocalCostMatrix {
     fn index_mut(&mut self, xy: RoomXY) -> &mut Self::Output {
-        // SAFETY: RoomXY is always a valid coordinate.
-        unsafe { self.bits.get_unchecked_mut(xy_to_linear_index(xy)) }
+        &mut self.bits[xy.x][xy.y]
     }
 }
 

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -69,7 +69,7 @@ impl Serialize for RawObjectId {
 
 struct RawObjectIdVisitor;
 
-impl<'de> Visitor<'de> for RawObjectIdVisitor {
+impl Visitor<'_> for RawObjectIdVisitor {
     type Value = RawObjectId;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -64,7 +64,7 @@ impl RoomCoordinate {
     /// Provides a hint to the compiler that the contained `u8` is smaller than
     /// `ROOM_SIZE`. Allows for better optimized safe code that uses this
     /// property.
-    pub fn assume_size_constraint(self) {
+    pub fn assume_bounds_constraint(self) {
         debug_assert!(self.0 < ROOM_SIZE);
         // SAFETY: It is only safe to construct `RoomCoordinate` when self.0 <
         // ROOM_SIZE.
@@ -100,7 +100,7 @@ impl RoomCoordinate {
     /// assert_eq!(forty_nine.checked_add(1), None);
     /// ```
     pub fn checked_add(self, rhs: i8) -> Option<RoomCoordinate> {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         // Why this works, assuming ROOM_SIZE < i8::MAX + 1 == 128 and ignoring the
         // test:
         //   - if rhs < 0: the smallest value this can produce is -128, which casted to
@@ -112,7 +112,7 @@ impl RoomCoordinate {
     }
 
     pub fn checked_add_offset(self, rhs: RoomOffset) -> Option<RoomCoordinate> {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         rhs.assume_bounds_constraint();
         RoomCoordinate::new(self.0.wrapping_add_signed(rhs.0)).ok()
     }
@@ -135,7 +135,7 @@ impl RoomCoordinate {
     /// assert_eq!(forty_nine.saturating_add(i8::MIN), zero);
     /// ```
     pub fn saturating_add(self, rhs: i8) -> RoomCoordinate {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         let (res, overflow) = self.0.overflowing_add_signed(rhs);
         if overflow {
             RoomCoordinate::MIN
@@ -146,14 +146,14 @@ impl RoomCoordinate {
     }
 
     pub fn saturating_add_offset(self, rhs: RoomOffset) -> Self {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         rhs.assume_bounds_constraint();
         let result = (self.0 as i8 + rhs.0).clamp(0, ROOM_SIZE_I8 - 1);
         RoomCoordinate::new(result as u8).unwrap_throw()
     }
 
     pub fn overflowing_add(self, rhs: i8) -> (RoomCoordinate, bool) {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         let raw = self.0 as i16 + rhs as i16;
         if raw >= ROOM_SIZE as i16 {
             (
@@ -171,7 +171,7 @@ impl RoomCoordinate {
     }
 
     pub fn overflowing_add_offset(self, rhs: RoomOffset) -> (RoomCoordinate, bool) {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         rhs.assume_bounds_constraint();
         let raw = self.0 as i8 + rhs.0;
         if raw >= ROOM_SIZE_I8 {
@@ -198,12 +198,12 @@ impl RoomCoordinate {
     }
 
     pub unsafe fn unchecked_add(self, rhs: i8) -> Self {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         Self::unchecked_new((self.0 as i8).unchecked_add(rhs) as u8)
     }
 
     pub unsafe fn unchecked_add_offset(self, rhs: RoomOffset) -> Self {
-        self.assume_size_constraint();
+        self.assume_bounds_constraint();
         rhs.assume_bounds_constraint();
         Self::unchecked_new((self.0 as i8).unchecked_add(rhs.0) as u8)
     }
@@ -239,14 +239,14 @@ impl<T> Index<RoomCoordinate> for [T; ROOM_USIZE] {
     type Output = T;
 
     fn index(&self, index: RoomCoordinate) -> &Self::Output {
-        index.assume_size_constraint();
+        index.assume_bounds_constraint();
         &self[index.0 as usize]
     }
 }
 
 impl<T> IndexMut<RoomCoordinate> for [T; ROOM_USIZE] {
     fn index_mut(&mut self, index: RoomCoordinate) -> &mut Self::Output {
-        index.assume_size_constraint();
+        index.assume_bounds_constraint();
         &mut self[index.0 as usize]
     }
 }
@@ -277,8 +277,8 @@ impl Sub for RoomCoordinate {
     type Output = RoomOffset;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        self.assume_size_constraint();
-        rhs.assume_size_constraint();
+        self.assume_bounds_constraint();
+        rhs.assume_bounds_constraint();
         RoomOffset::new(self.0 as i8 - rhs.0 as i8).unwrap_throw()
     }
 }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -6,10 +6,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    constants::{ROOM_SIZE, ROOM_USIZE},
-    ROOM_AREA,
-};
+use crate::constants::{ROOM_AREA, ROOM_SIZE, ROOM_USIZE};
 
 #[derive(Debug, Clone, Copy)]
 pub struct OutOfBoundsError(pub u8);

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -6,7 +6,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::{constants::ROOM_SIZE, ROOM_AREA};
+use crate::{
+    constants::{ROOM_SIZE, ROOM_USIZE},
+    ROOM_AREA,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub struct OutOfBoundsError(pub u8);
@@ -144,46 +147,42 @@ impl TryFrom<u8> for RoomCoordinate {
     }
 }
 
-impl<T> Index<RoomCoordinate> for [T; ROOM_SIZE as usize] {
+impl<T> Index<RoomCoordinate> for [T; ROOM_USIZE] {
     type Output = T;
 
     fn index(&self, index: RoomCoordinate) -> &Self::Output {
-        // SAFETY: index.0 is a u8 < ROOM_SIZE, so it is always in-bounds for [T;
-        // ROOM_SIZE]
+        // SAFETY: index.0 is a u8 < ROOM_USIZE, so it is always in-bounds for [T;
+        // ROOM_USIZE]
         unsafe { self.get_unchecked(index.0 as usize) }
     }
 }
 
-impl<T> IndexMut<RoomCoordinate> for [T; ROOM_SIZE as usize] {
+impl<T> IndexMut<RoomCoordinate> for [T; ROOM_USIZE] {
     fn index_mut(&mut self, index: RoomCoordinate) -> &mut Self::Output {
-        // SAFETY: index.0 is a u8 < ROOM_SIZE, so it is always in-bounds for [T;
-        // ROOM_SIZE]
+        // SAFETY: index.0 is a u8 < ROOM_USIZE, so it is always in-bounds for [T;
+        // ROOM_USIZE]
         unsafe { self.get_unchecked_mut(index.0 as usize) }
     }
 }
 
 impl<T> Index<RoomCoordinate> for [T; ROOM_AREA] {
-    type Output = [T; ROOM_SIZE as usize];
+    type Output = [T; ROOM_USIZE];
 
     fn index(&self, index: RoomCoordinate) -> &Self::Output {
-        // SAFETY: ROOM_SIZE * ROOM_SIZE = ROOM_AREA, so [T; ROOM_AREA] and [[T;
-        // ROOM_SIZE]; ROOM_SIZE] have the same layout.
-        let this = unsafe {
-            &*(self as *const [T; ROOM_AREA]
-                as *const [[T; ROOM_SIZE as usize]; ROOM_SIZE as usize])
-        };
+        // SAFETY: ROOM_USIZE * ROOM_USIZE = ROOM_AREA, so [T; ROOM_AREA] and [[T;
+        // ROOM_USIZE]; ROOM_USIZE] have the same layout.
+        let this =
+            unsafe { &*(self as *const [T; ROOM_AREA] as *const [[T; ROOM_USIZE]; ROOM_USIZE]) };
         &this[index]
     }
 }
 
 impl<T> IndexMut<RoomCoordinate> for [T; ROOM_AREA] {
     fn index_mut(&mut self, index: RoomCoordinate) -> &mut Self::Output {
-        // SAFETY: ROOM_SIZE * ROOM_SIZE = ROOM_AREA, so [T; ROOM_AREA] and [[T;
-        // ROOM_SIZE]; ROOM_SIZE] have the same layout.
-        let this = unsafe {
-            &mut *(self as *mut [T; ROOM_AREA]
-                as *mut [[T; ROOM_SIZE as usize]; ROOM_SIZE as usize])
-        };
+        // SAFETY: ROOM_USIZE * ROOM_USIZE = ROOM_AREA, so [T; ROOM_AREA] and [[T;
+        // ROOM_USIZE]; ROOM_USIZE] have the same layout.
+        let this =
+            unsafe { &mut *(self as *mut [T; ROOM_AREA] as *mut [[T; ROOM_USIZE]; ROOM_USIZE]) };
         &mut this[index]
     }
 }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -463,13 +463,14 @@ impl RoomOffset {
     /// );
     /// ```
     pub fn overflowing_add(self, rhs: Self) -> (Self, bool) {
+        const RANGE_WIDTH: i8 = 2 * ROOM_SIZE_I8 - 1;
         self.assume_bounds_constraint();
         rhs.assume_bounds_constraint();
         let raw = self.0 + rhs.0;
         if raw <= -ROOM_SIZE_I8 {
-            (Self::new(raw + ROOM_SIZE_I8).unwrap_throw(), true)
+            (Self::new(raw + RANGE_WIDTH).unwrap_throw(), true)
         } else if raw >= ROOM_SIZE_I8 {
-            (Self::new(raw - ROOM_SIZE_I8).unwrap_throw(), true)
+            (Self::new(raw - RANGE_WIDTH).unwrap_throw(), true)
         } else {
             (Self::new(raw).unwrap_throw(), false)
         }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -239,8 +239,9 @@ mod test {
             base[coord] += 1;
         }
         base.iter()
+            .copied()
             .zip(1..51)
-            .for_each(|(&actual, expected)| assert_eq!(actual, expected));
+            .for_each(|(actual, expected)| assert_eq!(actual, expected));
     }
 
     #[test]
@@ -254,7 +255,7 @@ mod test {
 
         for i in 0..ROOM_SIZE {
             let coord = RoomCoordinate::new(i).unwrap();
-            assert_eq!(base[coord], [i; 50]);
+            assert!(base[coord].iter().copied().all(|val| val == i));
             base[coord][0] += 1;
         }
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -511,7 +511,7 @@ impl RoomOffset {
     ///
     /// Can be used for distance computations, e.g.
     /// ```
-    /// use screeps::local::{RoomCoordinate, RoomOffset};
+    /// use screeps::local::{RoomXY, RoomOffset};
     ///
     /// fn get_movement_distance(a: RoomXY, b: RoomXY) -> u8 {
     ///     (a.x - b.x).abs().max((a.y - b.y).abs())

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -245,7 +245,7 @@ mod test {
         }
         base.iter()
             .copied()
-            .zip(1..51)
+            .zip(1..(ROOM_SIZE + 1))
             .for_each(|(actual, expected)| assert_eq!(actual, expected));
     }
 
@@ -254,13 +254,13 @@ mod test {
         let mut base: Box<[u16; ROOM_AREA]> = Box::new([0; ROOM_AREA]);
         for i in 0..ROOM_USIZE {
             for j in 0..ROOM_USIZE {
-                base[i * ROOM_USIZE + j] = i as u16 * 50;
+                base[i * ROOM_USIZE + j] = i as u16 * ROOM_SIZE as u16;
             }
         }
 
         for i in 0..ROOM_SIZE {
             let coord = RoomCoordinate::new(i).unwrap();
-            assert!(base[coord].iter().copied().all(|val| val == i as u16 * 50));
+            assert!(base[coord].iter().copied().all(|val| val == i as u16 * ROOM_SIZE as u16));
             for j in 0..ROOM_USIZE {
                 base[coord][j] += j as u16;
             }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -218,9 +218,7 @@ mod test {
             for rhs in i8::MIN..=i8::MAX {
                 assert_eq!(
                     coord.saturating_add(rhs).u8(),
-                    (coord_inner as i16 + rhs as i16)
-                        .max(0)
-                        .min(ROOM_SIZE as i16 - 1) as u8
+                    (coord_inner as i16 + rhs as i16).clamp(0, ROOM_SIZE as i16 - 1) as u8
                 )
             }
         }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -96,19 +96,8 @@ impl RoomCoordinate {
     /// assert_eq!(forty_nine.checked_add(1), None);
     /// ```
     pub fn checked_add(self, rhs: i8) -> Option<RoomCoordinate> {
-        const ROOM_SIZE_I8: i8 = ROOM_SIZE as i8;
         self.assume_size_constraint();
-        match (self.0 as i8).checked_add(rhs) {
-            Some(result) => match result {
-                // less than 0
-                i8::MIN..=-1 => None,
-                // greater than 49
-                ROOM_SIZE_I8..=i8::MAX => None,
-                // SAFETY: we've checked that this coord is in the valid range
-                c => Some(unsafe { RoomCoordinate::unchecked_new(c as u8) }),
-            },
-            None => None,
-        }
+        RoomCoordinate::new(self.0.checked_add_signed(rhs)?).ok()
     }
 
     /// Get the coordinate adjusted by a certain value, saturating at the edges
@@ -129,15 +118,8 @@ impl RoomCoordinate {
     /// assert_eq!(forty_nine.saturating_add(i8::MIN), zero);
     /// ```
     pub fn saturating_add(self, rhs: i8) -> RoomCoordinate {
-        const ROOM_SIZE_I8: i8 = ROOM_SIZE as i8;
         self.assume_size_constraint();
-        let result = match (self.0 as i8).saturating_add(rhs) {
-            // less than 0, saturate to 0
-            i8::MIN..=-1 => 0,
-            // >= ROOM_SIZE, saturate to ROOM_SIZE - 1
-            ROOM_SIZE_I8..=i8::MAX => ROOM_SIZE - 1,
-            c => c as u8,
-        };
+        let result = self.0.saturating_add_signed(rhs).min(ROOM_SIZE - 1);
         // Optimizer will see the return is always Ok
         RoomCoordinate::new(result).unwrap_throw()
     }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -1,8 +1,12 @@
-use std::{error::Error, fmt};
+use std::{
+    error::Error,
+    fmt,
+    ops::{Index, IndexMut},
+};
 
 use serde::{Deserialize, Serialize};
 
-use crate::constants::ROOM_SIZE;
+use crate::{constants::ROOM_SIZE, ROOM_AREA};
 
 #[derive(Debug, Clone, Copy)]
 pub struct OutOfBoundsError(pub u8);
@@ -137,5 +141,49 @@ impl TryFrom<u8> for RoomCoordinate {
 
     fn try_from(coord: u8) -> Result<Self, Self::Error> {
         RoomCoordinate::new(coord)
+    }
+}
+
+impl<T> Index<RoomCoordinate> for [T; ROOM_SIZE as usize] {
+    type Output = T;
+
+    fn index(&self, index: RoomCoordinate) -> &Self::Output {
+        // SAFETY: index.0 is a u8 < ROOM_SIZE, so it is always in-bounds for [T;
+        // ROOM_SIZE]
+        unsafe { self.get_unchecked(index.0 as usize) }
+    }
+}
+
+impl<T> IndexMut<RoomCoordinate> for [T; ROOM_SIZE as usize] {
+    fn index_mut(&mut self, index: RoomCoordinate) -> &mut Self::Output {
+        // SAFETY: index.0 is a u8 < ROOM_SIZE, so it is always in-bounds for [T;
+        // ROOM_SIZE]
+        unsafe { self.get_unchecked_mut(index.0 as usize) }
+    }
+}
+
+impl<T> Index<RoomCoordinate> for [T; ROOM_AREA] {
+    type Output = [T; ROOM_SIZE as usize];
+
+    fn index(&self, index: RoomCoordinate) -> &Self::Output {
+        // SAFETY: ROOM_SIZE * ROOM_SIZE = ROOM_AREA, so [T; ROOM_AREA] and [[T;
+        // ROOM_SIZE]; ROOM_SIZE] have the same layout.
+        let this = unsafe {
+            &*(self as *const [T; ROOM_AREA]
+                as *const [[T; ROOM_SIZE as usize]; ROOM_SIZE as usize])
+        };
+        &this[index]
+    }
+}
+
+impl<T> IndexMut<RoomCoordinate> for [T; ROOM_AREA] {
+    fn index_mut(&mut self, index: RoomCoordinate) -> &mut Self::Output {
+        // SAFETY: ROOM_SIZE * ROOM_SIZE = ROOM_AREA, so [T; ROOM_AREA] and [[T;
+        // ROOM_SIZE]; ROOM_SIZE] have the same layout.
+        let this = unsafe {
+            &mut *(self as *mut [T; ROOM_AREA]
+                as *mut [[T; ROOM_SIZE as usize]; ROOM_SIZE as usize])
+        };
+        &mut this[index]
     }
 }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -263,7 +263,7 @@ mod test {
             assert!(base[coord]
                 .iter()
                 .copied()
-                .all(|val| val == i as u16 * ROOM_SIZE as u16);
+                .all(|val| val == i as u16 * ROOM_SIZE as u16));
             for j in 0..ROOM_USIZE {
                 base[coord][j] += j as u16;
             }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -511,7 +511,7 @@ impl RoomOffset {
     ///
     /// Can be used for distance computations, e.g.
     /// ```
-    /// use screeps::local::{RoomXY, RoomOffset};
+    /// use screeps::local::{RoomOffset, RoomXY};
     ///
     /// fn get_movement_distance(a: RoomXY, b: RoomXY) -> u8 {
     ///     (a.x - b.x).abs().max((a.y - b.y).abs())

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -31,6 +31,9 @@ impl Error for OutOfBoundsError {}
 pub struct RoomCoordinate(u8);
 
 impl RoomCoordinate {
+    pub const MAX: Self = Self(ROOM_SIZE - 1);
+    pub const MIN: Self = Self(0);
+
     /// Create a `RoomCoordinate` from a `u8`, returning an error if the
     /// coordinate is not in the valid room size range
     #[inline]
@@ -126,9 +129,13 @@ impl RoomCoordinate {
     /// ```
     pub fn saturating_add(self, rhs: i8) -> RoomCoordinate {
         self.assume_size_constraint();
-        let result = self.0.saturating_add_signed(rhs).min(ROOM_SIZE - 1);
-        // Optimizer will see the return is always Ok
-        RoomCoordinate::new(result).unwrap_throw()
+        let (res, overflow) = self.0.overflowing_add_signed(rhs);
+        if overflow {
+            RoomCoordinate::MIN
+        } else {
+            // Optimizer will see the return is always Ok
+            RoomCoordinate::new(res.min(ROOM_SIZE - 1)).unwrap_throw()
+        }
     }
 }
 

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -246,21 +246,24 @@ mod test {
 
     #[test]
     fn index_room_area() {
-        let mut base: Box<[u8; ROOM_AREA]> = Box::new([0; ROOM_AREA]);
+        let mut base: Box<[u16; ROOM_AREA]> = Box::new([0; ROOM_AREA]);
         for i in 0..ROOM_USIZE {
             for j in 0..ROOM_USIZE {
-                base[i * ROOM_USIZE + j] = i as u8;
+                base[i * ROOM_USIZE + j] = i as u16 * 50;
             }
         }
 
         for i in 0..ROOM_SIZE {
             let coord = RoomCoordinate::new(i).unwrap();
-            assert!(base[coord].iter().copied().all(|val| val == i));
-            base[coord][0] += 1;
+            assert!(base[coord].iter().copied().all(|val| val == i as u16 * 50));
+            for j in 0..ROOM_USIZE {
+                base[coord][j] += j as u16;
+            }
         }
 
-        for i in 0..ROOM_SIZE {
-            assert_eq!(base[i as usize * 50], i + 1);
-        }
+        assert_eq!(
+            (0..ROOM_AREA as u16).collect::<Vec<u16>>().as_slice(),
+            base.as_slice()
+        );
     }
 }

--- a/src/local/room_coordinate.rs
+++ b/src/local/room_coordinate.rs
@@ -260,7 +260,10 @@ mod test {
 
         for i in 0..ROOM_SIZE {
             let coord = RoomCoordinate::new(i).unwrap();
-            assert!(base[coord].iter().copied().all(|val| val == i as u16 * ROOM_SIZE as u16));
+            assert!(base[coord]
+                .iter()
+                .copied()
+                .all(|val| val == i as u16 * ROOM_SIZE as u16);
             for j in 0..ROOM_USIZE {
                 base[coord][j] += j as u16;
             }

--- a/src/local/room_name.rs
+++ b/src/local/room_name.rs
@@ -548,7 +548,7 @@ mod serde {
 
     struct RoomNameVisitor;
 
-    impl<'de> Visitor<'de> for RoomNameVisitor {
+    impl Visitor<'_> for RoomNameVisitor {
         type Value = RoomName;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/local/room_xy.rs
+++ b/src/local/room_xy.rs
@@ -124,14 +124,8 @@ impl RoomXY {
     /// assert_eq!(forty_nine.checked_add((1, 1)), None);
     /// ```
     pub fn checked_add(self, rhs: (i8, i8)) -> Option<RoomXY> {
-        let x = match self.x.checked_add(rhs.0) {
-            Some(x) => x,
-            None => return None,
-        };
-        let y = match self.y.checked_add(rhs.1) {
-            Some(y) => y,
-            None => return None,
-        };
+        let x = self.x.checked_add(rhs.0)?;
+        let y = self.y.checked_add(rhs.1)?;
         Some(RoomXY { x, y })
     }
 

--- a/src/local/room_xy.rs
+++ b/src/local/room_xy.rs
@@ -1,9 +1,13 @@
-use std::{cmp::Ordering, fmt};
+use std::{
+    cmp::Ordering,
+    fmt,
+    ops::{Index, IndexMut},
+};
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use super::room_coordinate::{OutOfBoundsError, RoomCoordinate};
-use crate::constants::{Direction, ROOM_AREA, ROOM_SIZE};
+use crate::constants::{Direction, ROOM_AREA, ROOM_USIZE};
 
 mod approximate_offsets;
 mod extra_math;
@@ -16,7 +20,7 @@ mod game_math;
 /// [`LocalCostMatrix`]: crate::local::LocalCostMatrix
 #[inline]
 pub const fn xy_to_linear_index(xy: RoomXY) -> usize {
-    xy.x.u8() as usize * ROOM_SIZE as usize + xy.y.u8() as usize
+    xy.x.u8() as usize * ROOM_USIZE + xy.y.u8() as usize
 }
 
 /// Converts a linear index from the internal representation of a [`CostMatrix`]
@@ -30,8 +34,8 @@ pub fn linear_index_to_xy(idx: usize) -> RoomXY {
     assert!(idx < ROOM_AREA, "Out of bounds index: {idx}");
     // SAFETY: bounds checking above ensures both are within range.
     RoomXY {
-        x: unsafe { RoomCoordinate::unchecked_new((idx / (ROOM_SIZE as usize)) as u8) },
-        y: unsafe { RoomCoordinate::unchecked_new((idx % (ROOM_SIZE as usize)) as u8) },
+        x: unsafe { RoomCoordinate::unchecked_new((idx / (ROOM_USIZE)) as u8) },
+        y: unsafe { RoomCoordinate::unchecked_new((idx % (ROOM_USIZE)) as u8) },
     }
 }
 
@@ -42,7 +46,7 @@ pub fn linear_index_to_xy(idx: usize) -> RoomXY {
 /// [`LocalRoomTerrain`]: crate::local::LocalRoomTerrain
 #[inline]
 pub const fn xy_to_terrain_index(xy: RoomXY) -> usize {
-    xy.y.u8() as usize * ROOM_SIZE as usize + xy.x.u8() as usize
+    xy.y.u8() as usize * ROOM_USIZE + xy.x.u8() as usize
 }
 
 /// Converts a terrain index from the internal representation of a
@@ -56,8 +60,8 @@ pub fn terrain_index_to_xy(idx: usize) -> RoomXY {
     assert!(idx < ROOM_AREA, "Out of bounds index: {idx}");
     // SAFETY: bounds checking above ensures both are within range.
     RoomXY {
-        x: unsafe { RoomCoordinate::unchecked_new((idx % (ROOM_SIZE as usize)) as u8) },
-        y: unsafe { RoomCoordinate::unchecked_new((idx / (ROOM_SIZE as usize)) as u8) },
+        x: unsafe { RoomCoordinate::unchecked_new((idx % (ROOM_USIZE)) as u8) },
+        y: unsafe { RoomCoordinate::unchecked_new((idx / (ROOM_USIZE)) as u8) },
     }
 }
 
@@ -86,8 +90,8 @@ impl RoomXY {
     /// the range of valid values.
     ///
     /// # Safety
-    /// Calling this method with `x >= ROOM_SIZE` or `y >= ROOM_SIZE` can result
-    /// in undefined behaviour when the resulting `RoomXY` is used.
+    /// Calling this method with `x >= ROOM_SIZE` or `y >= ROOM_SIZE` can
+    /// result in undefined behaviour when the resulting `RoomXY` is used.
     #[inline]
     pub unsafe fn unchecked_new(x: u8, y: u8) -> Self {
         RoomXY {
@@ -338,9 +342,127 @@ impl<'de> Deserialize<'de> for RoomXY {
             RoomXY::try_from(xy).map_err(|err: OutOfBoundsError| {
                 de::Error::invalid_value(
                     de::Unexpected::Unsigned(err.0 as u64),
-                    &format!("a non-negative integer less-than {ROOM_SIZE}").as_str(),
+                    &format!("a non-negative integer less-than {ROOM_USIZE}").as_str(),
                 )
             })
         }
+    }
+}
+
+/// A wrapper struct indicating that the inner array should be indexed X major,
+/// i.e. ```
+/// use screeps::{
+///     constants::ROOM_USIZE,
+///     local::{XMajor, XY},
+/// };
+///
+/// let mut x_major = XMajor([[0_u8; ROOM_USIZE]; ROOM_USIZE]);
+/// x_major.0[10][0] = 1;
+/// let xy = RoomXY::checked_new(10, 0).unwrap();
+/// assert_eq!(x_major[xy], 1);
+/// ```
+#[repr(transparent)]
+pub struct XMajor<T>(pub [[T; ROOM_USIZE]; ROOM_USIZE]);
+
+impl<T> XMajor<T> {
+    pub fn from_ref(arr: &[[T; ROOM_USIZE]; ROOM_USIZE]) -> &Self {
+        // SAFETY: XMajor is a repr(transparent) wrapper around [[T; ROOM_USIZE];
+        // ROOM_USIZE], so casting references of one to the other is safe.
+        unsafe { &*(arr as *const [[T; ROOM_USIZE]; ROOM_USIZE] as *const Self) }
+    }
+
+    pub fn from_flat_ref(arr: &[T; ROOM_AREA]) -> &Self {
+        // SAFETY: ROOM_AREA = ROOM_USIZE * ROOM_USIZE, so [T; ROOM_AREA] is identical
+        // in data layout to [[T; ROOM_USIZE]; ROOM_USIZE].
+        Self::from_ref(unsafe {
+            &*(arr as *const [T; ROOM_AREA] as *const [[T; ROOM_USIZE]; ROOM_USIZE])
+        })
+    }
+
+    pub fn from_mut(arr: &mut [[T; ROOM_USIZE]; ROOM_USIZE]) -> &mut Self {
+        // SAFETY: XMajor is a repr(transparent) wrapper around [[T; ROOM_USIZE];
+        // ROOM_USIZE], so casting references of one to the other is safe.
+        unsafe { &mut *(arr as *mut [[T; ROOM_USIZE]; ROOM_USIZE] as *mut Self) }
+    }
+
+    pub fn from_flat_mut(arr: &mut [T; ROOM_AREA]) -> &mut Self {
+        // SAFETY: ROOM_AREA = ROOM_USIZE * ROOM_USIZE, so [T; ROOM_AREA] is identical
+        // in data layout to [[T; ROOM_USIZE]; ROOM_USIZE].
+        Self::from_mut(unsafe {
+            &mut *(arr as *mut [T; ROOM_AREA] as *mut [[T; ROOM_USIZE]; ROOM_USIZE])
+        })
+    }
+}
+
+impl<T> Index<RoomXY> for XMajor<T> {
+    type Output = T;
+
+    fn index(&self, index: RoomXY) -> &Self::Output {
+        &self.0[index.x][index.y]
+    }
+}
+
+impl<T> IndexMut<RoomXY> for XMajor<T> {
+    fn index_mut(&mut self, index: RoomXY) -> &mut Self::Output {
+        &mut self.0[index.x][index.y]
+    }
+}
+
+/// A wrapper struct indicating that the inner array should be indexed Y major,
+/// i.e. ```
+/// use screeps::{
+///     constants::ROOM_USIZE,
+///     local::{YMajor, XY},
+/// };
+///
+/// let mut y_major = YMajor([[0_u8; ROOM_USIZE]; ROOM_USIZE]);
+/// y_major.0[0][10] = 1;
+/// let xy = RoomXY::checked_new(10, 0).unwrap();
+/// assert_eq!(y_major[xy], 1);
+/// ```
+#[repr(transparent)]
+pub struct YMajor<T>(pub [[T; ROOM_USIZE]; ROOM_USIZE]);
+
+impl<T> YMajor<T> {
+    pub fn from_ref(arr: &[[T; ROOM_USIZE]; ROOM_USIZE]) -> &Self {
+        // SAFETY: XMajor is a repr(transparent) wrapper around [[T; ROOM_USIZE];
+        // ROOM_USIZE], so casting references of one to the other is safe.
+        unsafe { &*(arr as *const [[T; ROOM_USIZE]; ROOM_USIZE] as *const Self) }
+    }
+
+    pub fn from_flat_ref(arr: &[T; ROOM_AREA]) -> &Self {
+        // SAFETY: ROOM_AREA = ROOM_USIZE * ROOM_USIZE, so [T; ROOM_AREA] is identical
+        // in data layout to [[T; ROOM_USIZE]; ROOM_USIZE].
+        Self::from_ref(unsafe {
+            &*(arr as *const [T; ROOM_AREA] as *const [[T; ROOM_USIZE]; ROOM_USIZE])
+        })
+    }
+
+    pub fn from_mut(arr: &mut [[T; ROOM_USIZE]; ROOM_USIZE]) -> &mut Self {
+        // SAFETY: XMajor is a repr(transparent) wrapper around [[T; ROOM_USIZE];
+        // ROOM_USIZE], so casting references of one to the other is safe.
+        unsafe { &mut *(arr as *mut [[T; ROOM_USIZE]; ROOM_USIZE] as *mut Self) }
+    }
+
+    pub fn from_flat_mut(arr: &mut [T; ROOM_AREA]) -> &mut Self {
+        // SAFETY: ROOM_AREA = ROOM_USIZE * ROOM_USIZE, so [T; ROOM_AREA] is identical
+        // in data layout to [[T; ROOM_USIZE]; ROOM_USIZE].
+        Self::from_mut(unsafe {
+            &mut *(arr as *mut [T; ROOM_AREA] as *mut [[T; ROOM_USIZE]; ROOM_USIZE])
+        })
+    }
+}
+
+impl<T> Index<RoomXY> for YMajor<T> {
+    type Output = T;
+
+    fn index(&self, index: RoomXY) -> &Self::Output {
+        &self.0[index.y][index.x]
+    }
+}
+
+impl<T> IndexMut<RoomXY> for YMajor<T> {
+    fn index_mut(&mut self, index: RoomXY) -> &mut Self::Output {
+        &mut self.0[index.y][index.x]
     }
 }

--- a/src/local/terrain.rs
+++ b/src/local/terrain.rs
@@ -7,7 +7,7 @@ use crate::{
     objects::RoomTerrain,
 };
 
-use super::{xy_to_terrain_index, RoomXY};
+use super::RoomXY;
 
 #[derive(Debug, Clone)]
 pub struct LocalRoomTerrain {
@@ -20,8 +20,7 @@ pub struct LocalRoomTerrain {
 impl LocalRoomTerrain {
     /// Gets the terrain at the specified position in this room.
     pub fn get_xy(&self, xy: RoomXY) -> Terrain {
-        // SAFETY: RoomXY is always a valid coordinate.
-        let byte = unsafe { self.bits.get_unchecked(xy_to_terrain_index(xy)) };
+        let byte = self.bits[xy.y][xy.x];
         // not using Terrain::from_u8() because `0b11` value, wall+swamp, happens
         // in commonly used server environments (notably the private server default
         // map), and is special-cased in the engine code; we special-case it here


### PR DESCRIPTION
Adds indexing impls for `RoomCoordinate` and a wrapper type that allows indexing nested arrays by `RoomXY`. Re-writes `LocalCostMatrix` and `LocalRoomTerrain` indexing in terms of the `RoomCoordinate` indexing impls.

Also adds a new `RoomOffset` type which can be used for better-optimized arithmetic, as well as being the output of coordinate-coordinate subtraction.