### PR TITLE
(feature) Dedicated action return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Unreleased
 
 ### Breaking:
 
+- Replace all `ErrorCode` returns with new error code enums that include only the possible return
+  values for a given called function, allowing for exhaustive matching when handling errors
 - Change return type of `Structure::destroy` from `i8` to `Result<(), ErrorCode>`
 - Change inner u8 of `RoomCoordinate` to private
 - Use `f64` instead of `u64` to work around bindgen expecting `BigInt` return values

--- a/src/constants/seasonal.rs
+++ b/src/constants/seasonal.rs
@@ -108,7 +108,6 @@ pub mod season_1 {
 
     /// Calculates the state of the score cycle for season 1
     pub const fn score_cycle_at_tick(tick: u32) -> ScoreCycleState {
-        #[allow(clippy::match_overlapping_arm)]
         match tick % SCORE_CYCLE_DURATION {
             // the bonus/crisis periods are exclusive of their boundaries
             // https://github.com/screeps/mod-season1/blob/7ca3c7ddb47bf9dfbdfb4e72b666a3159fde8780/src/scoreContainer.roomObject.js#L77-L81
@@ -125,7 +124,6 @@ pub mod season_1 {
     /// Calculates the state of the score cycle for season 7, which reverses the
     /// crisis/bonus order
     pub const fn s7_score_cycle_at_tick(tick: u32) -> ScoreCycleState {
-        #[allow(clippy::match_overlapping_arm)]
         match tick % SCORE_CYCLE_DURATION {
             // the bonus/crisis periods are exclusive of their boundaries
             // https://github.com/screeps/mod-season1/blob/7ca3c7ddb47bf9dfbdfb4e72b666a3159fde8780/src/scoreContainer.roomObject.js#L77-L81

--- a/src/constants/seasonal.rs
+++ b/src/constants/seasonal.rs
@@ -108,6 +108,7 @@ pub mod season_1 {
 
     /// Calculates the state of the score cycle for season 1
     pub const fn score_cycle_at_tick(tick: u32) -> ScoreCycleState {
+        #[allow(clippy::match_overlapping_arm)]
         match tick % SCORE_CYCLE_DURATION {
             // the bonus/crisis periods are exclusive of their boundaries
             // https://github.com/screeps/mod-season1/blob/7ca3c7ddb47bf9dfbdfb4e72b666a3159fde8780/src/scoreContainer.roomObject.js#L77-L81
@@ -124,6 +125,7 @@ pub mod season_1 {
     /// Calculates the state of the score cycle for season 7, which reverses the
     /// crisis/bonus order
     pub const fn s7_score_cycle_at_tick(tick: u32) -> ScoreCycleState {
+        #[allow(clippy::match_overlapping_arm)]
         match tick % SCORE_CYCLE_DURATION {
             // the bonus/crisis periods are exclusive of their boundaries
             // https://github.com/screeps/mod-season1/blob/7ca3c7ddb47bf9dfbdfb4e72b666a3159fde8780/src/scoreContainer.roomObject.js#L77-L81

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -2,6 +2,8 @@
 //! shared traits.
 //!
 //! [`enum_dispatch`]: enum_dispatch::enum_dispatch
+pub mod action_error_codes;
+
 use enum_dispatch::enum_dispatch;
 use wasm_bindgen::{JsCast, JsValue};
 

--- a/src/enums/action_error_codes/constructionsite_error_codes.rs
+++ b/src/enums/action_error_codes/constructionsite_error_codes.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [ConstructionSite::remove](crate::ConstructionSite::remove).
+///
+/// Screeps API Docs: [ConstructionSite.remove](https://docs.screeps.com/api/#ConstructionSite.remove).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/construction-sites.js#L50)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ConstructionSiteRemoveErrorCode {
+    NotOwner = -1,
+}
+
+impl FromReturnCode for ConstructionSiteRemoveErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ConstructionSiteRemoveErrorCode::NotOwner)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ConstructionSiteRemoveErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ConstructionSiteRemoveErrorCode::NotOwner => "you are not the owner of this construction site, and it's not in your room",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ConstructionSiteRemoveErrorCode {}

--- a/src/enums/action_error_codes/constructionsite_error_codes.rs
+++ b/src/enums/action_error_codes/constructionsite_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/constructionsite_error_codes.rs
+++ b/src/enums/action_error_codes/constructionsite_error_codes.rs
@@ -63,8 +63,6 @@ impl From<ConstructionSiteRemoveErrorCode> for ErrorCode {
         // Safety: ConstructionSiteRemoveErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/constructionsite_error_codes.rs
+++ b/src/enums/action_error_codes/constructionsite_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [ConstructionSite::remove](crate::ConstructionSite::remove).
 ///
-/// Screeps API Docs: [ConstructionSite.remove](https://docs.screeps.com/api/#ConstructionSite.remove).
+/// [Screeps API Docs](https://docs.screeps.com/api/#ConstructionSite.remove).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/construction-sites.js#L50)
 #[derive(
@@ -54,3 +54,17 @@ impl fmt::Display for ConstructionSiteRemoveErrorCode {
 }
 
 impl Error for ConstructionSiteRemoveErrorCode {}
+
+impl From<ConstructionSiteRemoveErrorCode> for ErrorCode {
+    fn from(value: ConstructionSiteRemoveErrorCode) -> Self {
+        // Safety: ConstructionSiteRemoveErrorCode is repr(i8), so we can cast it to get
+        // the discriminant value, which will match the raw return code value that
+        // ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ConstructionSiteRemoveErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/constructionsite_error_codes.rs
+++ b/src/enums/action_error_codes/constructionsite_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [ConstructionSite::remove](crate::ConstructionSite::remove).
+/// Error codes used by
+/// [ConstructionSite::remove](crate::ConstructionSite::remove).
 ///
 /// Screeps API Docs: [ConstructionSite.remove](https://docs.screeps.com/api/#ConstructionSite.remove).
 ///
@@ -25,11 +25,11 @@ impl FromReturnCode for ConstructionSiteRemoveErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -45,7 +45,9 @@ impl FromReturnCode for ConstructionSiteRemoveErrorCode {
 impl fmt::Display for ConstructionSiteRemoveErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            ConstructionSiteRemoveErrorCode::NotOwner => "you are not the owner of this construction site, and it's not in your room",
+            ConstructionSiteRemoveErrorCode::NotOwner => {
+                "you are not the owner of this construction site, and it's not in your room"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/creep_error_codes.rs
+++ b/src/enums/action_error_codes/creep_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/creep_error_codes.rs
+++ b/src/enums/action_error_codes/creep_error_codes.rs
@@ -919,7 +919,7 @@ impl From<CreepMoveByPathErrorCode> for ErrorCode {
     }
 }
 
-/// Error codes used by [Creep::move_to](crate::Creep::move_to).
+/// Error codes used by [Creep::move_to<T>](crate::Creep::move_to<T>).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.moveTo).
 ///

--- a/src/enums/action_error_codes/creep_error_codes.rs
+++ b/src/enums/action_error_codes/creep_error_codes.rs
@@ -3,11 +3,11 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by [Creep::attack](crate::Creep::attack).
 ///
-/// Screeps API Docs: [Creep.attack](https://docs.screeps.com/api/#Creep.attack).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.attack).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L593)
 #[derive(
@@ -66,10 +66,24 @@ impl fmt::Display for CreepAttackErrorCode {
 
 impl Error for CreepAttackErrorCode {}
 
+impl From<CreepAttackErrorCode> for ErrorCode {
+    fn from(value: CreepAttackErrorCode) -> Self {
+        // Safety: CreepAttackErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepAttackErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [Creep::attack_controller](crate::Creep::attack_controller).
 ///
-/// Screeps API Docs: [Creep.attackController](https://docs.screeps.com/api/#Creep.attackController).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.attackController).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L885)
 #[derive(
@@ -135,9 +149,23 @@ impl fmt::Display for AttackControllerErrorCode {
 
 impl Error for AttackControllerErrorCode {}
 
+impl From<AttackControllerErrorCode> for ErrorCode {
+    fn from(value: AttackControllerErrorCode) -> Self {
+        // Safety: AttackControllerErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: AttackControllerErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::build](crate::Creep::build).
 ///
-/// Screeps API Docs: [Creep.build](https://docs.screeps.com/api/#Creep.build).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.build).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L762)
 #[derive(
@@ -197,9 +225,22 @@ impl fmt::Display for BuildErrorCode {
 
 impl Error for BuildErrorCode {}
 
+impl From<BuildErrorCode> for ErrorCode {
+    fn from(value: BuildErrorCode) -> Self {
+        // Safety: BuildErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: BuildErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::cancel_order](crate::Creep::cancel_order).
 ///
-/// Screeps API Docs: [Creep.cancelOrder](https://docs.screeps.com/api/#Creep.cancelOrder).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.cancelOrder).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1008)
 #[derive(
@@ -244,10 +285,24 @@ impl fmt::Display for CreepCancelOrderErrorCode {
 
 impl Error for CreepCancelOrderErrorCode {}
 
+impl From<CreepCancelOrderErrorCode> for ErrorCode {
+    fn from(value: CreepCancelOrderErrorCode) -> Self {
+        // Safety: CreepCancelOrderErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepCancelOrderErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [Creep::claim_controller](crate::Creep::claim_controller).
 ///
-/// Screeps API Docs: [Creep.claimController](https://docs.screeps.com/api/#Creep.claimController).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.claimController).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L839)
 #[derive(
@@ -316,9 +371,23 @@ impl fmt::Display for ClaimControllerErrorCode {
 
 impl Error for ClaimControllerErrorCode {}
 
+impl From<ClaimControllerErrorCode> for ErrorCode {
+    fn from(value: ClaimControllerErrorCode) -> Self {
+        // Safety: ClaimControllerErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ClaimControllerErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::dismantle](crate::Creep::dismantle).
 ///
-/// Screeps API Docs: [Creep.dismantle](https://docs.screeps.com/api/#Creep.dismantle).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.dismantle).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1016)
 #[derive(
@@ -375,70 +444,24 @@ impl fmt::Display for DismantleErrorCode {
 
 impl Error for DismantleErrorCode {}
 
-/// Error codes used by [Creep::drop](crate::Creep::drop).
-///
-/// Screeps API Docs: [Creep.drop](https://docs.screeps.com/api/#Creep.drop).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L404)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum CreepDropErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    NotEnoughResources = -6,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for CreepDropErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(CreepDropErrorCode::NotOwner)),
-            -4 => Some(Err(CreepDropErrorCode::Busy)),
-            -6 => Some(Err(CreepDropErrorCode::NotEnoughResources)),
-            -10 => Some(Err(CreepDropErrorCode::InvalidArgs)),
-            _ => None,
-        }
+impl From<DismantleErrorCode> for ErrorCode {
+    fn from(value: DismantleErrorCode) -> Self {
+        // Safety: DismantleErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: DismantleErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for CreepDropErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            CreepDropErrorCode::NotOwner => "you are not the owner of this creep",
-            CreepDropErrorCode::Busy => "the creep is still being spawned",
-            CreepDropErrorCode::NotEnoughResources => {
-                "the creep does not have the given amount of resources"
-            }
-            CreepDropErrorCode::InvalidArgs => {
-                "the resourcetype is not a valid resource_* constants"
-            }
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for CreepDropErrorCode {}
 
 /// Error codes used by
 /// [Creep::generate_safe_mode](crate::Creep::generate_safe_mode).
 ///
-/// Screeps API Docs: [Creep.generateSafeMode](https://docs.screeps.com/api/#Creep.generateSafeMode).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.generateSafeMode).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1049)
 #[derive(
@@ -499,9 +522,23 @@ impl fmt::Display for GenerateSafeModeErrorCode {
 
 impl Error for GenerateSafeModeErrorCode {}
 
+impl From<GenerateSafeModeErrorCode> for ErrorCode {
+    fn from(value: GenerateSafeModeErrorCode) -> Self {
+        // Safety: GenerateSafeModeErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: GenerateSafeModeErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::harvest](crate::Creep::harvest).
 ///
-/// Screeps API Docs: [Creep.harvest](https://docs.screeps.com/api/#Creep.harvest).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.harvest).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L335)
 #[derive(
@@ -570,9 +607,23 @@ impl fmt::Display for HarvestErrorCode {
 
 impl Error for HarvestErrorCode {}
 
+impl From<HarvestErrorCode> for ErrorCode {
+    fn from(value: HarvestErrorCode) -> Self {
+        // Safety: HarvestErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: HarvestErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::heal](crate::Creep::heal).
 ///
-/// Screeps API Docs: [Creep.heal](https://docs.screeps.com/api/#Creep.heal).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.heal).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L678)
 #[derive(
@@ -629,25 +680,38 @@ impl fmt::Display for CreepHealErrorCode {
 
 impl Error for CreepHealErrorCode {}
 
-/// Error codes used by [Creep::move](crate::Creep::move).
+impl From<CreepHealErrorCode> for ErrorCode {
+    fn from(value: CreepHealErrorCode) -> Self {
+        // Safety: CreepHealErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepHealErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [Creep::move_direction](crate::Creep::move_direction).
 ///
-/// Screeps API Docs: [Creep.move](https://docs.screeps.com/api/#Creep.move).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.move).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L126)
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
 )]
 #[repr(i8)]
-pub enum CreepMoveErrorCode {
+pub enum CreepMoveDirectionErrorCode {
     NotOwner = -1,
     Busy = -4,
-    NotInRange = -9,
     InvalidArgs = -10,
     Tired = -11,
     NoBodypart = -12,
 }
 
-impl FromReturnCode for CreepMoveErrorCode {
+impl FromReturnCode for CreepMoveDirectionErrorCode {
     type Error = Self;
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
@@ -663,37 +727,121 @@ impl FromReturnCode for CreepMoveErrorCode {
     fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
         match val {
             0 => Some(Ok(())),
-            -1 => Some(Err(CreepMoveErrorCode::NotOwner)),
-            -4 => Some(Err(CreepMoveErrorCode::Busy)),
-            -9 => Some(Err(CreepMoveErrorCode::NotInRange)),
-            -10 => Some(Err(CreepMoveErrorCode::InvalidArgs)),
-            -11 => Some(Err(CreepMoveErrorCode::Tired)),
-            -12 => Some(Err(CreepMoveErrorCode::NoBodypart)),
+            -1 => Some(Err(CreepMoveDirectionErrorCode::NotOwner)),
+            -4 => Some(Err(CreepMoveDirectionErrorCode::Busy)),
+            -10 => Some(Err(CreepMoveDirectionErrorCode::InvalidArgs)),
+            -11 => Some(Err(CreepMoveDirectionErrorCode::Tired)),
+            -12 => Some(Err(CreepMoveDirectionErrorCode::NoBodypart)),
             _ => None,
         }
     }
 }
 
-impl fmt::Display for CreepMoveErrorCode {
+impl fmt::Display for CreepMoveDirectionErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            CreepMoveErrorCode::NotOwner => "you are not the owner of this creep",
-            CreepMoveErrorCode::Busy => "the creep is still being spawned",
-            CreepMoveErrorCode::NotInRange => "the target creep is too far away",
-            CreepMoveErrorCode::InvalidArgs => "the provided direction is incorrect",
-            CreepMoveErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
-            CreepMoveErrorCode::NoBodypart => "there are no move body parts in this creep’s body",
+            CreepMoveDirectionErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepMoveDirectionErrorCode::Busy => "the creep is still being spawned",
+            CreepMoveDirectionErrorCode::InvalidArgs => "the provided direction is incorrect",
+            CreepMoveDirectionErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+            CreepMoveDirectionErrorCode::NoBodypart => {
+                "there are no move body parts in this creep’s body"
+            }
         };
 
         write!(f, "{}", msg)
     }
 }
 
-impl Error for CreepMoveErrorCode {}
+impl Error for CreepMoveDirectionErrorCode {}
+
+impl From<CreepMoveDirectionErrorCode> for ErrorCode {
+    fn from(value: CreepMoveDirectionErrorCode) -> Self {
+        // Safety: CreepMoveDirectionErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepMoveDirectionErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [Creep::move_pulled_by](crate::Creep::move_pulled_by).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.move).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L126)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepMovePulledByErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotInRange = -9,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for CreepMovePulledByErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepMovePulledByErrorCode::NotOwner)),
+            -4 => Some(Err(CreepMovePulledByErrorCode::Busy)),
+            -9 => Some(Err(CreepMovePulledByErrorCode::NotInRange)),
+            -10 => Some(Err(CreepMovePulledByErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepMovePulledByErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepMovePulledByErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepMovePulledByErrorCode::Busy => "the creep is still being spawned",
+            CreepMovePulledByErrorCode::NotInRange => "the target creep is too far away",
+            CreepMovePulledByErrorCode::InvalidArgs => "the provided direction is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepMovePulledByErrorCode {}
+
+impl From<CreepMovePulledByErrorCode> for ErrorCode {
+    fn from(value: CreepMovePulledByErrorCode) -> Self {
+        // Safety: CreepMovePulledByErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepMovePulledByErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
 
 /// Error codes used by [Creep::move_by_path](crate::Creep::move_by_path).
 ///
-/// Screeps API Docs: [Creep.moveByPath](https://docs.screeps.com/api/#Creep.moveByPath).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.moveByPath).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L305)
 #[derive(
@@ -757,9 +905,23 @@ impl fmt::Display for CreepMoveByPathErrorCode {
 
 impl Error for CreepMoveByPathErrorCode {}
 
+impl From<CreepMoveByPathErrorCode> for ErrorCode {
+    fn from(value: CreepMoveByPathErrorCode) -> Self {
+        // Safety: CreepMoveByPathErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepMoveByPathErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::move_to](crate::Creep::move_to).
 ///
-/// Screeps API Docs: [Creep.moveTo](https://docs.screeps.com/api/#Creep.moveTo).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.moveTo).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L158)
 #[derive(
@@ -822,124 +984,23 @@ impl fmt::Display for CreepMoveToErrorCode {
 
 impl Error for CreepMoveToErrorCode {}
 
-/// Error codes used by
-/// [Creep::notify_when_attacked](crate::Creep::notify_when_attacked).
-///
-/// Screeps API Docs: [Creep.notifyWhenAttacked](https://docs.screeps.com/api/#Creep.notifyWhenAttacked).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L988)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum CreepNotifyWhenAttackedErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for CreepNotifyWhenAttackedErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(CreepNotifyWhenAttackedErrorCode::NotOwner)),
-            -4 => Some(Err(CreepNotifyWhenAttackedErrorCode::Busy)),
-            -10 => Some(Err(CreepNotifyWhenAttackedErrorCode::InvalidArgs)),
-            _ => None,
-        }
+impl From<CreepMoveToErrorCode> for ErrorCode {
+    fn from(value: CreepMoveToErrorCode) -> Self {
+        // Safety: CreepMoveToErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepMoveToErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for CreepNotifyWhenAttackedErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            CreepNotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this creep",
-            CreepNotifyWhenAttackedErrorCode::Busy => "the creep is still being spawned",
-            CreepNotifyWhenAttackedErrorCode::InvalidArgs => {
-                "enable argument is not a boolean value"
-            }
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for CreepNotifyWhenAttackedErrorCode {}
-
-/// Error codes used by [Creep::pickup](crate::Creep::pickup).
-///
-/// Screeps API Docs: [Creep.pickup](https://docs.screeps.com/api/#Creep.pickup).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L566)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum CreepPickupErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    InvalidTarget = -7,
-    Full = -8,
-    NotInRange = -9,
-}
-
-impl FromReturnCode for CreepPickupErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(CreepPickupErrorCode::NotOwner)),
-            -4 => Some(Err(CreepPickupErrorCode::Busy)),
-            -7 => Some(Err(CreepPickupErrorCode::InvalidTarget)),
-            -8 => Some(Err(CreepPickupErrorCode::Full)),
-            -9 => Some(Err(CreepPickupErrorCode::NotInRange)),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for CreepPickupErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            CreepPickupErrorCode::NotOwner => "you are not the owner of this creep",
-            CreepPickupErrorCode::Busy => "the creep is still being spawned",
-            CreepPickupErrorCode::InvalidTarget => "the target is not a valid object to pick up",
-            CreepPickupErrorCode::Full => "the creep cannot receive any more resource",
-            CreepPickupErrorCode::NotInRange => "the target is too far away",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for CreepPickupErrorCode {}
 
 /// Error codes used by [Creep::pull](crate::Creep::pull).
 ///
-/// Screeps API Docs: [Creep.pull](https://docs.screeps.com/api/#Creep.pull).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.pull).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1093)
 #[derive(
@@ -993,9 +1054,22 @@ impl fmt::Display for PullErrorCode {
 
 impl Error for PullErrorCode {}
 
+impl From<PullErrorCode> for ErrorCode {
+    fn from(value: PullErrorCode) -> Self {
+        // Safety: PullErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PullErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::ranged_attack](crate::Creep::ranged_attack).
 ///
-/// Screeps API Docs: [Creep.rangedAttack](https://docs.screeps.com/api/#Creep.rangedAttack).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.rangedAttack).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L626)
 #[derive(
@@ -1054,9 +1128,23 @@ impl fmt::Display for RangedAttackErrorCode {
 
 impl Error for RangedAttackErrorCode {}
 
+impl From<RangedAttackErrorCode> for ErrorCode {
+    fn from(value: RangedAttackErrorCode) -> Self {
+        // Safety: RangedAttackErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RangedAttackErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::ranged_heal](crate::Creep::ranged_heal).
 ///
-/// Screeps API Docs: [Creep.rangedHeal](https://docs.screeps.com/api/#Creep.rangedHeal).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.rangedHeal).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L706)
 #[derive(
@@ -1113,10 +1201,24 @@ impl fmt::Display for RangedHealErrorCode {
 
 impl Error for RangedHealErrorCode {}
 
+impl From<RangedHealErrorCode> for ErrorCode {
+    fn from(value: RangedHealErrorCode) -> Self {
+        // Safety: RangedHealErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RangedHealErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [Creep::ranged_mass_attack](crate::Creep::ranged_mass_attack).
 ///
-/// Screeps API Docs: [Creep.rangedMassAttack](https://docs.screeps.com/api/#Creep.rangedMassAttack).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.rangedMassAttack).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L658)
 #[derive(
@@ -1169,9 +1271,23 @@ impl fmt::Display for RangedMassAttackErrorCode {
 
 impl Error for RangedMassAttackErrorCode {}
 
+impl From<RangedMassAttackErrorCode> for ErrorCode {
+    fn from(value: RangedMassAttackErrorCode) -> Self {
+        // Safety: RangedMassAttackErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RangedMassAttackErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Creep::repair](crate::Creep::repair).
 ///
-/// Screeps API Docs: [Creep.repair](https://docs.screeps.com/api/#Creep.repair).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.repair).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L734)
 #[derive(
@@ -1231,10 +1347,24 @@ impl fmt::Display for CreepRepairErrorCode {
 
 impl Error for CreepRepairErrorCode {}
 
+impl From<CreepRepairErrorCode> for ErrorCode {
+    fn from(value: CreepRepairErrorCode) -> Self {
+        // Safety: CreepRepairErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreepRepairErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [Creep::reserve_controller](crate::Creep::reserve_controller).
 ///
-/// Screeps API Docs: [Creep.reserveController](https://docs.screeps.com/api/#Creep.reserveController).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.reserveController).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L955)
 #[derive(
@@ -1295,59 +1425,23 @@ impl fmt::Display for ReserveControllerErrorCode {
 
 impl Error for ReserveControllerErrorCode {}
 
-/// Error codes used by [Creep::say](crate::Creep::say).
-///
-/// Screeps API Docs: [Creep.say](https://docs.screeps.com/api/#Creep.say).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L826)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum CreepSayErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-}
-
-impl FromReturnCode for CreepSayErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(CreepSayErrorCode::NotOwner)),
-            -4 => Some(Err(CreepSayErrorCode::Busy)),
-            _ => None,
-        }
+impl From<ReserveControllerErrorCode> for ErrorCode {
+    fn from(value: ReserveControllerErrorCode) -> Self {
+        // Safety: ReserveControllerErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ReserveControllerErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for CreepSayErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            CreepSayErrorCode::NotOwner => "you are not the owner of this creep",
-            CreepSayErrorCode::Busy => "the creep is still being spawned",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for CreepSayErrorCode {}
 
 /// Error codes used by [Creep::sign_controller](crate::Creep::sign_controller).
 ///
-/// Screeps API Docs: [Creep.signController](https://docs.screeps.com/api/#Creep.signController).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.signController).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1072)
 #[derive(
@@ -1398,125 +1492,24 @@ impl fmt::Display for SignControllerErrorCode {
 
 impl Error for SignControllerErrorCode {}
 
-/// Error codes used by [Creep::suicide](crate::Creep::suicide).
-///
-/// Screeps API Docs: [Creep.suicide](https://docs.screeps.com/api/#Creep.suicide).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L813)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum CreepSuicideErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-}
-
-impl FromReturnCode for CreepSuicideErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(CreepSuicideErrorCode::NotOwner)),
-            -4 => Some(Err(CreepSuicideErrorCode::Busy)),
-            _ => None,
-        }
+impl From<SignControllerErrorCode> for ErrorCode {
+    fn from(value: SignControllerErrorCode) -> Self {
+        // Safety: SignControllerErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SignControllerErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for CreepSuicideErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            CreepSuicideErrorCode::NotOwner => "you are not the owner of this creep",
-            CreepSuicideErrorCode::Busy => "the creep is still being spawned",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for CreepSuicideErrorCode {}
-
-/// Error codes used by [Creep::transfer](crate::Creep::transfer).
-///
-/// Screeps API Docs: [Creep.transfer](https://docs.screeps.com/api/#Creep.transfer).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L428)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum CreepTransferErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    NotEnoughResources = -6,
-    InvalidTarget = -7,
-    Full = -8,
-    NotInRange = -9,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for CreepTransferErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(CreepTransferErrorCode::NotOwner)),
-            -4 => Some(Err(CreepTransferErrorCode::Busy)),
-            -6 => Some(Err(CreepTransferErrorCode::NotEnoughResources)),
-            -7 => Some(Err(CreepTransferErrorCode::InvalidTarget)),
-            -8 => Some(Err(CreepTransferErrorCode::Full)),
-            -9 => Some(Err(CreepTransferErrorCode::NotInRange)),
-            -10 => Some(Err(CreepTransferErrorCode::InvalidArgs)),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for CreepTransferErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            CreepTransferErrorCode::NotOwner => "you are not the owner of this creep",
-            CreepTransferErrorCode::Busy => "the creep is still being spawned",
-            CreepTransferErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
-            CreepTransferErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
-            CreepTransferErrorCode::Full => "the target cannot receive any more resources",
-            CreepTransferErrorCode::NotInRange => "the target is too far away",
-            CreepTransferErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for CreepTransferErrorCode {}
 
 /// Error codes used by
 /// [Creep::upgrade_controller](crate::Creep::upgrade_controller).
 ///
-/// Screeps API Docs: [Creep.upgradeController](https://docs.screeps.com/api/#Creep.upgradeController).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.upgradeController).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L919)
 #[derive(
@@ -1576,67 +1569,16 @@ impl fmt::Display for UpgradeControllerErrorCode {
 
 impl Error for UpgradeControllerErrorCode {}
 
-/// Error codes used by [Creep::withdraw](crate::Creep::withdraw).
-///
-/// Screeps API Docs: [Creep.withdraw](https://docs.screeps.com/api/#Creep.withdraw).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L493)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum CreepWithdrawErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    NotEnoughResources = -6,
-    InvalidTarget = -7,
-    Full = -8,
-    NotInRange = -9,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for CreepWithdrawErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(CreepWithdrawErrorCode::NotOwner)),
-            -4 => Some(Err(CreepWithdrawErrorCode::Busy)),
-            -6 => Some(Err(CreepWithdrawErrorCode::NotEnoughResources)),
-            -7 => Some(Err(CreepWithdrawErrorCode::InvalidTarget)),
-            -8 => Some(Err(CreepWithdrawErrorCode::Full)),
-            -9 => Some(Err(CreepWithdrawErrorCode::NotInRange)),
-            -10 => Some(Err(CreepWithdrawErrorCode::InvalidArgs)),
-            _ => None,
-        }
+impl From<UpgradeControllerErrorCode> for ErrorCode {
+    fn from(value: UpgradeControllerErrorCode) -> Self {
+        // Safety: UpgradeControllerErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: UpgradeControllerErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for CreepWithdrawErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            CreepWithdrawErrorCode::NotOwner => "you are not the owner of this creep, or there is a hostile rampart on top of the target",
-            CreepWithdrawErrorCode::Busy => "the creep is still being spawned",
-            CreepWithdrawErrorCode::NotEnoughResources => "the target does not have the given amount of resources",
-            CreepWithdrawErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
-            CreepWithdrawErrorCode::Full => "the creep's carry is full",
-            CreepWithdrawErrorCode::NotInRange => "the target is too far away",
-            CreepWithdrawErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for CreepWithdrawErrorCode {}

--- a/src/enums/action_error_codes/creep_error_codes.rs
+++ b/src/enums/action_error_codes/creep_error_codes.rs
@@ -1,0 +1,1601 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [Creep::attack](crate::Creep::attack).
+///
+/// Screeps API Docs: [Creep.attack](https://docs.screeps.com/api/#Creep.attack).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L593)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepAttackErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for CreepAttackErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepAttackErrorCode::NotOwner)),
+            -4 => Some(Err(CreepAttackErrorCode::Busy)),
+            -7 => Some(Err(CreepAttackErrorCode::InvalidTarget)),
+            -9 => Some(Err(CreepAttackErrorCode::NotInRange)),
+            -12 => Some(Err(CreepAttackErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepAttackErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepAttackErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepAttackErrorCode::Busy => "the creep is still being spawned",
+            CreepAttackErrorCode::InvalidTarget => "the target is not a valid attackable object",
+            CreepAttackErrorCode::NotInRange => "the target is too far away",
+            CreepAttackErrorCode::NoBodypart => "there are no attack body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepAttackErrorCode {}
+
+/// Error codes used by [Creep::attack_controller](crate::Creep::attack_controller).
+///
+/// Screeps API Docs: [Creep.attackController](https://docs.screeps.com/api/#Creep.attackController).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L885)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum AttackControllerErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    Tired = -11,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for AttackControllerErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(AttackControllerErrorCode::NotOwner)),
+            -4 => Some(Err(AttackControllerErrorCode::Busy)),
+            -7 => Some(Err(AttackControllerErrorCode::InvalidTarget)),
+            -9 => Some(Err(AttackControllerErrorCode::NotInRange)),
+            -11 => Some(Err(AttackControllerErrorCode::Tired)),
+            -12 => Some(Err(AttackControllerErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for AttackControllerErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            AttackControllerErrorCode::NotOwner => "you are not the owner of this creep",
+            AttackControllerErrorCode::Busy => "the creep is still being spawned",
+            AttackControllerErrorCode::InvalidTarget => "the target is not a valid owned or reserved controller object",
+            AttackControllerErrorCode::NotInRange => "the target is too far away",
+            AttackControllerErrorCode::Tired => "you have to wait until the next attack is possible",
+            AttackControllerErrorCode::NoBodypart => "there are not enough claim body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for AttackControllerErrorCode {}
+
+/// Error codes used by [Creep::build](crate::Creep::build).
+///
+/// Screeps API Docs: [Creep.build](https://docs.screeps.com/api/#Creep.build).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L762)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum BuildErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for BuildErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(BuildErrorCode::NotOwner)),
+            -4 => Some(Err(BuildErrorCode::Busy)),
+            -6 => Some(Err(BuildErrorCode::NotEnoughResources)),
+            -7 => Some(Err(BuildErrorCode::InvalidTarget)),
+            -9 => Some(Err(BuildErrorCode::NotInRange)),
+            -12 => Some(Err(BuildErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for BuildErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            BuildErrorCode::NotOwner => "you are not the owner of this creep",
+            BuildErrorCode::Busy => "the creep is still being spawned",
+            BuildErrorCode::NotEnoughResources => "the creep does not have any carried energy",
+            BuildErrorCode::InvalidTarget => "the target is not a valid construction site object or the structure cannot be built here (probably because of a creep at the same square)",
+            BuildErrorCode::NotInRange => "the target is too far away",
+            BuildErrorCode::NoBodypart => "there are no work body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for BuildErrorCode {}
+
+/// Error codes used by [Creep::cancel_order](crate::Creep::cancel_order).
+///
+/// Screeps API Docs: [Creep.cancelOrder](https://docs.screeps.com/api/#Creep.cancelOrder).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1008)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepCancelOrderErrorCode {
+    NotFound = -5,
+}
+
+impl FromReturnCode for CreepCancelOrderErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -5 => Some(Err(CreepCancelOrderErrorCode::NotFound)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepCancelOrderErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepCancelOrderErrorCode::NotFound => "the order with the specified name is not found",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepCancelOrderErrorCode {}
+
+/// Error codes used by [Creep::claim_controller](crate::Creep::claim_controller).
+///
+/// Screeps API Docs: [Creep.claimController](https://docs.screeps.com/api/#Creep.claimController).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L839)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ClaimControllerErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    NoBodypart = -12,
+    GclNotEnough = -15,
+}
+
+impl FromReturnCode for ClaimControllerErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ClaimControllerErrorCode::NotOwner)),
+            -4 => Some(Err(ClaimControllerErrorCode::Busy)),
+            -7 => Some(Err(ClaimControllerErrorCode::InvalidTarget)),
+            -8 => Some(Err(ClaimControllerErrorCode::Full)),
+            -9 => Some(Err(ClaimControllerErrorCode::NotInRange)),
+            -12 => Some(Err(ClaimControllerErrorCode::NoBodypart)),
+            -15 => Some(Err(ClaimControllerErrorCode::GclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ClaimControllerErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ClaimControllerErrorCode::NotOwner => "you are not the owner of this creep",
+            ClaimControllerErrorCode::Busy => "the creep is still being spawned",
+            ClaimControllerErrorCode::InvalidTarget => "the target is not a valid neutral controller object",
+            ClaimControllerErrorCode::Full => "you cannot claim more than 3 rooms in the novice area",
+            ClaimControllerErrorCode::NotInRange => "the target is too far away",
+            ClaimControllerErrorCode::NoBodypart => "there are no claim body parts in this creep’s body",
+            ClaimControllerErrorCode::GclNotEnough => "your global control level is not enough",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ClaimControllerErrorCode {}
+
+/// Error codes used by [Creep::dismantle](crate::Creep::dismantle).
+///
+/// Screeps API Docs: [Creep.dismantle](https://docs.screeps.com/api/#Creep.dismantle).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1016)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum DismantleErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for DismantleErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(DismantleErrorCode::NotOwner)),
+            -4 => Some(Err(DismantleErrorCode::Busy)),
+            -7 => Some(Err(DismantleErrorCode::InvalidTarget)),
+            -9 => Some(Err(DismantleErrorCode::NotInRange)),
+            -12 => Some(Err(DismantleErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DismantleErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            DismantleErrorCode::NotOwner => "you are not the owner of this creep",
+            DismantleErrorCode::Busy => "the creep is still being spawned",
+            DismantleErrorCode::InvalidTarget => "the target is not a valid structure object",
+            DismantleErrorCode::NotInRange => "the target is too far away",
+            DismantleErrorCode::NoBodypart => "there are no work body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for DismantleErrorCode {}
+
+/// Error codes used by [Creep::drop](crate::Creep::drop).
+///
+/// Screeps API Docs: [Creep.drop](https://docs.screeps.com/api/#Creep.drop).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L404)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepDropErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for CreepDropErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepDropErrorCode::NotOwner)),
+            -4 => Some(Err(CreepDropErrorCode::Busy)),
+            -6 => Some(Err(CreepDropErrorCode::NotEnoughResources)),
+            -10 => Some(Err(CreepDropErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepDropErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepDropErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepDropErrorCode::Busy => "the creep is still being spawned",
+            CreepDropErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
+            CreepDropErrorCode::InvalidArgs => "the resourcetype is not a valid resource_* constants",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepDropErrorCode {}
+
+/// Error codes used by [Creep::generate_safe_mode](crate::Creep::generate_safe_mode).
+///
+/// Screeps API Docs: [Creep.generateSafeMode](https://docs.screeps.com/api/#Creep.generateSafeMode).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1049)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum GenerateSafeModeErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for GenerateSafeModeErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(GenerateSafeModeErrorCode::NotOwner)),
+            -4 => Some(Err(GenerateSafeModeErrorCode::Busy)),
+            -6 => Some(Err(GenerateSafeModeErrorCode::NotEnoughResources)),
+            -7 => Some(Err(GenerateSafeModeErrorCode::InvalidTarget)),
+            -9 => Some(Err(GenerateSafeModeErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for GenerateSafeModeErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            GenerateSafeModeErrorCode::NotOwner => "you are not the owner of this creep",
+            GenerateSafeModeErrorCode::Busy => "the creep is still being spawned",
+            GenerateSafeModeErrorCode::NotEnoughResources => "the creep does not have enough ghodium",
+            GenerateSafeModeErrorCode::InvalidTarget => "the target is not a valid controller object",
+            GenerateSafeModeErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for GenerateSafeModeErrorCode {}
+
+/// Error codes used by [Creep::harvest](crate::Creep::harvest).
+///
+/// Screeps API Docs: [Creep.harvest](https://docs.screeps.com/api/#Creep.harvest).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L335)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum HarvestErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotFound = -5,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    Tired = -11,
+    NoBodypart = -12,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for HarvestErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(HarvestErrorCode::NotOwner)),
+            -4 => Some(Err(HarvestErrorCode::Busy)),
+            -5 => Some(Err(HarvestErrorCode::NotFound)),
+            -6 => Some(Err(HarvestErrorCode::NotEnoughResources)),
+            -7 => Some(Err(HarvestErrorCode::InvalidTarget)),
+            -9 => Some(Err(HarvestErrorCode::NotInRange)),
+            -11 => Some(Err(HarvestErrorCode::Tired)),
+            -12 => Some(Err(HarvestErrorCode::NoBodypart)),
+            -14 => Some(Err(HarvestErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for HarvestErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            HarvestErrorCode::NotOwner => "you are not the owner of this creep, or the room controller is owned or reserved by another player",
+            HarvestErrorCode::Busy => "the creep is still being spawned",
+            HarvestErrorCode::NotFound => "extractor not found. you must build an extractor structure to harvest minerals. learn more",
+            HarvestErrorCode::NotEnoughResources => "the target does not contain any harvestable energy or mineral",
+            HarvestErrorCode::InvalidTarget => "the target is not a valid source or mineral object",
+            HarvestErrorCode::NotInRange => "the target is too far away",
+            HarvestErrorCode::Tired => "the extractor or the deposit is still cooling down",
+            HarvestErrorCode::NoBodypart => "there are no work body parts in this creep’s body",
+            HarvestErrorCode::RclNotEnough => "room controller level insufficient to use the extractor",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for HarvestErrorCode {}
+
+/// Error codes used by [Creep::heal](crate::Creep::heal).
+///
+/// Screeps API Docs: [Creep.heal](https://docs.screeps.com/api/#Creep.heal).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L678)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepHealErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for CreepHealErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepHealErrorCode::NotOwner)),
+            -4 => Some(Err(CreepHealErrorCode::Busy)),
+            -7 => Some(Err(CreepHealErrorCode::InvalidTarget)),
+            -9 => Some(Err(CreepHealErrorCode::NotInRange)),
+            -12 => Some(Err(CreepHealErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepHealErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepHealErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepHealErrorCode::Busy => "the creep is still being spawned",
+            CreepHealErrorCode::InvalidTarget => "the target is not a valid creep object",
+            CreepHealErrorCode::NotInRange => "the target is too far away",
+            CreepHealErrorCode::NoBodypart => "there are no heal body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepHealErrorCode {}
+
+/// Error codes used by [Creep::move](crate::Creep::move).
+///
+/// Screeps API Docs: [Creep.move](https://docs.screeps.com/api/#Creep.move).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L126)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepMoveErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    Tired = -11,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for CreepMoveErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepMoveErrorCode::NotOwner)),
+            -4 => Some(Err(CreepMoveErrorCode::Busy)),
+            -9 => Some(Err(CreepMoveErrorCode::NotInRange)),
+            -10 => Some(Err(CreepMoveErrorCode::InvalidArgs)),
+            -11 => Some(Err(CreepMoveErrorCode::Tired)),
+            -12 => Some(Err(CreepMoveErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepMoveErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepMoveErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepMoveErrorCode::Busy => "the creep is still being spawned",
+            CreepMoveErrorCode::NotInRange => "the target creep is too far away",
+            CreepMoveErrorCode::InvalidArgs => "the provided direction is incorrect",
+            CreepMoveErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+            CreepMoveErrorCode::NoBodypart => "there are no move body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepMoveErrorCode {}
+
+/// Error codes used by [Creep::move_by_path](crate::Creep::move_by_path).
+///
+/// Screeps API Docs: [Creep.moveByPath](https://docs.screeps.com/api/#Creep.moveByPath).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L305)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepMoveByPathErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotFound = -5,
+    InvalidArgs = -10,
+    Tired = -11,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for CreepMoveByPathErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepMoveByPathErrorCode::NotOwner)),
+            -4 => Some(Err(CreepMoveByPathErrorCode::Busy)),
+            -5 => Some(Err(CreepMoveByPathErrorCode::NotFound)),
+            -10 => Some(Err(CreepMoveByPathErrorCode::InvalidArgs)),
+            -11 => Some(Err(CreepMoveByPathErrorCode::Tired)),
+            -12 => Some(Err(CreepMoveByPathErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepMoveByPathErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepMoveByPathErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepMoveByPathErrorCode::Busy => "the creep is still being spawned",
+            CreepMoveByPathErrorCode::NotFound => "the specified path doesn't match the creep's location",
+            CreepMoveByPathErrorCode::InvalidArgs => "path is not a valid path array",
+            CreepMoveByPathErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+            CreepMoveByPathErrorCode::NoBodypart => "there are no move body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepMoveByPathErrorCode {}
+
+/// Error codes used by [Creep::move_to](crate::Creep::move_to).
+///
+/// Screeps API Docs: [Creep.moveTo](https://docs.screeps.com/api/#Creep.moveTo).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L158)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepMoveToErrorCode {
+    NotOwner = -1,
+    NoPath = -2,
+    Busy = -4,
+    NotFound = -5,
+    InvalidTarget = -7,
+    Tired = -11,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for CreepMoveToErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepMoveToErrorCode::NotOwner)),
+            -2 => Some(Err(CreepMoveToErrorCode::NoPath)),
+            -4 => Some(Err(CreepMoveToErrorCode::Busy)),
+            -5 => Some(Err(CreepMoveToErrorCode::NotFound)),
+            -7 => Some(Err(CreepMoveToErrorCode::InvalidTarget)),
+            -11 => Some(Err(CreepMoveToErrorCode::Tired)),
+            -12 => Some(Err(CreepMoveToErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepMoveToErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepMoveToErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepMoveToErrorCode::NoPath => "no path to the target could be found",
+            CreepMoveToErrorCode::Busy => "the creep is still being spawned",
+            CreepMoveToErrorCode::NotFound => "the creep has no memorized path to reuse",
+            CreepMoveToErrorCode::InvalidTarget => "the target provided is invalid",
+            CreepMoveToErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+            CreepMoveToErrorCode::NoBodypart => "there are no move body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepMoveToErrorCode {}
+
+/// Error codes used by [Creep::notify_when_attacked](crate::Creep::notify_when_attacked).
+///
+/// Screeps API Docs: [Creep.notifyWhenAttacked](https://docs.screeps.com/api/#Creep.notifyWhenAttacked).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L988)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepNotifyWhenAttackedErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for CreepNotifyWhenAttackedErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepNotifyWhenAttackedErrorCode::NotOwner)),
+            -4 => Some(Err(CreepNotifyWhenAttackedErrorCode::Busy)),
+            -10 => Some(Err(CreepNotifyWhenAttackedErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepNotifyWhenAttackedErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepNotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepNotifyWhenAttackedErrorCode::Busy => "the creep is still being spawned",
+            CreepNotifyWhenAttackedErrorCode::InvalidArgs => "enable argument is not a boolean value",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepNotifyWhenAttackedErrorCode {}
+
+/// Error codes used by [Creep::pickup](crate::Creep::pickup).
+///
+/// Screeps API Docs: [Creep.pickup](https://docs.screeps.com/api/#Creep.pickup).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L566)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepPickupErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for CreepPickupErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepPickupErrorCode::NotOwner)),
+            -4 => Some(Err(CreepPickupErrorCode::Busy)),
+            -7 => Some(Err(CreepPickupErrorCode::InvalidTarget)),
+            -8 => Some(Err(CreepPickupErrorCode::Full)),
+            -9 => Some(Err(CreepPickupErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepPickupErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepPickupErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepPickupErrorCode::Busy => "the creep is still being spawned",
+            CreepPickupErrorCode::InvalidTarget => "the target is not a valid object to pick up",
+            CreepPickupErrorCode::Full => "the creep cannot receive any more resource",
+            CreepPickupErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepPickupErrorCode {}
+
+/// Error codes used by [Creep::pull](crate::Creep::pull).
+///
+/// Screeps API Docs: [Creep.pull](https://docs.screeps.com/api/#Creep.pull).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1093)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PullErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for PullErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PullErrorCode::NotOwner)),
+            -4 => Some(Err(PullErrorCode::Busy)),
+            -7 => Some(Err(PullErrorCode::InvalidTarget)),
+            -9 => Some(Err(PullErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PullErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PullErrorCode::NotOwner => "you are not the owner of this creep",
+            PullErrorCode::Busy => "the creep is still being spawned",
+            PullErrorCode::InvalidTarget => "the target provided is invalid",
+            PullErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PullErrorCode {}
+
+/// Error codes used by [Creep::ranged_attack](crate::Creep::ranged_attack).
+///
+/// Screeps API Docs: [Creep.rangedAttack](https://docs.screeps.com/api/#Creep.rangedAttack).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L626)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RangedAttackErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for RangedAttackErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RangedAttackErrorCode::NotOwner)),
+            -4 => Some(Err(RangedAttackErrorCode::Busy)),
+            -7 => Some(Err(RangedAttackErrorCode::InvalidTarget)),
+            -9 => Some(Err(RangedAttackErrorCode::NotInRange)),
+            -12 => Some(Err(RangedAttackErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RangedAttackErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RangedAttackErrorCode::NotOwner => "you are not the owner of this creep",
+            RangedAttackErrorCode::Busy => "the creep is still being spawned",
+            RangedAttackErrorCode::InvalidTarget => "the target is not a valid attackable object",
+            RangedAttackErrorCode::NotInRange => "the target is too far away",
+            RangedAttackErrorCode::NoBodypart => "there are no ranged_attack body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RangedAttackErrorCode {}
+
+/// Error codes used by [Creep::ranged_heal](crate::Creep::ranged_heal).
+///
+/// Screeps API Docs: [Creep.rangedHeal](https://docs.screeps.com/api/#Creep.rangedHeal).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L706)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RangedHealErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for RangedHealErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RangedHealErrorCode::NotOwner)),
+            -4 => Some(Err(RangedHealErrorCode::Busy)),
+            -7 => Some(Err(RangedHealErrorCode::InvalidTarget)),
+            -9 => Some(Err(RangedHealErrorCode::NotInRange)),
+            -12 => Some(Err(RangedHealErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RangedHealErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RangedHealErrorCode::NotOwner => "you are not the owner of this creep",
+            RangedHealErrorCode::Busy => "the creep is still being spawned",
+            RangedHealErrorCode::InvalidTarget => "the target is not a valid creep object",
+            RangedHealErrorCode::NotInRange => "the target is too far away",
+            RangedHealErrorCode::NoBodypart => "there are no heal body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RangedHealErrorCode {}
+
+/// Error codes used by [Creep::ranged_mass_attack](crate::Creep::ranged_mass_attack).
+///
+/// Screeps API Docs: [Creep.rangedMassAttack](https://docs.screeps.com/api/#Creep.rangedMassAttack).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L658)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RangedMassAttackErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for RangedMassAttackErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RangedMassAttackErrorCode::NotOwner)),
+            -4 => Some(Err(RangedMassAttackErrorCode::Busy)),
+            -12 => Some(Err(RangedMassAttackErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RangedMassAttackErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RangedMassAttackErrorCode::NotOwner => "you are not the owner of this creep",
+            RangedMassAttackErrorCode::Busy => "the creep is still being spawned",
+            RangedMassAttackErrorCode::NoBodypart => "there are no ranged_attack body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RangedMassAttackErrorCode {}
+
+/// Error codes used by [Creep::repair](crate::Creep::repair).
+///
+/// Screeps API Docs: [Creep.repair](https://docs.screeps.com/api/#Creep.repair).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L734)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepRepairErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for CreepRepairErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepRepairErrorCode::NotOwner)),
+            -4 => Some(Err(CreepRepairErrorCode::Busy)),
+            -6 => Some(Err(CreepRepairErrorCode::NotEnoughResources)),
+            -7 => Some(Err(CreepRepairErrorCode::InvalidTarget)),
+            -9 => Some(Err(CreepRepairErrorCode::NotInRange)),
+            -12 => Some(Err(CreepRepairErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepRepairErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepRepairErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepRepairErrorCode::Busy => "the creep is still being spawned",
+            CreepRepairErrorCode::NotEnoughResources => "the creep does not carry any energy",
+            CreepRepairErrorCode::InvalidTarget => "the target is not a valid structure object",
+            CreepRepairErrorCode::NotInRange => "the target is too far away",
+            CreepRepairErrorCode::NoBodypart => "there are no work body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepRepairErrorCode {}
+
+/// Error codes used by [Creep::reserve_controller](crate::Creep::reserve_controller).
+///
+/// Screeps API Docs: [Creep.reserveController](https://docs.screeps.com/api/#Creep.reserveController).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L955)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ReserveControllerErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for ReserveControllerErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ReserveControllerErrorCode::NotOwner)),
+            -4 => Some(Err(ReserveControllerErrorCode::Busy)),
+            -7 => Some(Err(ReserveControllerErrorCode::InvalidTarget)),
+            -9 => Some(Err(ReserveControllerErrorCode::NotInRange)),
+            -12 => Some(Err(ReserveControllerErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ReserveControllerErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ReserveControllerErrorCode::NotOwner => "you are not the owner of this creep",
+            ReserveControllerErrorCode::Busy => "the creep is still being spawned",
+            ReserveControllerErrorCode::InvalidTarget => "the target is not a valid neutral controller object",
+            ReserveControllerErrorCode::NotInRange => "the target is too far away",
+            ReserveControllerErrorCode::NoBodypart => "there are no claim body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ReserveControllerErrorCode {}
+
+/// Error codes used by [Creep::say](crate::Creep::say).
+///
+/// Screeps API Docs: [Creep.say](https://docs.screeps.com/api/#Creep.say).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L826)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepSayErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+}
+
+impl FromReturnCode for CreepSayErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepSayErrorCode::NotOwner)),
+            -4 => Some(Err(CreepSayErrorCode::Busy)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepSayErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepSayErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepSayErrorCode::Busy => "the creep is still being spawned",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepSayErrorCode {}
+
+/// Error codes used by [Creep::sign_controller](crate::Creep::sign_controller).
+///
+/// Screeps API Docs: [Creep.signController](https://docs.screeps.com/api/#Creep.signController).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L1072)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SignControllerErrorCode {
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for SignControllerErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -4 => Some(Err(SignControllerErrorCode::Busy)),
+            -7 => Some(Err(SignControllerErrorCode::InvalidTarget)),
+            -9 => Some(Err(SignControllerErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SignControllerErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SignControllerErrorCode::Busy => "the creep is still being spawned",
+            SignControllerErrorCode::InvalidTarget => "the target is not a valid controller object",
+            SignControllerErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SignControllerErrorCode {}
+
+/// Error codes used by [Creep::suicide](crate::Creep::suicide).
+///
+/// Screeps API Docs: [Creep.suicide](https://docs.screeps.com/api/#Creep.suicide).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L813)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepSuicideErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+}
+
+impl FromReturnCode for CreepSuicideErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepSuicideErrorCode::NotOwner)),
+            -4 => Some(Err(CreepSuicideErrorCode::Busy)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepSuicideErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepSuicideErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepSuicideErrorCode::Busy => "the creep is still being spawned",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepSuicideErrorCode {}
+
+/// Error codes used by [Creep::transfer](crate::Creep::transfer).
+///
+/// Screeps API Docs: [Creep.transfer](https://docs.screeps.com/api/#Creep.transfer).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L428)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepTransferErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for CreepTransferErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepTransferErrorCode::NotOwner)),
+            -4 => Some(Err(CreepTransferErrorCode::Busy)),
+            -6 => Some(Err(CreepTransferErrorCode::NotEnoughResources)),
+            -7 => Some(Err(CreepTransferErrorCode::InvalidTarget)),
+            -8 => Some(Err(CreepTransferErrorCode::Full)),
+            -9 => Some(Err(CreepTransferErrorCode::NotInRange)),
+            -10 => Some(Err(CreepTransferErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepTransferErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepTransferErrorCode::NotOwner => "you are not the owner of this creep",
+            CreepTransferErrorCode::Busy => "the creep is still being spawned",
+            CreepTransferErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
+            CreepTransferErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
+            CreepTransferErrorCode::Full => "the target cannot receive any more resources",
+            CreepTransferErrorCode::NotInRange => "the target is too far away",
+            CreepTransferErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepTransferErrorCode {}
+
+/// Error codes used by [Creep::upgrade_controller](crate::Creep::upgrade_controller).
+///
+/// Screeps API Docs: [Creep.upgradeController](https://docs.screeps.com/api/#Creep.upgradeController).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L919)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum UpgradeControllerErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for UpgradeControllerErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(UpgradeControllerErrorCode::NotOwner)),
+            -4 => Some(Err(UpgradeControllerErrorCode::Busy)),
+            -6 => Some(Err(UpgradeControllerErrorCode::NotEnoughResources)),
+            -7 => Some(Err(UpgradeControllerErrorCode::InvalidTarget)),
+            -9 => Some(Err(UpgradeControllerErrorCode::NotInRange)),
+            -12 => Some(Err(UpgradeControllerErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UpgradeControllerErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            UpgradeControllerErrorCode::NotOwner => "you are not the owner of this creep or the target controller",
+            UpgradeControllerErrorCode::Busy => "the creep is still being spawned",
+            UpgradeControllerErrorCode::NotEnoughResources => "the creep does not have any carried energy",
+            UpgradeControllerErrorCode::InvalidTarget => "the target is not a valid controller object, or the controller upgrading is blocked",
+            UpgradeControllerErrorCode::NotInRange => "the target is too far away",
+            UpgradeControllerErrorCode::NoBodypart => "there are no work body parts in this creep’s body",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for UpgradeControllerErrorCode {}
+
+/// Error codes used by [Creep::withdraw](crate::Creep::withdraw).
+///
+/// Screeps API Docs: [Creep.withdraw](https://docs.screeps.com/api/#Creep.withdraw).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L493)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreepWithdrawErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for CreepWithdrawErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreepWithdrawErrorCode::NotOwner)),
+            -4 => Some(Err(CreepWithdrawErrorCode::Busy)),
+            -6 => Some(Err(CreepWithdrawErrorCode::NotEnoughResources)),
+            -7 => Some(Err(CreepWithdrawErrorCode::InvalidTarget)),
+            -8 => Some(Err(CreepWithdrawErrorCode::Full)),
+            -9 => Some(Err(CreepWithdrawErrorCode::NotInRange)),
+            -10 => Some(Err(CreepWithdrawErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreepWithdrawErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreepWithdrawErrorCode::NotOwner => "you are not the owner of this creep, or there is a hostile rampart on top of the target",
+            CreepWithdrawErrorCode::Busy => "the creep is still being spawned",
+            CreepWithdrawErrorCode::NotEnoughResources => "the target does not have the given amount of resources",
+            CreepWithdrawErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
+            CreepWithdrawErrorCode::Full => "the creep's carry is full",
+            CreepWithdrawErrorCode::NotInRange => "the target is too far away",
+            CreepWithdrawErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreepWithdrawErrorCode {}

--- a/src/enums/action_error_codes/creep_error_codes.rs
+++ b/src/enums/action_error_codes/creep_error_codes.rs
@@ -23,6 +23,7 @@ pub enum CreepClaimReactorErrorCode {
     NoBodypart = -12,
 }
 
+#[cfg(feature = "seasonal-season-5")]
 impl FromReturnCode for CreepClaimReactorErrorCode {
     type Error = Self;
 
@@ -49,6 +50,7 @@ impl FromReturnCode for CreepClaimReactorErrorCode {
     }
 }
 
+#[cfg(feature = "seasonal-season-5")]
 impl fmt::Display for CreepClaimReactorErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
@@ -65,8 +67,10 @@ impl fmt::Display for CreepClaimReactorErrorCode {
     }
 }
 
+#[cfg(feature = "seasonal-season-5")]
 impl Error for CreepClaimReactorErrorCode {}
 
+#[cfg(feature = "seasonal-season-5")]
 impl From<CreepClaimReactorErrorCode> for ErrorCode {
     fn from(value: CreepClaimReactorErrorCode) -> Self {
         // Safety: CreepClaimReactorErrorCode is repr(i8), so we can cast it to get the
@@ -75,9 +79,7 @@ impl From<CreepClaimReactorErrorCode> for ErrorCode {
         // Safety: CreepClaimReactorErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -150,9 +152,7 @@ impl From<CreepAttackErrorCode> for ErrorCode {
         // Safety: CreepAttackErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -233,9 +233,7 @@ impl From<AttackControllerErrorCode> for ErrorCode {
         // Safety: AttackControllerErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -308,9 +306,7 @@ impl From<BuildErrorCode> for ErrorCode {
         // Safety: BuildErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -369,9 +365,7 @@ impl From<CreepCancelOrderErrorCode> for ErrorCode {
         // Safety: CreepCancelOrderErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -455,9 +449,7 @@ impl From<ClaimControllerErrorCode> for ErrorCode {
         // Safety: ClaimControllerErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -528,9 +520,7 @@ impl From<DismantleErrorCode> for ErrorCode {
         // Safety: DismantleErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -606,9 +596,7 @@ impl From<GenerateSafeModeErrorCode> for ErrorCode {
         // Safety: GenerateSafeModeErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -691,9 +679,7 @@ impl From<HarvestErrorCode> for ErrorCode {
         // Safety: HarvestErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -764,9 +750,7 @@ impl From<CreepHealErrorCode> for ErrorCode {
         // Safety: CreepHealErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -839,9 +823,7 @@ impl From<CreepMoveDirectionErrorCode> for ErrorCode {
         // Safety: CreepMoveDirectionErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -909,9 +891,7 @@ impl From<CreepMovePulledByErrorCode> for ErrorCode {
         // Safety: CreepMovePulledByErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -989,9 +969,7 @@ impl From<CreepMoveByPathErrorCode> for ErrorCode {
         // Safety: CreepMoveByPathErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1068,9 +1046,7 @@ impl From<CreepMoveToErrorCode> for ErrorCode {
         // Safety: CreepMoveToErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1137,9 +1113,7 @@ impl From<PullErrorCode> for ErrorCode {
         // Safety: PullErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1212,9 +1186,7 @@ impl From<RangedAttackErrorCode> for ErrorCode {
         // Safety: RangedAttackErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1285,9 +1257,7 @@ impl From<RangedHealErrorCode> for ErrorCode {
         // Safety: RangedHealErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1355,9 +1325,7 @@ impl From<RangedMassAttackErrorCode> for ErrorCode {
         // Safety: RangedMassAttackErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1431,9 +1399,7 @@ impl From<CreepRepairErrorCode> for ErrorCode {
         // Safety: CreepRepairErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1509,9 +1475,7 @@ impl From<ReserveControllerErrorCode> for ErrorCode {
         // Safety: ReserveControllerErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1576,9 +1540,7 @@ impl From<SignControllerErrorCode> for ErrorCode {
         // Safety: SignControllerErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -1653,8 +1615,6 @@ impl From<UpgradeControllerErrorCode> for ErrorCode {
         // Safety: UpgradeControllerErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/creep_error_codes.rs
+++ b/src/enums/action_error_codes/creep_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -29,11 +28,11 @@ impl FromReturnCode for CreepAttackErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -57,7 +56,9 @@ impl fmt::Display for CreepAttackErrorCode {
             CreepAttackErrorCode::Busy => "the creep is still being spawned",
             CreepAttackErrorCode::InvalidTarget => "the target is not a valid attackable object",
             CreepAttackErrorCode::NotInRange => "the target is too far away",
-            CreepAttackErrorCode::NoBodypart => "there are no attack body parts in this creep’s body",
+            CreepAttackErrorCode::NoBodypart => {
+                "there are no attack body parts in this creep’s body"
+            }
         };
 
         write!(f, "{}", msg)
@@ -66,7 +67,8 @@ impl fmt::Display for CreepAttackErrorCode {
 
 impl Error for CreepAttackErrorCode {}
 
-/// Error codes used by [Creep::attack_controller](crate::Creep::attack_controller).
+/// Error codes used by
+/// [Creep::attack_controller](crate::Creep::attack_controller).
 ///
 /// Screeps API Docs: [Creep.attackController](https://docs.screeps.com/api/#Creep.attackController).
 ///
@@ -89,11 +91,11 @@ impl FromReturnCode for AttackControllerErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -116,10 +118,16 @@ impl fmt::Display for AttackControllerErrorCode {
         let msg: &'static str = match self {
             AttackControllerErrorCode::NotOwner => "you are not the owner of this creep",
             AttackControllerErrorCode::Busy => "the creep is still being spawned",
-            AttackControllerErrorCode::InvalidTarget => "the target is not a valid owned or reserved controller object",
+            AttackControllerErrorCode::InvalidTarget => {
+                "the target is not a valid owned or reserved controller object"
+            }
             AttackControllerErrorCode::NotInRange => "the target is too far away",
-            AttackControllerErrorCode::Tired => "you have to wait until the next attack is possible",
-            AttackControllerErrorCode::NoBodypart => "there are not enough claim body parts in this creep’s body",
+            AttackControllerErrorCode::Tired => {
+                "you have to wait until the next attack is possible"
+            }
+            AttackControllerErrorCode::NoBodypart => {
+                "there are not enough claim body parts in this creep’s body"
+            }
         };
 
         write!(f, "{}", msg)
@@ -151,11 +159,11 @@ impl FromReturnCode for BuildErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -208,11 +216,11 @@ impl FromReturnCode for CreepCancelOrderErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -237,7 +245,8 @@ impl fmt::Display for CreepCancelOrderErrorCode {
 
 impl Error for CreepCancelOrderErrorCode {}
 
-/// Error codes used by [Creep::claim_controller](crate::Creep::claim_controller).
+/// Error codes used by
+/// [Creep::claim_controller](crate::Creep::claim_controller).
 ///
 /// Screeps API Docs: [Creep.claimController](https://docs.screeps.com/api/#Creep.claimController).
 ///
@@ -261,11 +270,11 @@ impl FromReturnCode for ClaimControllerErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -289,10 +298,16 @@ impl fmt::Display for ClaimControllerErrorCode {
         let msg: &'static str = match self {
             ClaimControllerErrorCode::NotOwner => "you are not the owner of this creep",
             ClaimControllerErrorCode::Busy => "the creep is still being spawned",
-            ClaimControllerErrorCode::InvalidTarget => "the target is not a valid neutral controller object",
-            ClaimControllerErrorCode::Full => "you cannot claim more than 3 rooms in the novice area",
+            ClaimControllerErrorCode::InvalidTarget => {
+                "the target is not a valid neutral controller object"
+            }
+            ClaimControllerErrorCode::Full => {
+                "you cannot claim more than 3 rooms in the novice area"
+            }
             ClaimControllerErrorCode::NotInRange => "the target is too far away",
-            ClaimControllerErrorCode::NoBodypart => "there are no claim body parts in this creep’s body",
+            ClaimControllerErrorCode::NoBodypart => {
+                "there are no claim body parts in this creep’s body"
+            }
             ClaimControllerErrorCode::GclNotEnough => "your global control level is not enough",
         };
 
@@ -324,11 +339,11 @@ impl FromReturnCode for DismantleErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -382,11 +397,11 @@ impl FromReturnCode for CreepDropErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -407,8 +422,12 @@ impl fmt::Display for CreepDropErrorCode {
         let msg: &'static str = match self {
             CreepDropErrorCode::NotOwner => "you are not the owner of this creep",
             CreepDropErrorCode::Busy => "the creep is still being spawned",
-            CreepDropErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
-            CreepDropErrorCode::InvalidArgs => "the resourcetype is not a valid resource_* constants",
+            CreepDropErrorCode::NotEnoughResources => {
+                "the creep does not have the given amount of resources"
+            }
+            CreepDropErrorCode::InvalidArgs => {
+                "the resourcetype is not a valid resource_* constants"
+            }
         };
 
         write!(f, "{}", msg)
@@ -417,7 +436,8 @@ impl fmt::Display for CreepDropErrorCode {
 
 impl Error for CreepDropErrorCode {}
 
-/// Error codes used by [Creep::generate_safe_mode](crate::Creep::generate_safe_mode).
+/// Error codes used by
+/// [Creep::generate_safe_mode](crate::Creep::generate_safe_mode).
 ///
 /// Screeps API Docs: [Creep.generateSafeMode](https://docs.screeps.com/api/#Creep.generateSafeMode).
 ///
@@ -439,11 +459,11 @@ impl FromReturnCode for GenerateSafeModeErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -465,8 +485,12 @@ impl fmt::Display for GenerateSafeModeErrorCode {
         let msg: &'static str = match self {
             GenerateSafeModeErrorCode::NotOwner => "you are not the owner of this creep",
             GenerateSafeModeErrorCode::Busy => "the creep is still being spawned",
-            GenerateSafeModeErrorCode::NotEnoughResources => "the creep does not have enough ghodium",
-            GenerateSafeModeErrorCode::InvalidTarget => "the target is not a valid controller object",
+            GenerateSafeModeErrorCode::NotEnoughResources => {
+                "the creep does not have enough ghodium"
+            }
+            GenerateSafeModeErrorCode::InvalidTarget => {
+                "the target is not a valid controller object"
+            }
             GenerateSafeModeErrorCode::NotInRange => "the target is too far away",
         };
 
@@ -502,11 +526,11 @@ impl FromReturnCode for HarvestErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -569,11 +593,11 @@ impl FromReturnCode for CreepHealErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -629,11 +653,11 @@ impl FromReturnCode for CreepMoveErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -691,11 +715,11 @@ impl FromReturnCode for CreepMoveByPathErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -718,10 +742,14 @@ impl fmt::Display for CreepMoveByPathErrorCode {
         let msg: &'static str = match self {
             CreepMoveByPathErrorCode::NotOwner => "you are not the owner of this creep",
             CreepMoveByPathErrorCode::Busy => "the creep is still being spawned",
-            CreepMoveByPathErrorCode::NotFound => "the specified path doesn't match the creep's location",
+            CreepMoveByPathErrorCode::NotFound => {
+                "the specified path doesn't match the creep's location"
+            }
             CreepMoveByPathErrorCode::InvalidArgs => "path is not a valid path array",
             CreepMoveByPathErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
-            CreepMoveByPathErrorCode::NoBodypart => "there are no move body parts in this creep’s body",
+            CreepMoveByPathErrorCode::NoBodypart => {
+                "there are no move body parts in this creep’s body"
+            }
         };
 
         write!(f, "{}", msg)
@@ -754,11 +782,11 @@ impl FromReturnCode for CreepMoveToErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -795,7 +823,8 @@ impl fmt::Display for CreepMoveToErrorCode {
 
 impl Error for CreepMoveToErrorCode {}
 
-/// Error codes used by [Creep::notify_when_attacked](crate::Creep::notify_when_attacked).
+/// Error codes used by
+/// [Creep::notify_when_attacked](crate::Creep::notify_when_attacked).
 ///
 /// Screeps API Docs: [Creep.notifyWhenAttacked](https://docs.screeps.com/api/#Creep.notifyWhenAttacked).
 ///
@@ -815,11 +844,11 @@ impl FromReturnCode for CreepNotifyWhenAttackedErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -839,7 +868,9 @@ impl fmt::Display for CreepNotifyWhenAttackedErrorCode {
         let msg: &'static str = match self {
             CreepNotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this creep",
             CreepNotifyWhenAttackedErrorCode::Busy => "the creep is still being spawned",
-            CreepNotifyWhenAttackedErrorCode::InvalidArgs => "enable argument is not a boolean value",
+            CreepNotifyWhenAttackedErrorCode::InvalidArgs => {
+                "enable argument is not a boolean value"
+            }
         };
 
         write!(f, "{}", msg)
@@ -870,11 +901,11 @@ impl FromReturnCode for CreepPickupErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -928,11 +959,11 @@ impl FromReturnCode for PullErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -985,11 +1016,11 @@ impl FromReturnCode for RangedAttackErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1013,7 +1044,9 @@ impl fmt::Display for RangedAttackErrorCode {
             RangedAttackErrorCode::Busy => "the creep is still being spawned",
             RangedAttackErrorCode::InvalidTarget => "the target is not a valid attackable object",
             RangedAttackErrorCode::NotInRange => "the target is too far away",
-            RangedAttackErrorCode::NoBodypart => "there are no ranged_attack body parts in this creep’s body",
+            RangedAttackErrorCode::NoBodypart => {
+                "there are no ranged_attack body parts in this creep’s body"
+            }
         };
 
         write!(f, "{}", msg)
@@ -1044,11 +1077,11 @@ impl FromReturnCode for RangedHealErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1081,7 +1114,8 @@ impl fmt::Display for RangedHealErrorCode {
 
 impl Error for RangedHealErrorCode {}
 
-/// Error codes used by [Creep::ranged_mass_attack](crate::Creep::ranged_mass_attack).
+/// Error codes used by
+/// [Creep::ranged_mass_attack](crate::Creep::ranged_mass_attack).
 ///
 /// Screeps API Docs: [Creep.rangedMassAttack](https://docs.screeps.com/api/#Creep.rangedMassAttack).
 ///
@@ -1101,11 +1135,11 @@ impl FromReturnCode for RangedMassAttackErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1125,7 +1159,9 @@ impl fmt::Display for RangedMassAttackErrorCode {
         let msg: &'static str = match self {
             RangedMassAttackErrorCode::NotOwner => "you are not the owner of this creep",
             RangedMassAttackErrorCode::Busy => "the creep is still being spawned",
-            RangedMassAttackErrorCode::NoBodypart => "there are no ranged_attack body parts in this creep’s body",
+            RangedMassAttackErrorCode::NoBodypart => {
+                "there are no ranged_attack body parts in this creep’s body"
+            }
         };
 
         write!(f, "{}", msg)
@@ -1157,11 +1193,11 @@ impl FromReturnCode for CreepRepairErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1196,7 +1232,8 @@ impl fmt::Display for CreepRepairErrorCode {
 
 impl Error for CreepRepairErrorCode {}
 
-/// Error codes used by [Creep::reserve_controller](crate::Creep::reserve_controller).
+/// Error codes used by
+/// [Creep::reserve_controller](crate::Creep::reserve_controller).
 ///
 /// Screeps API Docs: [Creep.reserveController](https://docs.screeps.com/api/#Creep.reserveController).
 ///
@@ -1218,11 +1255,11 @@ impl FromReturnCode for ReserveControllerErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1244,9 +1281,13 @@ impl fmt::Display for ReserveControllerErrorCode {
         let msg: &'static str = match self {
             ReserveControllerErrorCode::NotOwner => "you are not the owner of this creep",
             ReserveControllerErrorCode::Busy => "the creep is still being spawned",
-            ReserveControllerErrorCode::InvalidTarget => "the target is not a valid neutral controller object",
+            ReserveControllerErrorCode::InvalidTarget => {
+                "the target is not a valid neutral controller object"
+            }
             ReserveControllerErrorCode::NotInRange => "the target is too far away",
-            ReserveControllerErrorCode::NoBodypart => "there are no claim body parts in this creep’s body",
+            ReserveControllerErrorCode::NoBodypart => {
+                "there are no claim body parts in this creep’s body"
+            }
         };
 
         write!(f, "{}", msg)
@@ -1274,11 +1315,11 @@ impl FromReturnCode for CreepSayErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1325,11 +1366,11 @@ impl FromReturnCode for SignControllerErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1377,11 +1418,11 @@ impl FromReturnCode for CreepSuicideErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1432,11 +1473,11 @@ impl FromReturnCode for CreepTransferErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1473,7 +1514,8 @@ impl fmt::Display for CreepTransferErrorCode {
 
 impl Error for CreepTransferErrorCode {}
 
-/// Error codes used by [Creep::upgrade_controller](crate::Creep::upgrade_controller).
+/// Error codes used by
+/// [Creep::upgrade_controller](crate::Creep::upgrade_controller).
 ///
 /// Screeps API Docs: [Creep.upgradeController](https://docs.screeps.com/api/#Creep.upgradeController).
 ///
@@ -1496,11 +1538,11 @@ impl FromReturnCode for UpgradeControllerErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1559,11 +1601,11 @@ impl FromReturnCode for CreepWithdrawErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/flag_error_codes.rs
+++ b/src/enums/action_error_codes/flag_error_codes.rs
@@ -101,9 +101,7 @@ impl From<SetColorErrorCode> for ErrorCode {
         // Safety: SetColorErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -162,8 +160,6 @@ impl From<SetPositionErrorCode> for ErrorCode {
         // Safety: SetPositionErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/flag_error_codes.rs
+++ b/src/enums/action_error_codes/flag_error_codes.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [Flag::remove](crate::Flag::remove).
+///
+/// Screeps API Docs: [Flag.remove](https://docs.screeps.com/api/#Flag.remove).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/flags.js#L57)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive,
+)]
+pub enum FlagRemoveErrorCode {}
+
+impl FromReturnCode for FlagRemoveErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for FlagRemoveErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unimplemented!()
+    }
+}
+
+impl Error for FlagRemoveErrorCode {}
+
+/// Error codes used by [Flag::set_color](crate::Flag::set_color).
+///
+/// Screeps API Docs: [Flag.setColor](https://docs.screeps.com/api/#Flag.setColor).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/flags.js#L76)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SetColorErrorCode {
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for SetColorErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -10 => Some(Err(SetColorErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SetColorErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SetColorErrorCode::InvalidArgs => "color or secondarycolor is not a valid color constant",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SetColorErrorCode {}
+
+/// Error codes used by [Flag::set_position](crate::Flag::set_position).
+///
+/// Screeps API Docs: [Flag.setPosition](https://docs.screeps.com/api/#Flag.setPosition).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/flags.js#L63)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SetPositionErrorCode {
+    InvalidTarget = -7,
+}
+
+impl FromReturnCode for SetPositionErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -7 => Some(Err(SetPositionErrorCode::InvalidTarget)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SetPositionErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SetPositionErrorCode::InvalidTarget => "the target provided is invalid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SetPositionErrorCode {}

--- a/src/enums/action_error_codes/flag_error_codes.rs
+++ b/src/enums/action_error_codes/flag_error_codes.rs
@@ -3,11 +3,11 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by [Flag::remove](crate::Flag::remove).
 ///
-/// Screeps API Docs: [Flag.remove](https://docs.screeps.com/api/#Flag.remove).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Flag.remove).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/flags.js#L57)
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive)]
@@ -35,8 +35,10 @@ impl FromReturnCode for FlagRemoveErrorCode {
 }
 
 impl fmt::Display for FlagRemoveErrorCode {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unimplemented!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = "Zero-variant enum";
+
+        write!(f, "{}", msg)
     }
 }
 
@@ -44,7 +46,7 @@ impl Error for FlagRemoveErrorCode {}
 
 /// Error codes used by [Flag::set_color](crate::Flag::set_color).
 ///
-/// Screeps API Docs: [Flag.setColor](https://docs.screeps.com/api/#Flag.setColor).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Flag.setColor).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/flags.js#L76)
 #[derive(
@@ -91,9 +93,23 @@ impl fmt::Display for SetColorErrorCode {
 
 impl Error for SetColorErrorCode {}
 
+impl From<SetColorErrorCode> for ErrorCode {
+    fn from(value: SetColorErrorCode) -> Self {
+        // Safety: SetColorErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SetColorErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Flag::set_position](crate::Flag::set_position).
 ///
-/// Screeps API Docs: [Flag.setPosition](https://docs.screeps.com/api/#Flag.setPosition).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Flag.setPosition).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/flags.js#L63)
 #[derive(
@@ -137,3 +153,17 @@ impl fmt::Display for SetPositionErrorCode {
 }
 
 impl Error for SetPositionErrorCode {}
+
+impl From<SetPositionErrorCode> for ErrorCode {
+    fn from(value: SetPositionErrorCode) -> Self {
+        // Safety: SetPositionErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SetPositionErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/flag_error_codes.rs
+++ b/src/enums/action_error_codes/flag_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
@@ -36,7 +35,7 @@ impl FromReturnCode for FlagRemoveErrorCode {
 }
 
 impl fmt::Display for FlagRemoveErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         unimplemented!()
     }
 }

--- a/src/enums/action_error_codes/flag_error_codes.rs
+++ b/src/enums/action_error_codes/flag_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -12,9 +11,7 @@ use crate::FromReturnCode;
 /// Screeps API Docs: [Flag.remove](https://docs.screeps.com/api/#Flag.remove).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/flags.js#L57)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive,
-)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive)]
 pub enum FlagRemoveErrorCode {}
 
 impl FromReturnCode for FlagRemoveErrorCode {
@@ -22,11 +19,11 @@ impl FromReturnCode for FlagRemoveErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -64,11 +61,11 @@ impl FromReturnCode for SetColorErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -84,7 +81,9 @@ impl FromReturnCode for SetColorErrorCode {
 impl fmt::Display for SetColorErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            SetColorErrorCode::InvalidArgs => "color or secondarycolor is not a valid color constant",
+            SetColorErrorCode::InvalidArgs => {
+                "color or secondarycolor is not a valid color constant"
+            }
         };
 
         write!(f, "{}", msg)
@@ -111,11 +110,11 @@ impl FromReturnCode for SetPositionErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/game_cpu_error_codes.rs
+++ b/src/enums/action_error_codes/game_cpu_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/game_cpu_error_codes.rs
+++ b/src/enums/action_error_codes/game_cpu_error_codes.rs
@@ -19,6 +19,7 @@ pub enum SetShardLimitsErrorCode {
     InvalidArgs = -10,
 }
 
+#[cfg(feature = "mmo")]
 impl FromReturnCode for SetShardLimitsErrorCode {
     type Error = Self;
 
@@ -42,6 +43,7 @@ impl FromReturnCode for SetShardLimitsErrorCode {
     }
 }
 
+#[cfg(feature = "mmo")]
 impl fmt::Display for SetShardLimitsErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
@@ -55,8 +57,10 @@ impl fmt::Display for SetShardLimitsErrorCode {
     }
 }
 
+#[cfg(feature = "mmo")]
 impl Error for SetShardLimitsErrorCode {}
 
+#[cfg(feature = "mmo")]
 impl From<SetShardLimitsErrorCode> for ErrorCode {
     fn from(value: SetShardLimitsErrorCode) -> Self {
         // Safety: SetShardLimitsErrorCode is repr(i8), so we can cast it to get the
@@ -65,9 +69,7 @@ impl From<SetShardLimitsErrorCode> for ErrorCode {
         // Safety: SetShardLimitsErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -129,9 +131,7 @@ impl From<UnlockErrorCode> for ErrorCode {
         // Safety: UnlockErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -189,8 +189,6 @@ impl From<GeneratePixelErrorCode> for ErrorCode {
         // Safety: GeneratePixelErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/game_cpu_error_codes.rs
+++ b/src/enums/action_error_codes/game_cpu_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [game::cpu::set_shard_limits](crate::game::cpu::set_shard_limits).
 ///
-/// Screeps API Docs: [Game.cpu.setShardLimits](https://docs.screeps.com/api/#Game.cpu.setShardLimits).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.cpu.setShardLimits).
 #[cfg(feature = "mmo")]
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
@@ -57,9 +57,23 @@ impl fmt::Display for SetShardLimitsErrorCode {
 
 impl Error for SetShardLimitsErrorCode {}
 
+impl From<SetShardLimitsErrorCode> for ErrorCode {
+    fn from(value: SetShardLimitsErrorCode) -> Self {
+        // Safety: SetShardLimitsErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SetShardLimitsErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [game::cpu::unlock](crate::game::cpu::unlock).
 ///
-/// Screeps API Docs: [Game.cpu.unlock](https://docs.screeps.com/api/#Game.cpu.unlock).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.cpu.unlock).
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
 )]
@@ -107,10 +121,24 @@ impl fmt::Display for UnlockErrorCode {
 
 impl Error for UnlockErrorCode {}
 
+impl From<UnlockErrorCode> for ErrorCode {
+    fn from(value: UnlockErrorCode) -> Self {
+        // Safety: UnlockErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: UnlockErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [game::cpu::generate_pixel](crate::game::cpu::generate_pixel).
 ///
-/// Screeps API Docs: [Game.cpu.generatePixel](https://docs.screeps.com/api/#Game.cpu.generatePixel).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.cpu.generatePixel).
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
 )]
@@ -152,3 +180,17 @@ impl fmt::Display for GeneratePixelErrorCode {
 }
 
 impl Error for GeneratePixelErrorCode {}
+
+impl From<GeneratePixelErrorCode> for ErrorCode {
+    fn from(value: GeneratePixelErrorCode) -> Self {
+        // Safety: GeneratePixelErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: GeneratePixelErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/game_cpu_error_codes.rs
+++ b/src/enums/action_error_codes/game_cpu_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [game::cpu::set_shard_limits](crate::game::cpu::set_shard_limits).
+/// Error codes used by
+/// [game::cpu::set_shard_limits](crate::game::cpu::set_shard_limits).
 ///
 /// Screeps API Docs: [Game.cpu.setShardLimits](https://docs.screeps.com/api/#Game.cpu.setShardLimits).
 #[cfg(feature = "mmo")]
@@ -25,11 +25,11 @@ impl FromReturnCode for SetShardLimitsErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -47,7 +47,9 @@ impl fmt::Display for SetShardLimitsErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             SetShardLimitsErrorCode::Busy => "12-hours cooldown period is not over yet",
-            SetShardLimitsErrorCode::InvalidArgs => "the argument is not a valid shard limits object",
+            SetShardLimitsErrorCode::InvalidArgs => {
+                "the argument is not a valid shard limits object"
+            }
         };
 
         write!(f, "{}", msg)
@@ -73,11 +75,11 @@ impl FromReturnCode for UnlockErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -94,7 +96,9 @@ impl FromReturnCode for UnlockErrorCode {
 impl fmt::Display for UnlockErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            UnlockErrorCode::NotEnoughResources => "your account does not have enough cpuunlock resource",
+            UnlockErrorCode::NotEnoughResources => {
+                "your account does not have enough cpuunlock resource"
+            }
             UnlockErrorCode::Full => "your cpu is unlocked with a subscription",
         };
 
@@ -104,7 +108,8 @@ impl fmt::Display for UnlockErrorCode {
 
 impl Error for UnlockErrorCode {}
 
-/// Error codes used by [game::cpu::generate_pixel](crate::game::cpu::generate_pixel).
+/// Error codes used by
+/// [game::cpu::generate_pixel](crate::game::cpu::generate_pixel).
 ///
 /// Screeps API Docs: [Game.cpu.generatePixel](https://docs.screeps.com/api/#Game.cpu.generatePixel).
 #[derive(
@@ -120,11 +125,11 @@ impl FromReturnCode for GeneratePixelErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/game_cpu_error_codes.rs
+++ b/src/enums/action_error_codes/game_cpu_error_codes.rs
@@ -1,0 +1,150 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [game::cpu::set_shard_limits](crate::game::cpu::set_shard_limits).
+///
+/// Screeps API Docs: [Game.cpu.setShardLimits](https://docs.screeps.com/api/#Game.cpu.setShardLimits).
+#[cfg(feature = "mmo")]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SetShardLimitsErrorCode {
+    Busy = -4,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for SetShardLimitsErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -4 => Some(Err(SetShardLimitsErrorCode::Busy)),
+            -10 => Some(Err(SetShardLimitsErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SetShardLimitsErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SetShardLimitsErrorCode::Busy => "12-hours cooldown period is not over yet",
+            SetShardLimitsErrorCode::InvalidArgs => "the argument is not a valid shard limits object",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SetShardLimitsErrorCode {}
+
+/// Error codes used by [game::cpu::unlock](crate::game::cpu::unlock).
+///
+/// Screeps API Docs: [Game.cpu.unlock](https://docs.screeps.com/api/#Game.cpu.unlock).
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum UnlockErrorCode {
+    NotEnoughResources = -6,
+    Full = -8,
+}
+
+impl FromReturnCode for UnlockErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -6 => Some(Err(UnlockErrorCode::NotEnoughResources)),
+            -8 => Some(Err(UnlockErrorCode::Full)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UnlockErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            UnlockErrorCode::NotEnoughResources => "your account does not have enough cpuunlock resource",
+            UnlockErrorCode::Full => "your cpu is unlocked with a subscription",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for UnlockErrorCode {}
+
+/// Error codes used by [game::cpu::generate_pixel](crate::game::cpu::generate_pixel).
+///
+/// Screeps API Docs: [Game.cpu.generatePixel](https://docs.screeps.com/api/#Game.cpu.generatePixel).
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum GeneratePixelErrorCode {
+    NotEnoughResources = -6,
+}
+
+impl FromReturnCode for GeneratePixelErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -6 => Some(Err(GeneratePixelErrorCode::NotEnoughResources)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for GeneratePixelErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            GeneratePixelErrorCode::NotEnoughResources => "your bucket does not have enough cpu",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for GeneratePixelErrorCode {}

--- a/src/enums/action_error_codes/game_map_error_codes.rs
+++ b/src/enums/action_error_codes/game_map_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/game_map_error_codes.rs
+++ b/src/enums/action_error_codes/game_map_error_codes.rs
@@ -1,0 +1,115 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [game::map::find_exit](crate::game::map::find_exit).
+///
+/// Screeps API Docs: [Game.map.findExit](https://docs.screeps.com/api/#Game.map.findExit).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/map.js#L188)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum FindExitErrorCode {
+    NoPath = -2,
+    InvalidArgs = -10,
+    FindExitTop = 1,
+    FindExitRight = 3,
+    FindExitBottom = 5,
+    FindExitLeft = 7,
+}
+
+impl FromReturnCode for FindExitErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            -2 => Some(Err(FindExitErrorCode::NoPath)),
+            -10 => Some(Err(FindExitErrorCode::InvalidArgs)),
+            1 => Some(Err(FindExitErrorCode::FindExitTop)),
+            3 => Some(Err(FindExitErrorCode::FindExitRight)),
+            5 => Some(Err(FindExitErrorCode::FindExitBottom)),
+            7 => Some(Err(FindExitErrorCode::FindExitLeft)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for FindExitErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            FindExitErrorCode::NoPath => "path can not be found",
+            FindExitErrorCode::InvalidArgs => "the location is incorrect",
+            FindExitErrorCode::FindExitTop => "exit top",
+            FindExitErrorCode::FindExitRight => "exit right",
+            FindExitErrorCode::FindExitBottom => "exit bottom",
+            FindExitErrorCode::FindExitLeft => "exit left",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for FindExitErrorCode {}
+
+/// Error codes used by [game::map::find_route](crate::game::map::find_route).
+///
+/// Screeps API Docs: [Game.map.findRoute](https://docs.screeps.com/api/#Game.map.findRoute).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/map.js#L69)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum FindRouteErrorCode {
+    NoPath = -2,
+}
+
+impl FromReturnCode for FindRouteErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            -2 => Some(Err(FindRouteErrorCode::NoPath)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for FindRouteErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            FindRouteErrorCode::NoPath => "path can not be found",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for FindRouteErrorCode {}

--- a/src/enums/action_error_codes/game_map_error_codes.rs
+++ b/src/enums/action_error_codes/game_map_error_codes.rs
@@ -62,9 +62,7 @@ impl From<FindExitErrorCode> for ErrorCode {
         // Safety: FindExitErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -122,8 +120,6 @@ impl From<FindRouteErrorCode> for ErrorCode {
         // Safety: FindRouteErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/game_map_error_codes.rs
+++ b/src/enums/action_error_codes/game_map_error_codes.rs
@@ -19,10 +19,6 @@ use crate::FromReturnCode;
 pub enum FindExitErrorCode {
     NoPath = -2,
     InvalidArgs = -10,
-    FindExitTop = 1,
-    FindExitRight = 3,
-    FindExitBottom = 5,
-    FindExitLeft = 7,
 }
 
 impl FromReturnCode for FindExitErrorCode {
@@ -42,10 +38,6 @@ impl FromReturnCode for FindExitErrorCode {
         match val {
             -2 => Some(Err(FindExitErrorCode::NoPath)),
             -10 => Some(Err(FindExitErrorCode::InvalidArgs)),
-            1 => Some(Err(FindExitErrorCode::FindExitTop)),
-            3 => Some(Err(FindExitErrorCode::FindExitRight)),
-            5 => Some(Err(FindExitErrorCode::FindExitBottom)),
-            7 => Some(Err(FindExitErrorCode::FindExitLeft)),
             _ => None,
         }
     }
@@ -56,10 +48,6 @@ impl fmt::Display for FindExitErrorCode {
         let msg: &'static str = match self {
             FindExitErrorCode::NoPath => "path can not be found",
             FindExitErrorCode::InvalidArgs => "the location is incorrect",
-            FindExitErrorCode::FindExitTop => "exit top",
-            FindExitErrorCode::FindExitRight => "exit right",
-            FindExitErrorCode::FindExitBottom => "exit bottom",
-            FindExitErrorCode::FindExitLeft => "exit left",
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/game_map_error_codes.rs
+++ b/src/enums/action_error_codes/game_map_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -26,11 +25,11 @@ impl FromReturnCode for FindExitErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -74,11 +73,11 @@ impl FromReturnCode for FindRouteErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/game_map_error_codes.rs
+++ b/src/enums/action_error_codes/game_map_error_codes.rs
@@ -3,11 +3,11 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by [game::map::find_exit](crate::game::map::find_exit).
 ///
-/// Screeps API Docs: [Game.map.findExit](https://docs.screeps.com/api/#Game.map.findExit).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.map.findExit).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/map.js#L188)
 #[derive(
@@ -54,9 +54,23 @@ impl fmt::Display for FindExitErrorCode {
 
 impl Error for FindExitErrorCode {}
 
+impl From<FindExitErrorCode> for ErrorCode {
+    fn from(value: FindExitErrorCode) -> Self {
+        // Safety: FindExitErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: FindExitErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [game::map::find_route](crate::game::map::find_route).
 ///
-/// Screeps API Docs: [Game.map.findRoute](https://docs.screeps.com/api/#Game.map.findRoute).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.map.findRoute).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/map.js#L69)
 #[derive(
@@ -99,3 +113,17 @@ impl fmt::Display for FindRouteErrorCode {
 }
 
 impl Error for FindRouteErrorCode {}
+
+impl From<FindRouteErrorCode> for ErrorCode {
+    fn from(value: FindRouteErrorCode) -> Self {
+        // Safety: FindRouteErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: FindRouteErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/game_market_error_codes.rs
+++ b/src/enums/action_error_codes/game_market_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [game::market::cancel_order](crate::game::market::cancel_order).
+/// Error codes used by
+/// [game::market::cancel_order](crate::game::market::cancel_order).
 ///
 /// Screeps API Docs: [Game.market.cancelOrder](https://docs.screeps.com/api/#Game.market.cancelOrder).
 ///
@@ -25,11 +25,11 @@ impl FromReturnCode for MarketCancelOrderErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -54,7 +54,8 @@ impl fmt::Display for MarketCancelOrderErrorCode {
 
 impl Error for MarketCancelOrderErrorCode {}
 
-/// Error codes used by [game::market::change_order_price](crate::game::market::change_order_price).
+/// Error codes used by
+/// [game::market::change_order_price](crate::game::market::change_order_price).
 ///
 /// Screeps API Docs: [Game.market.changeOrderPrice](https://docs.screeps.com/api/#Game.market.changeOrderPrice).
 ///
@@ -74,11 +75,11 @@ impl FromReturnCode for ChangeOrderPriceErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -96,8 +97,12 @@ impl FromReturnCode for ChangeOrderPriceErrorCode {
 impl fmt::Display for ChangeOrderPriceErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            ChangeOrderPriceErrorCode::NotOwner => "you are not the owner of the room's terminal or there is no terminal",
-            ChangeOrderPriceErrorCode::NotEnoughResources => "you don't have enough credits to pay a fee",
+            ChangeOrderPriceErrorCode::NotOwner => {
+                "you are not the owner of the room's terminal or there is no terminal"
+            }
+            ChangeOrderPriceErrorCode::NotEnoughResources => {
+                "you don't have enough credits to pay a fee"
+            }
             ChangeOrderPriceErrorCode::InvalidArgs => "the arguments provided are invalid",
         };
 
@@ -107,7 +112,8 @@ impl fmt::Display for ChangeOrderPriceErrorCode {
 
 impl Error for ChangeOrderPriceErrorCode {}
 
-/// Error codes used by [game::market::create_order](crate::game::market::create_order).
+/// Error codes used by
+/// [game::market::create_order](crate::game::market::create_order).
 ///
 /// Screeps API Docs: [Game.market.createOrder](https://docs.screeps.com/api/#Game.market.createOrder).
 ///
@@ -128,11 +134,11 @@ impl FromReturnCode for CreateOrderErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -151,8 +157,12 @@ impl FromReturnCode for CreateOrderErrorCode {
 impl fmt::Display for CreateOrderErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            CreateOrderErrorCode::NotOwner => "you are not the owner of the room's terminal or there is no terminal",
-            CreateOrderErrorCode::NotEnoughResources => "you don't have enough credits to pay a fee",
+            CreateOrderErrorCode::NotOwner => {
+                "you are not the owner of the room's terminal or there is no terminal"
+            }
+            CreateOrderErrorCode::NotEnoughResources => {
+                "you don't have enough credits to pay a fee"
+            }
             CreateOrderErrorCode::Full => "you cannot create more than 50 orders",
             CreateOrderErrorCode::InvalidArgs => "the arguments provided are invalid",
         };
@@ -185,11 +195,11 @@ impl FromReturnCode for DealErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -222,7 +232,8 @@ impl fmt::Display for DealErrorCode {
 
 impl Error for DealErrorCode {}
 
-/// Error codes used by [game::market::extend_order](crate::game::market::extend_order).
+/// Error codes used by
+/// [game::market::extend_order](crate::game::market::extend_order).
 ///
 /// Screeps API Docs: [Game.market.extendOrder](https://docs.screeps.com/api/#Game.market.extendOrder).
 ///
@@ -241,11 +252,11 @@ impl FromReturnCode for ExtendOrderErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -262,7 +273,9 @@ impl FromReturnCode for ExtendOrderErrorCode {
 impl fmt::Display for ExtendOrderErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            ExtendOrderErrorCode::NotEnoughResources => "you don't have enough credits to pay a fee",
+            ExtendOrderErrorCode::NotEnoughResources => {
+                "you don't have enough credits to pay a fee"
+            }
             ExtendOrderErrorCode::InvalidArgs => "the arguments provided are invalid",
         };
 

--- a/src/enums/action_error_codes/game_market_error_codes.rs
+++ b/src/enums/action_error_codes/game_market_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/game_market_error_codes.rs
+++ b/src/enums/action_error_codes/game_market_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [game::market::cancel_order](crate::game::market::cancel_order).
 ///
-/// Screeps API Docs: [Game.market.cancelOrder](https://docs.screeps.com/api/#Game.market.cancelOrder).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.market.cancelOrder).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L100)
 #[derive(
@@ -53,10 +53,24 @@ impl fmt::Display for MarketCancelOrderErrorCode {
 
 impl Error for MarketCancelOrderErrorCode {}
 
+impl From<MarketCancelOrderErrorCode> for ErrorCode {
+    fn from(value: MarketCancelOrderErrorCode) -> Self {
+        // Safety: MarketCancelOrderErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: MarketCancelOrderErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [game::market::change_order_price](crate::game::market::change_order_price).
 ///
-/// Screeps API Docs: [Game.market.changeOrderPrice](https://docs.screeps.com/api/#Game.market.changeOrderPrice).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.market.changeOrderPrice).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L155)
 #[derive(
@@ -111,10 +125,24 @@ impl fmt::Display for ChangeOrderPriceErrorCode {
 
 impl Error for ChangeOrderPriceErrorCode {}
 
+impl From<ChangeOrderPriceErrorCode> for ErrorCode {
+    fn from(value: ChangeOrderPriceErrorCode) -> Self {
+        // Safety: ChangeOrderPriceErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ChangeOrderPriceErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [game::market::create_order](crate::game::market::create_order).
 ///
-/// Screeps API Docs: [Game.market.createOrder](https://docs.screeps.com/api/#Game.market.createOrder).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.market.createOrder).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L68)
 #[derive(
@@ -172,9 +200,23 @@ impl fmt::Display for CreateOrderErrorCode {
 
 impl Error for CreateOrderErrorCode {}
 
+impl From<CreateOrderErrorCode> for ErrorCode {
+    fn from(value: CreateOrderErrorCode) -> Self {
+        // Safety: CreateOrderErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CreateOrderErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [game::market::deal](crate::game::market::deal).
 ///
-/// Screeps API Docs: [Game.market.deal](https://docs.screeps.com/api/#Game.market.deal).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.market.deal).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L108)
 #[derive(
@@ -231,10 +273,23 @@ impl fmt::Display for DealErrorCode {
 
 impl Error for DealErrorCode {}
 
+impl From<DealErrorCode> for ErrorCode {
+    fn from(value: DealErrorCode) -> Self {
+        // Safety: DealErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: DealErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [game::market::extend_order](crate::game::market::extend_order).
 ///
-/// Screeps API Docs: [Game.market.extendOrder](https://docs.screeps.com/api/#Game.market.extendOrder).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Game.market.extendOrder).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L174)
 #[derive(
@@ -283,3 +338,17 @@ impl fmt::Display for ExtendOrderErrorCode {
 }
 
 impl Error for ExtendOrderErrorCode {}
+
+impl From<ExtendOrderErrorCode> for ErrorCode {
+    fn from(value: ExtendOrderErrorCode) -> Self {
+        // Safety: ExtendOrderErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ExtendOrderErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/game_market_error_codes.rs
+++ b/src/enums/action_error_codes/game_market_error_codes.rs
@@ -1,0 +1,273 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [game::market::cancel_order](crate::game::market::cancel_order).
+///
+/// Screeps API Docs: [Game.market.cancelOrder](https://docs.screeps.com/api/#Game.market.cancelOrder).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L100)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum MarketCancelOrderErrorCode {
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for MarketCancelOrderErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -10 => Some(Err(MarketCancelOrderErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for MarketCancelOrderErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            MarketCancelOrderErrorCode::InvalidArgs => "the order id is not valid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for MarketCancelOrderErrorCode {}
+
+/// Error codes used by [game::market::change_order_price](crate::game::market::change_order_price).
+///
+/// Screeps API Docs: [Game.market.changeOrderPrice](https://docs.screeps.com/api/#Game.market.changeOrderPrice).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L155)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ChangeOrderPriceErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for ChangeOrderPriceErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ChangeOrderPriceErrorCode::NotOwner)),
+            -6 => Some(Err(ChangeOrderPriceErrorCode::NotEnoughResources)),
+            -10 => Some(Err(ChangeOrderPriceErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ChangeOrderPriceErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ChangeOrderPriceErrorCode::NotOwner => "you are not the owner of the room's terminal or there is no terminal",
+            ChangeOrderPriceErrorCode::NotEnoughResources => "you don't have enough credits to pay a fee",
+            ChangeOrderPriceErrorCode::InvalidArgs => "the arguments provided are invalid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ChangeOrderPriceErrorCode {}
+
+/// Error codes used by [game::market::create_order](crate::game::market::create_order).
+///
+/// Screeps API Docs: [Game.market.createOrder](https://docs.screeps.com/api/#Game.market.createOrder).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L68)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CreateOrderErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    Full = -8,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for CreateOrderErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CreateOrderErrorCode::NotOwner)),
+            -6 => Some(Err(CreateOrderErrorCode::NotEnoughResources)),
+            -8 => Some(Err(CreateOrderErrorCode::Full)),
+            -10 => Some(Err(CreateOrderErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CreateOrderErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CreateOrderErrorCode::NotOwner => "you are not the owner of the room's terminal or there is no terminal",
+            CreateOrderErrorCode::NotEnoughResources => "you don't have enough credits to pay a fee",
+            CreateOrderErrorCode::Full => "you cannot create more than 50 orders",
+            CreateOrderErrorCode::InvalidArgs => "the arguments provided are invalid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CreateOrderErrorCode {}
+
+/// Error codes used by [game::market::deal](crate::game::market::deal).
+///
+/// Screeps API Docs: [Game.market.deal](https://docs.screeps.com/api/#Game.market.deal).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L108)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum DealErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    Full = -8,
+    InvalidArgs = -10,
+    Tired = -11,
+}
+
+impl FromReturnCode for DealErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(DealErrorCode::NotOwner)),
+            -6 => Some(Err(DealErrorCode::NotEnoughResources)),
+            -8 => Some(Err(DealErrorCode::Full)),
+            -10 => Some(Err(DealErrorCode::InvalidArgs)),
+            -11 => Some(Err(DealErrorCode::Tired)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DealErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            DealErrorCode::NotOwner => "you don't have a terminal in the target room",
+            DealErrorCode::NotEnoughResources => "you don't have enough credits or resource units",
+            DealErrorCode::Full => "you cannot execute more than 10 deals during one tick",
+            DealErrorCode::InvalidArgs => "the arguments provided are invalid",
+            DealErrorCode::Tired => "the target terminal is still cooling down",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for DealErrorCode {}
+
+/// Error codes used by [game::market::extend_order](crate::game::market::extend_order).
+///
+/// Screeps API Docs: [Game.market.extendOrder](https://docs.screeps.com/api/#Game.market.extendOrder).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/market.js#L174)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ExtendOrderErrorCode {
+    NotEnoughResources = -6,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for ExtendOrderErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -6 => Some(Err(ExtendOrderErrorCode::NotEnoughResources)),
+            -10 => Some(Err(ExtendOrderErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ExtendOrderErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ExtendOrderErrorCode::NotEnoughResources => "you don't have enough credits to pay a fee",
+            ExtendOrderErrorCode::InvalidArgs => "the arguments provided are invalid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ExtendOrderErrorCode {}

--- a/src/enums/action_error_codes/game_market_error_codes.rs
+++ b/src/enums/action_error_codes/game_market_error_codes.rs
@@ -61,9 +61,7 @@ impl From<MarketCancelOrderErrorCode> for ErrorCode {
         // Safety: MarketCancelOrderErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -133,9 +131,7 @@ impl From<ChangeOrderPriceErrorCode> for ErrorCode {
         // Safety: ChangeOrderPriceErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -208,9 +204,7 @@ impl From<CreateOrderErrorCode> for ErrorCode {
         // Safety: CreateOrderErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -280,9 +274,7 @@ impl From<DealErrorCode> for ErrorCode {
         // Safety: DealErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -347,8 +339,6 @@ impl From<ExtendOrderErrorCode> for ErrorCode {
         // Safety: ExtendOrderErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/mod.rs
+++ b/src/enums/action_error_codes/mod.rs
@@ -161,7 +161,8 @@ pub mod structure_tower {
 
 pub use self::{
     construction_site::*, creep::*, flag::*, game::*, powercreep::*, room::*, room_position::*,
-    spawning::*, structure::*, structure_controller::*, structure_factory::*, structure_lab::*,
-    structure_link::*, structure_nuker::*, structure_observer::*, structure_powerspawn::*,
-    structure_rampart::*, structure_spawn::*, structure_terminal::*, structure_tower::*,
+    shared::*, spawning::*, structure::*, structure_controller::*, structure_factory::*,
+    structure_lab::*, structure_link::*, structure_nuker::*, structure_observer::*,
+    structure_powerspawn::*, structure_rampart::*, structure_spawn::*, structure_terminal::*,
+    structure_tower::*,
 };

--- a/src/enums/action_error_codes/mod.rs
+++ b/src/enums/action_error_codes/mod.rs
@@ -10,6 +10,7 @@ mod game_market_error_codes;
 mod powercreep_error_codes;
 mod room_error_codes;
 mod roomposition_error_codes;
+mod sharedcreep_error_codes;
 mod spawning_error_codes;
 mod structure_error_codes;
 mod structurecontroller_error_codes;
@@ -31,12 +32,10 @@ pub mod construction_site {
 pub mod creep {
     pub use super::creep_error_codes::{
         AttackControllerErrorCode, BuildErrorCode, ClaimControllerErrorCode, CreepAttackErrorCode,
-        CreepCancelOrderErrorCode, CreepDropErrorCode, CreepHealErrorCode,
-        CreepMoveByPathErrorCode, CreepMoveErrorCode, CreepMoveToErrorCode,
-        CreepNotifyWhenAttackedErrorCode, CreepPickupErrorCode, CreepRepairErrorCode,
-        CreepSayErrorCode, CreepSuicideErrorCode, CreepTransferErrorCode, CreepWithdrawErrorCode,
-        DismantleErrorCode, GenerateSafeModeErrorCode, HarvestErrorCode, PullErrorCode,
-        RangedAttackErrorCode, RangedHealErrorCode, RangedMassAttackErrorCode,
+        CreepCancelOrderErrorCode, CreepHealErrorCode, CreepMoveByPathErrorCode,
+        CreepMoveDirectionErrorCode, CreepMovePulledByErrorCode, CreepMoveToErrorCode,
+        CreepRepairErrorCode, DismantleErrorCode, GenerateSafeModeErrorCode, HarvestErrorCode,
+        PullErrorCode, RangedAttackErrorCode, RangedHealErrorCode, RangedMassAttackErrorCode,
         ReserveControllerErrorCode, SignControllerErrorCode, UpgradeControllerErrorCode,
     };
 }
@@ -75,11 +74,9 @@ pub mod game {
 pub mod powercreep {
     pub use super::powercreep_error_codes::{
         DeleteErrorCode, EnableRoomErrorCode, PowerCreepCancelOrderErrorCode,
-        PowerCreepCreateErrorCode, PowerCreepDropErrorCode, PowerCreepMoveByPathErrorCode,
-        PowerCreepMoveErrorCode, PowerCreepMoveToErrorCode, PowerCreepNotifyWhenAttackedErrorCode,
-        PowerCreepPickupErrorCode, PowerCreepSayErrorCode, PowerCreepSuicideErrorCode,
-        PowerCreepTransferErrorCode, PowerCreepWithdrawErrorCode, RenameErrorCode, RenewErrorCode,
-        SpawnErrorCode, UpgradeErrorCode, UsePowerErrorCode,
+        PowerCreepCreateErrorCode, PowerCreepMoveByPathErrorCode, PowerCreepMoveDirectionErrorCode,
+        PowerCreepMoveToErrorCode, RenameErrorCode, RenewErrorCode, SpawnErrorCode,
+        UpgradeErrorCode, UsePowerErrorCode,
     };
 }
 
@@ -92,6 +89,13 @@ pub mod room {
 pub mod room_position {
     pub use super::roomposition_error_codes::{
         RoomPositionCreateConstructionSiteErrorCode, RoomPositionCreateFlagErrorCode,
+    };
+}
+
+pub mod shared {
+    pub use super::sharedcreep_error_codes::{
+        DropErrorCode, NotifyWhenAttackedErrorCode, PickupErrorCode, SayErrorCode,
+        SuicideErrorCode, TransferErrorCode, WithdrawErrorCode,
     };
 }
 

--- a/src/enums/action_error_codes/mod.rs
+++ b/src/enums/action_error_codes/mod.rs
@@ -38,6 +38,9 @@ pub mod creep {
         PullErrorCode, RangedAttackErrorCode, RangedHealErrorCode, RangedMassAttackErrorCode,
         ReserveControllerErrorCode, SignControllerErrorCode, UpgradeControllerErrorCode,
     };
+
+    #[cfg(feature = "seasonal-season-5")]
+    pub use super::creep_error_codes::CreepClaimReactorErrorCode;
 }
 
 pub mod flag {

--- a/src/enums/action_error_codes/mod.rs
+++ b/src/enums/action_error_codes/mod.rs
@@ -11,8 +11,8 @@ mod powercreep_error_codes;
 mod room_error_codes;
 mod roomposition_error_codes;
 mod spawning_error_codes;
-mod structurecontroller_error_codes;
 mod structure_error_codes;
+mod structurecontroller_error_codes;
 mod structurefactory_error_codes;
 mod structurelab_error_codes;
 mod structurelink_error_codes;
@@ -30,21 +30,20 @@ pub mod construction_site {
 
 pub mod creep {
     pub use super::creep_error_codes::{
-        CreepAttackErrorCode, AttackControllerErrorCode, BuildErrorCode,
-        CreepCancelOrderErrorCode, ClaimControllerErrorCode, DismantleErrorCode,
-        CreepDropErrorCode, GenerateSafeModeErrorCode, HarvestErrorCode,
-        CreepHealErrorCode, CreepMoveErrorCode, CreepMoveByPathErrorCode,
-        CreepMoveToErrorCode, CreepNotifyWhenAttackedErrorCode, CreepPickupErrorCode,
-        PullErrorCode, RangedAttackErrorCode, RangedHealErrorCode,
-        RangedMassAttackErrorCode, CreepRepairErrorCode, ReserveControllerErrorCode,
-        CreepSayErrorCode, SignControllerErrorCode, CreepSuicideErrorCode,
-        CreepTransferErrorCode, UpgradeControllerErrorCode, CreepWithdrawErrorCode,
+        AttackControllerErrorCode, BuildErrorCode, ClaimControllerErrorCode, CreepAttackErrorCode,
+        CreepCancelOrderErrorCode, CreepDropErrorCode, CreepHealErrorCode,
+        CreepMoveByPathErrorCode, CreepMoveErrorCode, CreepMoveToErrorCode,
+        CreepNotifyWhenAttackedErrorCode, CreepPickupErrorCode, CreepRepairErrorCode,
+        CreepSayErrorCode, CreepSuicideErrorCode, CreepTransferErrorCode, CreepWithdrawErrorCode,
+        DismantleErrorCode, GenerateSafeModeErrorCode, HarvestErrorCode, PullErrorCode,
+        RangedAttackErrorCode, RangedHealErrorCode, RangedMassAttackErrorCode,
+        ReserveControllerErrorCode, SignControllerErrorCode, UpgradeControllerErrorCode,
     };
 }
 
 pub mod flag {
     pub use super::flag_error_codes::{
-        FlagRemoveErrorCode, SetColorErrorCode, SetPositionErrorCode
+        FlagRemoveErrorCode, SetColorErrorCode, SetPositionErrorCode,
     };
 }
 
@@ -57,43 +56,40 @@ pub mod game {
     #[cfg(feature = "mmo")]
     pub mod cpu {
         pub use super::game_cpu_error_codes::{
-            SetShardLimitsErrorCode, UnlockErrorCode, GeneratePixelErrorCode
+            GeneratePixelErrorCode, SetShardLimitsErrorCode, UnlockErrorCode,
         };
     }
 
     pub mod map {
-        pub use super::game_map_error_codes::{
-            FindExitErrorCode, FindRouteErrorCode
-        };
+        pub use super::game_map_error_codes::{FindExitErrorCode, FindRouteErrorCode};
     }
 
     pub mod market {
         pub use super::game_market_error_codes::{
-            MarketCancelOrderErrorCode, ChangeOrderPriceErrorCode, CreateOrderErrorCode,
-            DealErrorCode, ExtendOrderErrorCode,
+            ChangeOrderPriceErrorCode, CreateOrderErrorCode, DealErrorCode, ExtendOrderErrorCode,
+            MarketCancelOrderErrorCode,
         };
     }
 }
 
 pub mod powercreep {
     pub use super::powercreep_error_codes::{
-        PowerCreepCreateErrorCode, PowerCreepCancelOrderErrorCode, DeleteErrorCode,
-        PowerCreepDropErrorCode, EnableRoomErrorCode, PowerCreepMoveErrorCode,
-        PowerCreepMoveByPathErrorCode, PowerCreepMoveToErrorCode,
-        PowerCreepNotifyWhenAttackedErrorCode, PowerCreepPickupErrorCode, RenameErrorCode,
-        RenewErrorCode, PowerCreepSayErrorCode, SpawnErrorCode, PowerCreepSuicideErrorCode,
-        PowerCreepTransferErrorCode, UpgradeErrorCode, UsePowerErrorCode,
-        PowerCreepWithdrawErrorCode,
+        DeleteErrorCode, EnableRoomErrorCode, PowerCreepCancelOrderErrorCode,
+        PowerCreepCreateErrorCode, PowerCreepDropErrorCode, PowerCreepMoveByPathErrorCode,
+        PowerCreepMoveErrorCode, PowerCreepMoveToErrorCode, PowerCreepNotifyWhenAttackedErrorCode,
+        PowerCreepPickupErrorCode, PowerCreepSayErrorCode, PowerCreepSuicideErrorCode,
+        PowerCreepTransferErrorCode, PowerCreepWithdrawErrorCode, RenameErrorCode, RenewErrorCode,
+        SpawnErrorCode, UpgradeErrorCode, UsePowerErrorCode,
     };
 }
 
 pub mod room {
     pub use super::room_error_codes::{
-        RoomCreateConstructionSiteErrorCode, RoomCreateFlagErrorCode, FindExitToErrorCode,
+        FindExitToErrorCode, RoomCreateConstructionSiteErrorCode, RoomCreateFlagErrorCode,
     };
 }
 
-pub mod room_position{
+pub mod room_position {
     pub use super::roomposition_error_codes::{
         RoomPositionCreateConstructionSiteErrorCode, RoomPositionCreateFlagErrorCode,
     };
@@ -104,7 +100,9 @@ pub mod spawning {
 }
 
 pub mod structure {
-    pub use super::structure_error_codes::{DestroyErrorCode, StructureNotifyWhenAttackedErrorCode};
+    pub use super::structure_error_codes::{
+        DestroyErrorCode, StructureNotifyWhenAttackedErrorCode,
+    };
 }
 
 pub mod structure_controller {
@@ -117,8 +115,7 @@ pub mod structure_factory {
 
 pub mod structure_lab {
     pub use super::structurelab_error_codes::{
-        BoostCreepErrorCode, ReverseReactionErrorCode, RunReactionErrorCode,
-        UnboostCreepErrorCode,
+        BoostCreepErrorCode, ReverseReactionErrorCode, RunReactionErrorCode, UnboostCreepErrorCode,
     };
 }
 
@@ -144,7 +141,7 @@ pub mod structure_rampart {
 
 pub mod structure_spawn {
     pub use super::structurespawn_error_codes::{
-        SpawnCreepErrorCode, RecycleCreepErrorCode, RenewCreepErrorCode,
+        RecycleCreepErrorCode, RenewCreepErrorCode, SpawnCreepErrorCode,
     };
 }
 
@@ -159,24 +156,8 @@ pub mod structure_tower {
 }
 
 pub use self::{
-    construction_site::*,
-    creep::*,
-    flag::*,
-    game::*,
-    powercreep::*,
-    room::*,
-    room_position::*,
-    spawning::*,
-    structure::*,
-    structure_controller::*,
-    structure_factory::*,
-    structure_lab::*,
-    structure_link::*,
-    structure_nuker::*,
-    structure_observer::*,
-    structure_powerspawn::*,
-    structure_rampart::*,
-    structure_spawn::*,
-    structure_terminal::*,
-    structure_tower::*,
+    construction_site::*, creep::*, flag::*, game::*, powercreep::*, room::*, room_position::*,
+    spawning::*, structure::*, structure_controller::*, structure_factory::*, structure_lab::*,
+    structure_link::*, structure_nuker::*, structure_observer::*, structure_powerspawn::*,
+    structure_rampart::*, structure_spawn::*, structure_terminal::*, structure_tower::*,
 };

--- a/src/enums/action_error_codes/mod.rs
+++ b/src/enums/action_error_codes/mod.rs
@@ -1,0 +1,182 @@
+//! This module contains error code enums for individual API actions.
+
+mod constructionsite_error_codes;
+mod creep_error_codes;
+mod flag_error_codes;
+#[cfg(feature = "mmo")]
+mod game_cpu_error_codes;
+mod game_map_error_codes;
+mod game_market_error_codes;
+mod powercreep_error_codes;
+mod room_error_codes;
+mod roomposition_error_codes;
+mod spawning_error_codes;
+mod structurecontroller_error_codes;
+mod structure_error_codes;
+mod structurefactory_error_codes;
+mod structurelab_error_codes;
+mod structurelink_error_codes;
+mod structurenuker_error_codes;
+mod structureobserver_error_codes;
+mod structurepowerspawn_error_codes;
+mod structurerampart_error_codes;
+mod structurespawn_error_codes;
+mod structureterminal_error_codes;
+mod structuretower_error_codes;
+
+pub mod construction_site {
+    pub use super::constructionsite_error_codes::ConstructionSiteRemoveErrorCode;
+}
+
+pub mod creep {
+    pub use super::creep_error_codes::{
+        CreepAttackErrorCode, AttackControllerErrorCode, BuildErrorCode,
+        CreepCancelOrderErrorCode, ClaimControllerErrorCode, DismantleErrorCode,
+        CreepDropErrorCode, GenerateSafeModeErrorCode, HarvestErrorCode,
+        CreepHealErrorCode, CreepMoveErrorCode, CreepMoveByPathErrorCode,
+        CreepMoveToErrorCode, CreepNotifyWhenAttackedErrorCode, CreepPickupErrorCode,
+        PullErrorCode, RangedAttackErrorCode, RangedHealErrorCode,
+        RangedMassAttackErrorCode, CreepRepairErrorCode, ReserveControllerErrorCode,
+        CreepSayErrorCode, SignControllerErrorCode, CreepSuicideErrorCode,
+        CreepTransferErrorCode, UpgradeControllerErrorCode, CreepWithdrawErrorCode,
+    };
+}
+
+pub mod flag {
+    pub use super::flag_error_codes::{
+        FlagRemoveErrorCode, SetColorErrorCode, SetPositionErrorCode
+    };
+}
+
+pub mod game {
+    use super::{game_map_error_codes, game_market_error_codes};
+
+    #[cfg(feature = "mmo")]
+    use super::game_cpu_error_codes;
+
+    #[cfg(feature = "mmo")]
+    pub mod cpu {
+        pub use super::game_cpu_error_codes::{
+            SetShardLimitsErrorCode, UnlockErrorCode, GeneratePixelErrorCode
+        };
+    }
+
+    pub mod map {
+        pub use super::game_map_error_codes::{
+            FindExitErrorCode, FindRouteErrorCode
+        };
+    }
+
+    pub mod market {
+        pub use super::game_market_error_codes::{
+            MarketCancelOrderErrorCode, ChangeOrderPriceErrorCode, CreateOrderErrorCode,
+            DealErrorCode, ExtendOrderErrorCode,
+        };
+    }
+}
+
+pub mod powercreep {
+    pub use super::powercreep_error_codes::{
+        PowerCreepCreateErrorCode, PowerCreepCancelOrderErrorCode, DeleteErrorCode,
+        PowerCreepDropErrorCode, EnableRoomErrorCode, PowerCreepMoveErrorCode,
+        PowerCreepMoveByPathErrorCode, PowerCreepMoveToErrorCode,
+        PowerCreepNotifyWhenAttackedErrorCode, PowerCreepPickupErrorCode, RenameErrorCode,
+        RenewErrorCode, PowerCreepSayErrorCode, SpawnErrorCode, PowerCreepSuicideErrorCode,
+        PowerCreepTransferErrorCode, UpgradeErrorCode, UsePowerErrorCode,
+        PowerCreepWithdrawErrorCode,
+    };
+}
+
+pub mod room {
+    pub use super::room_error_codes::{
+        RoomCreateConstructionSiteErrorCode, RoomCreateFlagErrorCode, FindExitToErrorCode,
+    };
+}
+
+pub mod room_position{
+    pub use super::roomposition_error_codes::{
+        RoomPositionCreateConstructionSiteErrorCode, RoomPositionCreateFlagErrorCode,
+    };
+}
+
+pub mod spawning {
+    pub use super::spawning_error_codes::{CancelErrorCode, SetDirectionsErrorCode};
+}
+
+pub mod structure {
+    pub use super::structure_error_codes::{DestroyErrorCode, StructureNotifyWhenAttackedErrorCode};
+}
+
+pub mod structure_controller {
+    pub use super::structurecontroller_error_codes::{ActivateSafeModeErrorCode, UnclaimErrorCode};
+}
+
+pub mod structure_factory {
+    pub use super::structurefactory_error_codes::ProduceErrorCode;
+}
+
+pub mod structure_lab {
+    pub use super::structurelab_error_codes::{
+        BoostCreepErrorCode, ReverseReactionErrorCode, RunReactionErrorCode,
+        UnboostCreepErrorCode,
+    };
+}
+
+pub mod structure_link {
+    pub use super::structurelink_error_codes::TransferEnergyErrorCode;
+}
+
+pub mod structure_nuker {
+    pub use super::structurenuker_error_codes::LaunchNukeErrorCode;
+}
+
+pub mod structure_observer {
+    pub use super::structureobserver_error_codes::ObserveRoomErrorCode;
+}
+
+pub mod structure_powerspawn {
+    pub use super::structurepowerspawn_error_codes::ProcessPowerErrorCode;
+}
+
+pub mod structure_rampart {
+    pub use super::structurerampart_error_codes::SetPublicErrorCode;
+}
+
+pub mod structure_spawn {
+    pub use super::structurespawn_error_codes::{
+        SpawnCreepErrorCode, RecycleCreepErrorCode, RenewCreepErrorCode,
+    };
+}
+
+pub mod structure_terminal {
+    pub use super::structureterminal_error_codes::SendErrorCode;
+}
+
+pub mod structure_tower {
+    pub use super::structuretower_error_codes::{
+        TowerAttackErrorCode, TowerHealErrorCode, TowerRepairErrorCode,
+    };
+}
+
+pub use self::{
+    construction_site::*,
+    creep::*,
+    flag::*,
+    game::*,
+    powercreep::*,
+    room::*,
+    room_position::*,
+    spawning::*,
+    structure::*,
+    structure_controller::*,
+    structure_factory::*,
+    structure_lab::*,
+    structure_link::*,
+    structure_nuker::*,
+    structure_observer::*,
+    structure_powerspawn::*,
+    structure_rampart::*,
+    structure_spawn::*,
+    structure_terminal::*,
+    structure_tower::*,
+};

--- a/src/enums/action_error_codes/powercreep_error_codes.rs
+++ b/src/enums/action_error_codes/powercreep_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -27,11 +26,11 @@ impl FromReturnCode for PowerCreepCreateErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -60,7 +59,8 @@ impl fmt::Display for PowerCreepCreateErrorCode {
 
 impl Error for PowerCreepCreateErrorCode {}
 
-/// Error codes used by [PowerCreep::cancel_order](crate::PowerCreep::cancel_order).
+/// Error codes used by
+/// [PowerCreep::cancel_order](crate::PowerCreep::cancel_order).
 ///
 /// Screeps API Docs: [PowerCreep.cancelOrder](https://docs.screeps.com/api/#PowerCreep.cancelOrder).
 ///
@@ -80,11 +80,11 @@ impl FromReturnCode for PowerCreepCancelOrderErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -104,7 +104,9 @@ impl fmt::Display for PowerCreepCancelOrderErrorCode {
         let msg: &'static str = match self {
             PowerCreepCancelOrderErrorCode::NotOwner => "you are not the owner of the creep",
             PowerCreepCancelOrderErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepCancelOrderErrorCode::NotFound => "the order with the specified name is not found",
+            PowerCreepCancelOrderErrorCode::NotFound => {
+                "the order with the specified name is not found"
+            }
         };
 
         write!(f, "{}", msg)
@@ -113,7 +115,8 @@ impl fmt::Display for PowerCreepCancelOrderErrorCode {
 
 impl Error for PowerCreepCancelOrderErrorCode {}
 
-/// Error codes used by [AccountPowerCreep::delete](crate::AccountPowerCreep::delete).
+/// Error codes used by
+/// [AccountPowerCreep::delete](crate::AccountPowerCreep::delete).
 ///
 /// Screeps API Docs: [PowerCreep.delete](https://docs.screeps.com/api/#PowerCreep.delete).
 ///
@@ -132,11 +135,11 @@ impl FromReturnCode for DeleteErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -184,11 +187,11 @@ impl FromReturnCode for PowerCreepDropErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -209,8 +212,12 @@ impl fmt::Display for PowerCreepDropErrorCode {
         let msg: &'static str = match self {
             PowerCreepDropErrorCode::NotOwner => "you are not the owner of this creep",
             PowerCreepDropErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepDropErrorCode::NotEnoughResources => "the creep does not have the given amount of energy",
-            PowerCreepDropErrorCode::InvalidArgs => "the resourcetype is not a valid resource_* constants",
+            PowerCreepDropErrorCode::NotEnoughResources => {
+                "the creep does not have the given amount of energy"
+            }
+            PowerCreepDropErrorCode::InvalidArgs => {
+                "the resourcetype is not a valid resource_* constants"
+            }
         };
 
         write!(f, "{}", msg)
@@ -219,7 +226,8 @@ impl fmt::Display for PowerCreepDropErrorCode {
 
 impl Error for PowerCreepDropErrorCode {}
 
-/// Error codes used by [PowerCreep::enable_room](crate::PowerCreep::enable_room).
+/// Error codes used by
+/// [PowerCreep::enable_room](crate::PowerCreep::enable_room).
 ///
 /// Screeps API Docs: [PowerCreep.enableRoom](https://docs.screeps.com/api/#PowerCreep.enableRoom).
 ///
@@ -240,11 +248,11 @@ impl FromReturnCode for EnableRoomErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -297,11 +305,11 @@ impl FromReturnCode for PowerCreepMoveErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -334,7 +342,8 @@ impl fmt::Display for PowerCreepMoveErrorCode {
 
 impl Error for PowerCreepMoveErrorCode {}
 
-/// Error codes used by [PowerCreep::move_by_path](crate::PowerCreep::move_by_path).
+/// Error codes used by
+/// [PowerCreep::move_by_path](crate::PowerCreep::move_by_path).
 ///
 /// Screeps API Docs: [PowerCreep.moveByPath](https://docs.screeps.com/api/#PowerCreep.moveByPath).
 ///
@@ -356,11 +365,11 @@ impl FromReturnCode for PowerCreepMoveByPathErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -382,9 +391,13 @@ impl fmt::Display for PowerCreepMoveByPathErrorCode {
         let msg: &'static str = match self {
             PowerCreepMoveByPathErrorCode::NotOwner => "you are not the owner of this creep",
             PowerCreepMoveByPathErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepMoveByPathErrorCode::NotFound => "the specified path doesn't match the creep's location",
+            PowerCreepMoveByPathErrorCode::NotFound => {
+                "the specified path doesn't match the creep's location"
+            }
             PowerCreepMoveByPathErrorCode::InvalidArgs => "path is not a valid path array",
-            PowerCreepMoveByPathErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+            PowerCreepMoveByPathErrorCode::Tired => {
+                "the fatigue indicator of the creep is non-zero"
+            }
         };
 
         write!(f, "{}", msg)
@@ -416,11 +429,11 @@ impl FromReturnCode for PowerCreepMoveToErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -455,7 +468,8 @@ impl fmt::Display for PowerCreepMoveToErrorCode {
 
 impl Error for PowerCreepMoveToErrorCode {}
 
-/// Error codes used by [PowerCreep::notify_when_attacked](crate::PowerCreep::notify_when_attacked).
+/// Error codes used by
+/// [PowerCreep::notify_when_attacked](crate::PowerCreep::notify_when_attacked).
 ///
 /// Screeps API Docs: [PowerCreep.notifyWhenAttacked](https://docs.screeps.com/api/#PowerCreep.notifyWhenAttacked).
 ///
@@ -475,11 +489,11 @@ impl FromReturnCode for PowerCreepNotifyWhenAttackedErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -497,9 +511,15 @@ impl FromReturnCode for PowerCreepNotifyWhenAttackedErrorCode {
 impl fmt::Display for PowerCreepNotifyWhenAttackedErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            PowerCreepNotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this creep",
-            PowerCreepNotifyWhenAttackedErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepNotifyWhenAttackedErrorCode::InvalidArgs => "enable argument is not a boolean value",
+            PowerCreepNotifyWhenAttackedErrorCode::NotOwner => {
+                "you are not the owner of this creep"
+            }
+            PowerCreepNotifyWhenAttackedErrorCode::Busy => {
+                "the power creep is not spawned in the world"
+            }
+            PowerCreepNotifyWhenAttackedErrorCode::InvalidArgs => {
+                "enable argument is not a boolean value"
+            }
         };
 
         write!(f, "{}", msg)
@@ -530,11 +550,11 @@ impl FromReturnCode for PowerCreepPickupErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -556,7 +576,9 @@ impl fmt::Display for PowerCreepPickupErrorCode {
         let msg: &'static str = match self {
             PowerCreepPickupErrorCode::NotOwner => "you are not the owner of this creep",
             PowerCreepPickupErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepPickupErrorCode::InvalidTarget => "the target is not a valid object to pick up",
+            PowerCreepPickupErrorCode::InvalidTarget => {
+                "the target is not a valid object to pick up"
+            }
             PowerCreepPickupErrorCode::Full => "the creep cannot receive any more resource",
             PowerCreepPickupErrorCode::NotInRange => "the target is too far away",
         };
@@ -567,7 +589,8 @@ impl fmt::Display for PowerCreepPickupErrorCode {
 
 impl Error for PowerCreepPickupErrorCode {}
 
-/// Error codes used by [AccountPowerCreep::rename](crate::AccountPowerCreep::rename).
+/// Error codes used by
+/// [AccountPowerCreep::rename](crate::AccountPowerCreep::rename).
 ///
 /// Screeps API Docs: [PowerCreep.rename](https://docs.screeps.com/api/#PowerCreep.rename).
 ///
@@ -588,11 +611,11 @@ impl FromReturnCode for RenameErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -644,11 +667,11 @@ impl FromReturnCode for RenewErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -698,11 +721,11 @@ impl FromReturnCode for PowerCreepSayErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -729,7 +752,8 @@ impl fmt::Display for PowerCreepSayErrorCode {
 
 impl Error for PowerCreepSayErrorCode {}
 
-/// Error codes used by [AccountPowerCreep::spawn](crate::AccountPowerCreep::spawn).
+/// Error codes used by
+/// [AccountPowerCreep::spawn](crate::AccountPowerCreep::spawn).
 ///
 /// Screeps API Docs: [PowerCreep.spawn](https://docs.screeps.com/api/#PowerCreep.spawn).
 ///
@@ -751,11 +775,11 @@ impl FromReturnCode for SpawnErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -807,11 +831,11 @@ impl FromReturnCode for PowerCreepSuicideErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -862,11 +886,11 @@ impl FromReturnCode for PowerCreepTransferErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -903,7 +927,8 @@ impl fmt::Display for PowerCreepTransferErrorCode {
 
 impl Error for PowerCreepTransferErrorCode {}
 
-/// Error codes used by [AccountPowerCreep::upgrade](crate::AccountPowerCreep::upgrade).
+/// Error codes used by
+/// [AccountPowerCreep::upgrade](crate::AccountPowerCreep::upgrade).
 ///
 /// Screeps API Docs: [PowerCreep.upgrade](https://docs.screeps.com/api/#PowerCreep.upgrade).
 ///
@@ -924,11 +949,11 @@ impl FromReturnCode for UpgradeErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -985,11 +1010,11 @@ impl FromReturnCode for UsePowerErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -1015,7 +1040,9 @@ impl fmt::Display for UsePowerErrorCode {
         let msg: &'static str = match self {
             UsePowerErrorCode::NotOwner => "you are not the owner of the creep",
             UsePowerErrorCode::Busy => "the creep is not spawned in the world",
-            UsePowerErrorCode::NotEnoughResources => "the creep doesn't have enough resources to use the power",
+            UsePowerErrorCode::NotEnoughResources => {
+                "the creep doesn't have enough resources to use the power"
+            }
             UsePowerErrorCode::InvalidTarget => "the specified target is not valid",
             UsePowerErrorCode::Full => "the target has the same active effect of a higher level",
             UsePowerErrorCode::NotInRange => "the specified target is too far away",
@@ -1054,11 +1081,11 @@ impl FromReturnCode for PowerCreepWithdrawErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/powercreep_error_codes.rs
+++ b/src/enums/action_error_codes/powercreep_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/powercreep_error_codes.rs
+++ b/src/enums/action_error_codes/powercreep_error_codes.rs
@@ -1,0 +1,1096 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [PowerCreep::create](crate::PowerCreep::create).
+///
+/// Screeps API Docs: [PowerCreep.create](https://docs.screeps.com/api/#PowerCreep.create).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L395)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepCreateErrorCode {
+    NameExists = -3,
+    NotEnoughResources = -6,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for PowerCreepCreateErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -3 => Some(Err(PowerCreepCreateErrorCode::NameExists)),
+            -6 => Some(Err(PowerCreepCreateErrorCode::NotEnoughResources)),
+            -10 => Some(Err(PowerCreepCreateErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepCreateErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepCreateErrorCode::NameExists => "a power creep with the specified name already exists",
+            PowerCreepCreateErrorCode::NotEnoughResources => "you don't have free power levels in your account",
+            PowerCreepCreateErrorCode::InvalidArgs => "the provided power creep name is exceeds the limit, or the power creep class is invalid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepCreateErrorCode {}
+
+/// Error codes used by [PowerCreep::cancel_order](crate::PowerCreep::cancel_order).
+///
+/// Screeps API Docs: [PowerCreep.cancelOrder](https://docs.screeps.com/api/#PowerCreep.cancelOrder).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L342)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepCancelOrderErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotFound = -5,
+}
+
+impl FromReturnCode for PowerCreepCancelOrderErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepCancelOrderErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepCancelOrderErrorCode::Busy)),
+            -5 => Some(Err(PowerCreepCancelOrderErrorCode::NotFound)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepCancelOrderErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepCancelOrderErrorCode::NotOwner => "you are not the owner of the creep",
+            PowerCreepCancelOrderErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepCancelOrderErrorCode::NotFound => "the order with the specified name is not found",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepCancelOrderErrorCode {}
+
+/// Error codes used by [AccountPowerCreep::delete](crate::AccountPowerCreep::delete).
+///
+/// Screeps API Docs: [PowerCreep.delete](https://docs.screeps.com/api/#PowerCreep.delete).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L204)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum DeleteErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+}
+
+impl FromReturnCode for DeleteErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(DeleteErrorCode::NotOwner)),
+            -4 => Some(Err(DeleteErrorCode::Busy)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DeleteErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            DeleteErrorCode::NotOwner => "you are not the owner of the creep",
+            DeleteErrorCode::Busy => "the power creep is spawned in the world",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for DeleteErrorCode {}
+
+/// Error codes used by [PowerCreep::drop](crate::PowerCreep::drop).
+///
+/// Screeps API Docs: [PowerCreep.drop](https://docs.screeps.com/api/#PowerCreep.drop).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L141)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepDropErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for PowerCreepDropErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepDropErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepDropErrorCode::Busy)),
+            -6 => Some(Err(PowerCreepDropErrorCode::NotEnoughResources)),
+            -10 => Some(Err(PowerCreepDropErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepDropErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepDropErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepDropErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepDropErrorCode::NotEnoughResources => "the creep does not have the given amount of energy",
+            PowerCreepDropErrorCode::InvalidArgs => "the resourcetype is not a valid resource_* constants",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepDropErrorCode {}
+
+/// Error codes used by [PowerCreep::enable_room](crate::PowerCreep::enable_room).
+///
+/// Screeps API Docs: [PowerCreep.enableRoom](https://docs.screeps.com/api/#PowerCreep.enableRoom).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L295)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum EnableRoomErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for EnableRoomErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(EnableRoomErrorCode::NotOwner)),
+            -4 => Some(Err(EnableRoomErrorCode::Busy)),
+            -7 => Some(Err(EnableRoomErrorCode::InvalidTarget)),
+            -9 => Some(Err(EnableRoomErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for EnableRoomErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            EnableRoomErrorCode::NotOwner => "you are not the owner of this creep",
+            EnableRoomErrorCode::Busy => "the power creep is not spawned in the world",
+            EnableRoomErrorCode::InvalidTarget => "the target is not a controller structure",
+            EnableRoomErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for EnableRoomErrorCode {}
+
+/// Error codes used by [PowerCreep::move](crate::PowerCreep::move).
+///
+/// Screeps API Docs: [PowerCreep.move](https://docs.screeps.com/api/#PowerCreep.move).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L106)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepMoveErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    Tired = -11,
+}
+
+impl FromReturnCode for PowerCreepMoveErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepMoveErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepMoveErrorCode::Busy)),
+            -9 => Some(Err(PowerCreepMoveErrorCode::NotInRange)),
+            -10 => Some(Err(PowerCreepMoveErrorCode::InvalidArgs)),
+            -11 => Some(Err(PowerCreepMoveErrorCode::Tired)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepMoveErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepMoveErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepMoveErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepMoveErrorCode::NotInRange => "the target creep is too far away",
+            PowerCreepMoveErrorCode::InvalidArgs => "the provided direction is incorrect",
+            PowerCreepMoveErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepMoveErrorCode {}
+
+/// Error codes used by [PowerCreep::move_by_path](crate::PowerCreep::move_by_path).
+///
+/// Screeps API Docs: [PowerCreep.moveByPath](https://docs.screeps.com/api/#PowerCreep.moveByPath).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L120)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepMoveByPathErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotFound = -5,
+    InvalidArgs = -10,
+    Tired = -11,
+}
+
+impl FromReturnCode for PowerCreepMoveByPathErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepMoveByPathErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepMoveByPathErrorCode::Busy)),
+            -5 => Some(Err(PowerCreepMoveByPathErrorCode::NotFound)),
+            -10 => Some(Err(PowerCreepMoveByPathErrorCode::InvalidArgs)),
+            -11 => Some(Err(PowerCreepMoveByPathErrorCode::Tired)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepMoveByPathErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepMoveByPathErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepMoveByPathErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepMoveByPathErrorCode::NotFound => "the specified path doesn't match the creep's location",
+            PowerCreepMoveByPathErrorCode::InvalidArgs => "path is not a valid path array",
+            PowerCreepMoveByPathErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepMoveByPathErrorCode {}
+
+/// Error codes used by [PowerCreep::move_to](crate::PowerCreep::move_to).
+///
+/// Screeps API Docs: [PowerCreep.moveTo](https://docs.screeps.com/api/#PowerCreep.moveTo).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L113)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepMoveToErrorCode {
+    NotOwner = -1,
+    NoPath = -2,
+    Busy = -4,
+    NotFound = -5,
+    InvalidTarget = -7,
+    Tired = -11,
+}
+
+impl FromReturnCode for PowerCreepMoveToErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepMoveToErrorCode::NotOwner)),
+            -2 => Some(Err(PowerCreepMoveToErrorCode::NoPath)),
+            -4 => Some(Err(PowerCreepMoveToErrorCode::Busy)),
+            -5 => Some(Err(PowerCreepMoveToErrorCode::NotFound)),
+            -7 => Some(Err(PowerCreepMoveToErrorCode::InvalidTarget)),
+            -11 => Some(Err(PowerCreepMoveToErrorCode::Tired)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepMoveToErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepMoveToErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepMoveToErrorCode::NoPath => "no path to the target could be found",
+            PowerCreepMoveToErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepMoveToErrorCode::NotFound => "the creep has no memorized path to reuse",
+            PowerCreepMoveToErrorCode::InvalidTarget => "the target provided is invalid",
+            PowerCreepMoveToErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepMoveToErrorCode {}
+
+/// Error codes used by [PowerCreep::notify_when_attacked](crate::PowerCreep::notify_when_attacked).
+///
+/// Screeps API Docs: [PowerCreep.notifyWhenAttacked](https://docs.screeps.com/api/#PowerCreep.notifyWhenAttacked).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L375)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepNotifyWhenAttackedErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for PowerCreepNotifyWhenAttackedErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepNotifyWhenAttackedErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepNotifyWhenAttackedErrorCode::Busy)),
+            -10 => Some(Err(PowerCreepNotifyWhenAttackedErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepNotifyWhenAttackedErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepNotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepNotifyWhenAttackedErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepNotifyWhenAttackedErrorCode::InvalidArgs => "enable argument is not a boolean value",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepNotifyWhenAttackedErrorCode {}
+
+/// Error codes used by [PowerCreep::pickup](crate::PowerCreep::pickup).
+///
+/// Screeps API Docs: [PowerCreep.pickup](https://docs.screeps.com/api/#PowerCreep.pickup).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L148)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepPickupErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for PowerCreepPickupErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepPickupErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepPickupErrorCode::Busy)),
+            -7 => Some(Err(PowerCreepPickupErrorCode::InvalidTarget)),
+            -8 => Some(Err(PowerCreepPickupErrorCode::Full)),
+            -9 => Some(Err(PowerCreepPickupErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepPickupErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepPickupErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepPickupErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepPickupErrorCode::InvalidTarget => "the target is not a valid object to pick up",
+            PowerCreepPickupErrorCode::Full => "the creep cannot receive any more resource",
+            PowerCreepPickupErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepPickupErrorCode {}
+
+/// Error codes used by [AccountPowerCreep::rename](crate::AccountPowerCreep::rename).
+///
+/// Screeps API Docs: [PowerCreep.rename](https://docs.screeps.com/api/#PowerCreep.rename).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L356)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RenameErrorCode {
+    NotOwner = -1,
+    NameExists = -3,
+    Busy = -4,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for RenameErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RenameErrorCode::NotOwner)),
+            -3 => Some(Err(RenameErrorCode::NameExists)),
+            -4 => Some(Err(RenameErrorCode::Busy)),
+            -10 => Some(Err(RenameErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RenameErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RenameErrorCode::NotOwner => "you are not the owner of the creep",
+            RenameErrorCode::NameExists => "a power creep with the specified name already exists",
+            RenameErrorCode::Busy => "the power creep is spawned in the world",
+            RenameErrorCode::InvalidArgs => "the provided power creep name is exceeds the limit",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RenameErrorCode {}
+
+/// Error codes used by [PowerCreep::renew](crate::PowerCreep::renew).
+///
+/// Screeps API Docs: [PowerCreep.renew](https://docs.screeps.com/api/#PowerCreep.renew).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L319)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RenewErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for RenewErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RenewErrorCode::NotOwner)),
+            -4 => Some(Err(RenewErrorCode::Busy)),
+            -7 => Some(Err(RenewErrorCode::InvalidTarget)),
+            -9 => Some(Err(RenewErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RenewErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RenewErrorCode::NotOwner => "you are not the owner of this creep",
+            RenewErrorCode::Busy => "the power creep is not spawned in the world",
+            RenewErrorCode::InvalidTarget => "the target is not a valid power bank object",
+            RenewErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RenewErrorCode {}
+
+/// Error codes used by [PowerCreep::say](crate::PowerCreep::say).
+///
+/// Screeps API Docs: [PowerCreep.say](https://docs.screeps.com/api/#PowerCreep.say).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L155)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepSayErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+}
+
+impl FromReturnCode for PowerCreepSayErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepSayErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepSayErrorCode::Busy)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepSayErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepSayErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepSayErrorCode::Busy => "the power creep is not spawned in the world",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepSayErrorCode {}
+
+/// Error codes used by [AccountPowerCreep::spawn](crate::AccountPowerCreep::spawn).
+///
+/// Screeps API Docs: [PowerCreep.spawn](https://docs.screeps.com/api/#PowerCreep.spawn).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L162)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SpawnErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for SpawnErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(SpawnErrorCode::NotOwner)),
+            -4 => Some(Err(SpawnErrorCode::Busy)),
+            -7 => Some(Err(SpawnErrorCode::InvalidTarget)),
+            -11 => Some(Err(SpawnErrorCode::Tired)),
+            -14 => Some(Err(SpawnErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SpawnErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SpawnErrorCode::NotOwner => "you are not the owner of the creep or the spawn",
+            SpawnErrorCode::Busy => "the power creep is already spawned in the world",
+            SpawnErrorCode::InvalidTarget => "the specified object is not a power spawn",
+            SpawnErrorCode::Tired => "the power creep cannot be spawned because of the cooldown",
+            SpawnErrorCode::RclNotEnough => "room controller level insufficient to use the spawn",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SpawnErrorCode {}
+
+/// Error codes used by [PowerCreep::suicide](crate::PowerCreep::suicide).
+///
+/// Screeps API Docs: [PowerCreep.suicide](https://docs.screeps.com/api/#PowerCreep.suicide).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L191)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepSuicideErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+}
+
+impl FromReturnCode for PowerCreepSuicideErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepSuicideErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepSuicideErrorCode::Busy)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepSuicideErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepSuicideErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepSuicideErrorCode::Busy => "the power creep is not spawned in the world",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepSuicideErrorCode {}
+
+/// Error codes used by [PowerCreep::transfer](crate::PowerCreep::transfer).
+///
+/// Screeps API Docs: [PowerCreep.transfer](https://docs.screeps.com/api/#PowerCreep.transfer).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L127)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepTransferErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for PowerCreepTransferErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepTransferErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepTransferErrorCode::Busy)),
+            -6 => Some(Err(PowerCreepTransferErrorCode::NotEnoughResources)),
+            -7 => Some(Err(PowerCreepTransferErrorCode::InvalidTarget)),
+            -8 => Some(Err(PowerCreepTransferErrorCode::Full)),
+            -9 => Some(Err(PowerCreepTransferErrorCode::NotInRange)),
+            -10 => Some(Err(PowerCreepTransferErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepTransferErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepTransferErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepTransferErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepTransferErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
+            PowerCreepTransferErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
+            PowerCreepTransferErrorCode::Full => "the target cannot receive any more resources",
+            PowerCreepTransferErrorCode::NotInRange => "the target is too far away",
+            PowerCreepTransferErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepTransferErrorCode {}
+
+/// Error codes used by [AccountPowerCreep::upgrade](crate::AccountPowerCreep::upgrade).
+///
+/// Screeps API Docs: [PowerCreep.upgrade](https://docs.screeps.com/api/#PowerCreep.upgrade).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L217)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum UpgradeErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    Full = -8,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for UpgradeErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(UpgradeErrorCode::NotOwner)),
+            -6 => Some(Err(UpgradeErrorCode::NotEnoughResources)),
+            -8 => Some(Err(UpgradeErrorCode::Full)),
+            -10 => Some(Err(UpgradeErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UpgradeErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            UpgradeErrorCode::NotOwner => "you are not the owner of the creep",
+            UpgradeErrorCode::NotEnoughResources => "you account power level is not enough",
+            UpgradeErrorCode::Full => "the specified power cannot be upgraded on this creep's level, or the creep reached the maximum level",
+            UpgradeErrorCode::InvalidArgs => "the specified power id is not valid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for UpgradeErrorCode {}
+
+/// Error codes used by [PowerCreep::use_power](crate::PowerCreep::use_power).
+///
+/// Screeps API Docs: [PowerCreep.usePower](https://docs.screeps.com/api/#PowerCreep.usePower).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L246)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum UsePowerErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    Tired = -11,
+    NoBodypart = -12,
+}
+
+impl FromReturnCode for UsePowerErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(UsePowerErrorCode::NotOwner)),
+            -4 => Some(Err(UsePowerErrorCode::Busy)),
+            -6 => Some(Err(UsePowerErrorCode::NotEnoughResources)),
+            -7 => Some(Err(UsePowerErrorCode::InvalidTarget)),
+            -8 => Some(Err(UsePowerErrorCode::Full)),
+            -9 => Some(Err(UsePowerErrorCode::NotInRange)),
+            -10 => Some(Err(UsePowerErrorCode::InvalidArgs)),
+            -11 => Some(Err(UsePowerErrorCode::Tired)),
+            -12 => Some(Err(UsePowerErrorCode::NoBodypart)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UsePowerErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            UsePowerErrorCode::NotOwner => "you are not the owner of the creep",
+            UsePowerErrorCode::Busy => "the creep is not spawned in the world",
+            UsePowerErrorCode::NotEnoughResources => "the creep doesn't have enough resources to use the power",
+            UsePowerErrorCode::InvalidTarget => "the specified target is not valid",
+            UsePowerErrorCode::Full => "the target has the same active effect of a higher level",
+            UsePowerErrorCode::NotInRange => "the specified target is too far away",
+            UsePowerErrorCode::InvalidArgs => "using powers is not enabled on the room controller",
+            UsePowerErrorCode::Tired => "the power ability is still on cooldown",
+            UsePowerErrorCode::NoBodypart => "the creep doesn't have the specified power ability",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for UsePowerErrorCode {}
+
+/// Error codes used by [PowerCreep::withdraw](crate::PowerCreep::withdraw).
+///
+/// Screeps API Docs: [PowerCreep.withdraw](https://docs.screeps.com/api/#PowerCreep.withdraw).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L134)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PowerCreepWithdrawErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for PowerCreepWithdrawErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PowerCreepWithdrawErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepWithdrawErrorCode::Busy)),
+            -6 => Some(Err(PowerCreepWithdrawErrorCode::NotEnoughResources)),
+            -7 => Some(Err(PowerCreepWithdrawErrorCode::InvalidTarget)),
+            -8 => Some(Err(PowerCreepWithdrawErrorCode::Full)),
+            -9 => Some(Err(PowerCreepWithdrawErrorCode::NotInRange)),
+            -10 => Some(Err(PowerCreepWithdrawErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PowerCreepWithdrawErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            PowerCreepWithdrawErrorCode::NotOwner => "you are not the owner of this creep, or there is a hostile rampart on top of the target",
+            PowerCreepWithdrawErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepWithdrawErrorCode::NotEnoughResources => "the target does not have the given amount of resources",
+            PowerCreepWithdrawErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
+            PowerCreepWithdrawErrorCode::Full => "the creep's carry is full",
+            PowerCreepWithdrawErrorCode::NotInRange => "the target is too far away",
+            PowerCreepWithdrawErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PowerCreepWithdrawErrorCode {}

--- a/src/enums/action_error_codes/powercreep_error_codes.rs
+++ b/src/enums/action_error_codes/powercreep_error_codes.rs
@@ -3,11 +3,11 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by [PowerCreep::create](crate::PowerCreep::create).
 ///
-/// Screeps API Docs: [PowerCreep.create](https://docs.screeps.com/api/#PowerCreep.create).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.create).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L395)
 #[derive(
@@ -58,10 +58,24 @@ impl fmt::Display for PowerCreepCreateErrorCode {
 
 impl Error for PowerCreepCreateErrorCode {}
 
+impl From<PowerCreepCreateErrorCode> for ErrorCode {
+    fn from(value: PowerCreepCreateErrorCode) -> Self {
+        // Safety: PowerCreepCreateErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PowerCreepCreateErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [PowerCreep::cancel_order](crate::PowerCreep::cancel_order).
 ///
-/// Screeps API Docs: [PowerCreep.cancelOrder](https://docs.screeps.com/api/#PowerCreep.cancelOrder).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.cancelOrder).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L342)
 #[derive(
@@ -114,10 +128,24 @@ impl fmt::Display for PowerCreepCancelOrderErrorCode {
 
 impl Error for PowerCreepCancelOrderErrorCode {}
 
+impl From<PowerCreepCancelOrderErrorCode> for ErrorCode {
+    fn from(value: PowerCreepCancelOrderErrorCode) -> Self {
+        // Safety: PowerCreepCancelOrderErrorCode is repr(i8), so we can cast it to get
+        // the discriminant value, which will match the raw return code value that
+        // ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PowerCreepCancelOrderErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [AccountPowerCreep::delete](crate::AccountPowerCreep::delete).
 ///
-/// Screeps API Docs: [PowerCreep.delete](https://docs.screeps.com/api/#PowerCreep.delete).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.delete).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L204)
 #[derive(
@@ -165,70 +193,24 @@ impl fmt::Display for DeleteErrorCode {
 
 impl Error for DeleteErrorCode {}
 
-/// Error codes used by [PowerCreep::drop](crate::PowerCreep::drop).
-///
-/// Screeps API Docs: [PowerCreep.drop](https://docs.screeps.com/api/#PowerCreep.drop).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L141)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum PowerCreepDropErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    NotEnoughResources = -6,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for PowerCreepDropErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepDropErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepDropErrorCode::Busy)),
-            -6 => Some(Err(PowerCreepDropErrorCode::NotEnoughResources)),
-            -10 => Some(Err(PowerCreepDropErrorCode::InvalidArgs)),
-            _ => None,
-        }
+impl From<DeleteErrorCode> for ErrorCode {
+    fn from(value: DeleteErrorCode) -> Self {
+        // Safety: DeleteErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: DeleteErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for PowerCreepDropErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            PowerCreepDropErrorCode::NotOwner => "you are not the owner of this creep",
-            PowerCreepDropErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepDropErrorCode::NotEnoughResources => {
-                "the creep does not have the given amount of energy"
-            }
-            PowerCreepDropErrorCode::InvalidArgs => {
-                "the resourcetype is not a valid resource_* constants"
-            }
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for PowerCreepDropErrorCode {}
 
 /// Error codes used by
 /// [PowerCreep::enable_room](crate::PowerCreep::enable_room).
 ///
-/// Screeps API Docs: [PowerCreep.enableRoom](https://docs.screeps.com/api/#PowerCreep.enableRoom).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.enableRoom).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L295)
 #[derive(
@@ -282,16 +264,31 @@ impl fmt::Display for EnableRoomErrorCode {
 
 impl Error for EnableRoomErrorCode {}
 
-/// Error codes used by [PowerCreep::move](crate::PowerCreep::move).
+impl From<EnableRoomErrorCode> for ErrorCode {
+    fn from(value: EnableRoomErrorCode) -> Self {
+        // Safety: EnableRoomErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: EnableRoomErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by
+/// [PowerCreep::move_direction](crate::PowerCreep::move_direction).
 ///
-/// Screeps API Docs: [PowerCreep.move](https://docs.screeps.com/api/#PowerCreep.move).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.move).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L106)
 #[derive(
     Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
 )]
 #[repr(i8)]
-pub enum PowerCreepMoveErrorCode {
+pub enum PowerCreepMoveDirectionErrorCode {
     NotOwner = -1,
     Busy = -4,
     NotInRange = -9,
@@ -299,7 +296,7 @@ pub enum PowerCreepMoveErrorCode {
     Tired = -11,
 }
 
-impl FromReturnCode for PowerCreepMoveErrorCode {
+impl FromReturnCode for PowerCreepMoveDirectionErrorCode {
     type Error = Self;
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
@@ -315,36 +312,52 @@ impl FromReturnCode for PowerCreepMoveErrorCode {
     fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
         match val {
             0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepMoveErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepMoveErrorCode::Busy)),
-            -9 => Some(Err(PowerCreepMoveErrorCode::NotInRange)),
-            -10 => Some(Err(PowerCreepMoveErrorCode::InvalidArgs)),
-            -11 => Some(Err(PowerCreepMoveErrorCode::Tired)),
+            -1 => Some(Err(PowerCreepMoveDirectionErrorCode::NotOwner)),
+            -4 => Some(Err(PowerCreepMoveDirectionErrorCode::Busy)),
+            -9 => Some(Err(PowerCreepMoveDirectionErrorCode::NotInRange)),
+            -10 => Some(Err(PowerCreepMoveDirectionErrorCode::InvalidArgs)),
+            -11 => Some(Err(PowerCreepMoveDirectionErrorCode::Tired)),
             _ => None,
         }
     }
 }
 
-impl fmt::Display for PowerCreepMoveErrorCode {
+impl fmt::Display for PowerCreepMoveDirectionErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            PowerCreepMoveErrorCode::NotOwner => "you are not the owner of this creep",
-            PowerCreepMoveErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepMoveErrorCode::NotInRange => "the target creep is too far away",
-            PowerCreepMoveErrorCode::InvalidArgs => "the provided direction is incorrect",
-            PowerCreepMoveErrorCode::Tired => "the fatigue indicator of the creep is non-zero",
+            PowerCreepMoveDirectionErrorCode::NotOwner => "you are not the owner of this creep",
+            PowerCreepMoveDirectionErrorCode::Busy => "the power creep is not spawned in the world",
+            PowerCreepMoveDirectionErrorCode::NotInRange => "the target creep is too far away",
+            PowerCreepMoveDirectionErrorCode::InvalidArgs => "the provided direction is incorrect",
+            PowerCreepMoveDirectionErrorCode::Tired => {
+                "the fatigue indicator of the creep is non-zero"
+            }
         };
 
         write!(f, "{}", msg)
     }
 }
 
-impl Error for PowerCreepMoveErrorCode {}
+impl Error for PowerCreepMoveDirectionErrorCode {}
+
+impl From<PowerCreepMoveDirectionErrorCode> for ErrorCode {
+    fn from(value: PowerCreepMoveDirectionErrorCode) -> Self {
+        // Safety: PowerCreepMoveDirectionErrorCode is repr(i8), so we can cast it to
+        // get the discriminant value, which will match the raw return code value that
+        // ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PowerCreepMoveDirectionErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
 
 /// Error codes used by
 /// [PowerCreep::move_by_path](crate::PowerCreep::move_by_path).
 ///
-/// Screeps API Docs: [PowerCreep.moveByPath](https://docs.screeps.com/api/#PowerCreep.moveByPath).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.moveByPath).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L120)
 #[derive(
@@ -405,9 +418,23 @@ impl fmt::Display for PowerCreepMoveByPathErrorCode {
 
 impl Error for PowerCreepMoveByPathErrorCode {}
 
+impl From<PowerCreepMoveByPathErrorCode> for ErrorCode {
+    fn from(value: PowerCreepMoveByPathErrorCode) -> Self {
+        // Safety: PowerCreepMoveByPathErrorCode is repr(i8), so we can cast it to get
+        // the discriminant value, which will match the raw return code value that
+        // ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PowerCreepMoveByPathErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [PowerCreep::move_to](crate::PowerCreep::move_to).
 ///
-/// Screeps API Docs: [PowerCreep.moveTo](https://docs.screeps.com/api/#PowerCreep.moveTo).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.moveTo).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L113)
 #[derive(
@@ -467,131 +494,24 @@ impl fmt::Display for PowerCreepMoveToErrorCode {
 
 impl Error for PowerCreepMoveToErrorCode {}
 
-/// Error codes used by
-/// [PowerCreep::notify_when_attacked](crate::PowerCreep::notify_when_attacked).
-///
-/// Screeps API Docs: [PowerCreep.notifyWhenAttacked](https://docs.screeps.com/api/#PowerCreep.notifyWhenAttacked).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L375)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum PowerCreepNotifyWhenAttackedErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for PowerCreepNotifyWhenAttackedErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepNotifyWhenAttackedErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepNotifyWhenAttackedErrorCode::Busy)),
-            -10 => Some(Err(PowerCreepNotifyWhenAttackedErrorCode::InvalidArgs)),
-            _ => None,
-        }
+impl From<PowerCreepMoveToErrorCode> for ErrorCode {
+    fn from(value: PowerCreepMoveToErrorCode) -> Self {
+        // Safety: PowerCreepMoveToErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PowerCreepMoveToErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for PowerCreepNotifyWhenAttackedErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            PowerCreepNotifyWhenAttackedErrorCode::NotOwner => {
-                "you are not the owner of this creep"
-            }
-            PowerCreepNotifyWhenAttackedErrorCode::Busy => {
-                "the power creep is not spawned in the world"
-            }
-            PowerCreepNotifyWhenAttackedErrorCode::InvalidArgs => {
-                "enable argument is not a boolean value"
-            }
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for PowerCreepNotifyWhenAttackedErrorCode {}
-
-/// Error codes used by [PowerCreep::pickup](crate::PowerCreep::pickup).
-///
-/// Screeps API Docs: [PowerCreep.pickup](https://docs.screeps.com/api/#PowerCreep.pickup).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L148)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum PowerCreepPickupErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    InvalidTarget = -7,
-    Full = -8,
-    NotInRange = -9,
-}
-
-impl FromReturnCode for PowerCreepPickupErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepPickupErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepPickupErrorCode::Busy)),
-            -7 => Some(Err(PowerCreepPickupErrorCode::InvalidTarget)),
-            -8 => Some(Err(PowerCreepPickupErrorCode::Full)),
-            -9 => Some(Err(PowerCreepPickupErrorCode::NotInRange)),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for PowerCreepPickupErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            PowerCreepPickupErrorCode::NotOwner => "you are not the owner of this creep",
-            PowerCreepPickupErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepPickupErrorCode::InvalidTarget => {
-                "the target is not a valid object to pick up"
-            }
-            PowerCreepPickupErrorCode::Full => "the creep cannot receive any more resource",
-            PowerCreepPickupErrorCode::NotInRange => "the target is too far away",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for PowerCreepPickupErrorCode {}
 
 /// Error codes used by
 /// [AccountPowerCreep::rename](crate::AccountPowerCreep::rename).
 ///
-/// Screeps API Docs: [PowerCreep.rename](https://docs.screeps.com/api/#PowerCreep.rename).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.rename).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L356)
 #[derive(
@@ -645,9 +565,23 @@ impl fmt::Display for RenameErrorCode {
 
 impl Error for RenameErrorCode {}
 
+impl From<RenameErrorCode> for ErrorCode {
+    fn from(value: RenameErrorCode) -> Self {
+        // Safety: RenameErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RenameErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [PowerCreep::renew](crate::PowerCreep::renew).
 ///
-/// Screeps API Docs: [PowerCreep.renew](https://docs.screeps.com/api/#PowerCreep.renew).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.renew).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L319)
 #[derive(
@@ -701,60 +635,23 @@ impl fmt::Display for RenewErrorCode {
 
 impl Error for RenewErrorCode {}
 
-/// Error codes used by [PowerCreep::say](crate::PowerCreep::say).
-///
-/// Screeps API Docs: [PowerCreep.say](https://docs.screeps.com/api/#PowerCreep.say).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L155)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum PowerCreepSayErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-}
-
-impl FromReturnCode for PowerCreepSayErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepSayErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepSayErrorCode::Busy)),
-            _ => None,
-        }
+impl From<RenewErrorCode> for ErrorCode {
+    fn from(value: RenewErrorCode) -> Self {
+        // Safety: RenewErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RenewErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for PowerCreepSayErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            PowerCreepSayErrorCode::NotOwner => "you are not the owner of this creep",
-            PowerCreepSayErrorCode::Busy => "the power creep is not spawned in the world",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for PowerCreepSayErrorCode {}
 
 /// Error codes used by
 /// [AccountPowerCreep::spawn](crate::AccountPowerCreep::spawn).
 ///
-/// Screeps API Docs: [PowerCreep.spawn](https://docs.screeps.com/api/#PowerCreep.spawn).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.spawn).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L162)
 #[derive(
@@ -811,125 +708,23 @@ impl fmt::Display for SpawnErrorCode {
 
 impl Error for SpawnErrorCode {}
 
-/// Error codes used by [PowerCreep::suicide](crate::PowerCreep::suicide).
-///
-/// Screeps API Docs: [PowerCreep.suicide](https://docs.screeps.com/api/#PowerCreep.suicide).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L191)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum PowerCreepSuicideErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-}
-
-impl FromReturnCode for PowerCreepSuicideErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepSuicideErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepSuicideErrorCode::Busy)),
-            _ => None,
-        }
+impl From<SpawnErrorCode> for ErrorCode {
+    fn from(value: SpawnErrorCode) -> Self {
+        // Safety: SpawnErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SpawnErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for PowerCreepSuicideErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            PowerCreepSuicideErrorCode::NotOwner => "you are not the owner of this creep",
-            PowerCreepSuicideErrorCode::Busy => "the power creep is not spawned in the world",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for PowerCreepSuicideErrorCode {}
-
-/// Error codes used by [PowerCreep::transfer](crate::PowerCreep::transfer).
-///
-/// Screeps API Docs: [PowerCreep.transfer](https://docs.screeps.com/api/#PowerCreep.transfer).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L127)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum PowerCreepTransferErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    NotEnoughResources = -6,
-    InvalidTarget = -7,
-    Full = -8,
-    NotInRange = -9,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for PowerCreepTransferErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepTransferErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepTransferErrorCode::Busy)),
-            -6 => Some(Err(PowerCreepTransferErrorCode::NotEnoughResources)),
-            -7 => Some(Err(PowerCreepTransferErrorCode::InvalidTarget)),
-            -8 => Some(Err(PowerCreepTransferErrorCode::Full)),
-            -9 => Some(Err(PowerCreepTransferErrorCode::NotInRange)),
-            -10 => Some(Err(PowerCreepTransferErrorCode::InvalidArgs)),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for PowerCreepTransferErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            PowerCreepTransferErrorCode::NotOwner => "you are not the owner of this creep",
-            PowerCreepTransferErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepTransferErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
-            PowerCreepTransferErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
-            PowerCreepTransferErrorCode::Full => "the target cannot receive any more resources",
-            PowerCreepTransferErrorCode::NotInRange => "the target is too far away",
-            PowerCreepTransferErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for PowerCreepTransferErrorCode {}
 
 /// Error codes used by
 /// [AccountPowerCreep::upgrade](crate::AccountPowerCreep::upgrade).
 ///
-/// Screeps API Docs: [PowerCreep.upgrade](https://docs.screeps.com/api/#PowerCreep.upgrade).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.upgrade).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L217)
 #[derive(
@@ -983,9 +778,23 @@ impl fmt::Display for UpgradeErrorCode {
 
 impl Error for UpgradeErrorCode {}
 
+impl From<UpgradeErrorCode> for ErrorCode {
+    fn from(value: UpgradeErrorCode) -> Self {
+        // Safety: UpgradeErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: UpgradeErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [PowerCreep::use_power](crate::PowerCreep::use_power).
 ///
-/// Screeps API Docs: [PowerCreep.usePower](https://docs.screeps.com/api/#PowerCreep.usePower).
+/// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.usePower).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L246)
 #[derive(
@@ -1056,67 +865,16 @@ impl fmt::Display for UsePowerErrorCode {
 
 impl Error for UsePowerErrorCode {}
 
-/// Error codes used by [PowerCreep::withdraw](crate::PowerCreep::withdraw).
-///
-/// Screeps API Docs: [PowerCreep.withdraw](https://docs.screeps.com/api/#PowerCreep.withdraw).
-///
-/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/power-creeps.js#L134)
-#[derive(
-    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
-)]
-#[repr(i8)]
-pub enum PowerCreepWithdrawErrorCode {
-    NotOwner = -1,
-    Busy = -4,
-    NotEnoughResources = -6,
-    InvalidTarget = -7,
-    Full = -8,
-    NotInRange = -9,
-    InvalidArgs = -10,
-}
-
-impl FromReturnCode for PowerCreepWithdrawErrorCode {
-    type Error = Self;
-
-    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
-        let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature = "unsafe-return-conversion")]
-        unsafe {
-            maybe_result.unwrap_unchecked()
-        }
-        #[cfg(not(feature = "unsafe-return-conversion"))]
-        maybe_result.unwrap()
-    }
-
-    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
-        match val {
-            0 => Some(Ok(())),
-            -1 => Some(Err(PowerCreepWithdrawErrorCode::NotOwner)),
-            -4 => Some(Err(PowerCreepWithdrawErrorCode::Busy)),
-            -6 => Some(Err(PowerCreepWithdrawErrorCode::NotEnoughResources)),
-            -7 => Some(Err(PowerCreepWithdrawErrorCode::InvalidTarget)),
-            -8 => Some(Err(PowerCreepWithdrawErrorCode::Full)),
-            -9 => Some(Err(PowerCreepWithdrawErrorCode::NotInRange)),
-            -10 => Some(Err(PowerCreepWithdrawErrorCode::InvalidArgs)),
-            _ => None,
-        }
+impl From<UsePowerErrorCode> for ErrorCode {
+    fn from(value: UsePowerErrorCode) -> Self {
+        // Safety: UsePowerErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: UsePowerErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
     }
 }
-
-impl fmt::Display for PowerCreepWithdrawErrorCode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg: &'static str = match self {
-            PowerCreepWithdrawErrorCode::NotOwner => "you are not the owner of this creep, or there is a hostile rampart on top of the target",
-            PowerCreepWithdrawErrorCode::Busy => "the power creep is not spawned in the world",
-            PowerCreepWithdrawErrorCode::NotEnoughResources => "the target does not have the given amount of resources",
-            PowerCreepWithdrawErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
-            PowerCreepWithdrawErrorCode::Full => "the creep's carry is full",
-            PowerCreepWithdrawErrorCode::NotInRange => "the target is too far away",
-            PowerCreepWithdrawErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
-        };
-
-        write!(f, "{}", msg)
-    }
-}
-
-impl Error for PowerCreepWithdrawErrorCode {}

--- a/src/enums/action_error_codes/powercreep_error_codes.rs
+++ b/src/enums/action_error_codes/powercreep_error_codes.rs
@@ -66,9 +66,7 @@ impl From<PowerCreepCreateErrorCode> for ErrorCode {
         // Safety: PowerCreepCreateErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -136,9 +134,7 @@ impl From<PowerCreepCancelOrderErrorCode> for ErrorCode {
         // Safety: PowerCreepCancelOrderErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -201,9 +197,7 @@ impl From<DeleteErrorCode> for ErrorCode {
         // Safety: DeleteErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -272,9 +266,7 @@ impl From<EnableRoomErrorCode> for ErrorCode {
         // Safety: EnableRoomErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -348,9 +340,7 @@ impl From<PowerCreepMoveDirectionErrorCode> for ErrorCode {
         // Safety: PowerCreepMoveDirectionErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -426,9 +416,7 @@ impl From<PowerCreepMoveByPathErrorCode> for ErrorCode {
         // Safety: PowerCreepMoveByPathErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -502,9 +490,7 @@ impl From<PowerCreepMoveToErrorCode> for ErrorCode {
         // Safety: PowerCreepMoveToErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -573,9 +559,7 @@ impl From<RenameErrorCode> for ErrorCode {
         // Safety: RenameErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -642,9 +626,7 @@ impl From<RenewErrorCode> for ErrorCode {
         // Safety: RenewErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -715,9 +697,7 @@ impl From<SpawnErrorCode> for ErrorCode {
         // Safety: SpawnErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -786,9 +766,7 @@ impl From<UpgradeErrorCode> for ErrorCode {
         // Safety: UpgradeErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -873,8 +851,6 @@ impl From<UsePowerErrorCode> for ErrorCode {
         // Safety: UsePowerErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/powercreep_error_codes.rs
+++ b/src/enums/action_error_codes/powercreep_error_codes.rs
@@ -432,7 +432,7 @@ impl From<PowerCreepMoveByPathErrorCode> for ErrorCode {
     }
 }
 
-/// Error codes used by [PowerCreep::move_to](crate::PowerCreep::move_to).
+/// Error codes used by [PowerCreep::move_to](crate::PowerCreep#method.move_to).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#PowerCreep.moveTo).
 ///

--- a/src/enums/action_error_codes/room_error_codes.rs
+++ b/src/enums/action_error_codes/room_error_codes.rs
@@ -130,10 +130,6 @@ impl Error for RoomCreateFlagErrorCode {}
 pub enum FindExitToErrorCode {
     NoPath = -2,
     InvalidArgs = -10,
-    FindExitTop = 1,
-    FindExitRight = 3,
-    FindExitBottom = 5,
-    FindExitLeft = 7,
 }
 
 impl FromReturnCode for FindExitToErrorCode {
@@ -153,10 +149,6 @@ impl FromReturnCode for FindExitToErrorCode {
         match val {
             -2 => Some(Err(FindExitToErrorCode::NoPath)),
             -10 => Some(Err(FindExitToErrorCode::InvalidArgs)),
-            1 => Some(Err(FindExitToErrorCode::FindExitTop)),
-            3 => Some(Err(FindExitToErrorCode::FindExitRight)),
-            5 => Some(Err(FindExitToErrorCode::FindExitBottom)),
-            7 => Some(Err(FindExitToErrorCode::FindExitLeft)),
             _ => None,
         }
     }
@@ -167,10 +159,6 @@ impl fmt::Display for FindExitToErrorCode {
         let msg: &'static str = match self {
             FindExitToErrorCode::NoPath => "path can not be found",
             FindExitToErrorCode::InvalidArgs => "the location is incorrect",
-            FindExitToErrorCode::FindExitTop => "exit top",
-            FindExitToErrorCode::FindExitRight => "exit right",
-            FindExitToErrorCode::FindExitBottom => "exit bottom",
-            FindExitToErrorCode::FindExitLeft => "exit left",
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/room_error_codes.rs
+++ b/src/enums/action_error_codes/room_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/room_error_codes.rs
+++ b/src/enums/action_error_codes/room_error_codes.rs
@@ -73,9 +73,7 @@ impl From<RoomCreateConstructionSiteErrorCode> for ErrorCode {
         // Safety: RoomCreateConstructionSiteErrorCode discriminants are always error
         // code values, and thus the Result returned here will always be an `Err`
         // variant, so we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -143,9 +141,7 @@ impl From<RoomCreateFlagErrorCode> for ErrorCode {
         // Safety: RoomCreateFlagErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -206,8 +202,6 @@ impl From<FindExitToErrorCode> for ErrorCode {
         // Safety: FindExitToErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/room_error_codes.rs
+++ b/src/enums/action_error_codes/room_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [Room::create_construction_site](crate::Room::create_construction_site).
+/// Error codes used by
+/// [Room::create_construction_site](crate::Room::create_construction_site).
 ///
 /// Screeps API Docs: [Room.createConstructionSite](https://docs.screeps.com/api/#Room.createConstructionSite).
 ///
@@ -29,11 +29,11 @@ impl FromReturnCode for RoomCreateConstructionSiteErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -86,11 +86,11 @@ impl FromReturnCode for RoomCreateFlagErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -108,8 +108,12 @@ impl fmt::Display for RoomCreateFlagErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             RoomCreateFlagErrorCode::NameExists => "there is a flag with the same name already",
-            RoomCreateFlagErrorCode::Full => "you have too many flags. the maximum number of flags per player is 10000",
-            RoomCreateFlagErrorCode::InvalidArgs => "the location or the name or the color constant is incorrect",
+            RoomCreateFlagErrorCode::Full => {
+                "you have too many flags. the maximum number of flags per player is 10000"
+            }
+            RoomCreateFlagErrorCode::InvalidArgs => {
+                "the location or the name or the color constant is incorrect"
+            }
         };
 
         write!(f, "{}", msg)
@@ -137,11 +141,11 @@ impl FromReturnCode for FindExitToErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/room_error_codes.rs
+++ b/src/enums/action_error_codes/room_error_codes.rs
@@ -1,0 +1,180 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [Room::create_construction_site](crate::Room::create_construction_site).
+///
+/// Screeps API Docs: [Room.createConstructionSite](https://docs.screeps.com/api/#Room.createConstructionSite).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1029)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RoomCreateConstructionSiteErrorCode {
+    NotOwner = -1,
+    InvalidTarget = -7,
+    Full = -8,
+    InvalidArgs = -10,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for RoomCreateConstructionSiteErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RoomCreateConstructionSiteErrorCode::NotOwner)),
+            -7 => Some(Err(RoomCreateConstructionSiteErrorCode::InvalidTarget)),
+            -8 => Some(Err(RoomCreateConstructionSiteErrorCode::Full)),
+            -10 => Some(Err(RoomCreateConstructionSiteErrorCode::InvalidArgs)),
+            -14 => Some(Err(RoomCreateConstructionSiteErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RoomCreateConstructionSiteErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RoomCreateConstructionSiteErrorCode::NotOwner => "the room is claimed or reserved by a hostile player",
+            RoomCreateConstructionSiteErrorCode::InvalidTarget => "the structure cannot be placed at the specified location",
+            RoomCreateConstructionSiteErrorCode::Full => "you have too many construction sites. the maximum number of construction sites per player is 100",
+            RoomCreateConstructionSiteErrorCode::InvalidArgs => "the location is incorrect",
+            RoomCreateConstructionSiteErrorCode::RclNotEnough => "room controller level insufficient. learn more",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RoomCreateConstructionSiteErrorCode {}
+
+/// Error codes used by [Room::create_flag](crate::Room::create_flag).
+///
+/// Screeps API Docs: [Room.createFlag](https://docs.screeps.com/api/#Room.createFlag).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L978)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RoomCreateFlagErrorCode {
+    NameExists = -3,
+    Full = -8,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for RoomCreateFlagErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            -3 => Some(Err(RoomCreateFlagErrorCode::NameExists)),
+            -8 => Some(Err(RoomCreateFlagErrorCode::Full)),
+            -10 => Some(Err(RoomCreateFlagErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RoomCreateFlagErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RoomCreateFlagErrorCode::NameExists => "there is a flag with the same name already",
+            RoomCreateFlagErrorCode::Full => "you have too many flags. the maximum number of flags per player is 10000",
+            RoomCreateFlagErrorCode::InvalidArgs => "the location or the name or the color constant is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RoomCreateFlagErrorCode {}
+
+/// Error codes used by [Room::find_exit_to](crate::Room::find_exit_to).
+///
+/// Screeps API Docs: [Room.findExitTo](https://docs.screeps.com/api/#Room.findExitTo).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1130)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum FindExitToErrorCode {
+    NoPath = -2,
+    InvalidArgs = -10,
+    FindExitTop = 1,
+    FindExitRight = 3,
+    FindExitBottom = 5,
+    FindExitLeft = 7,
+}
+
+impl FromReturnCode for FindExitToErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            -2 => Some(Err(FindExitToErrorCode::NoPath)),
+            -10 => Some(Err(FindExitToErrorCode::InvalidArgs)),
+            1 => Some(Err(FindExitToErrorCode::FindExitTop)),
+            3 => Some(Err(FindExitToErrorCode::FindExitRight)),
+            5 => Some(Err(FindExitToErrorCode::FindExitBottom)),
+            7 => Some(Err(FindExitToErrorCode::FindExitLeft)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for FindExitToErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            FindExitToErrorCode::NoPath => "path can not be found",
+            FindExitToErrorCode::InvalidArgs => "the location is incorrect",
+            FindExitToErrorCode::FindExitTop => "exit top",
+            FindExitToErrorCode::FindExitRight => "exit right",
+            FindExitToErrorCode::FindExitBottom => "exit bottom",
+            FindExitToErrorCode::FindExitLeft => "exit left",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for FindExitToErrorCode {}

--- a/src/enums/action_error_codes/room_error_codes.rs
+++ b/src/enums/action_error_codes/room_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [Room::create_construction_site](crate::Room::create_construction_site).
 ///
-/// Screeps API Docs: [Room.createConstructionSite](https://docs.screeps.com/api/#Room.createConstructionSite).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Room.createConstructionSite).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1029)
 #[derive(
@@ -65,9 +65,23 @@ impl fmt::Display for RoomCreateConstructionSiteErrorCode {
 
 impl Error for RoomCreateConstructionSiteErrorCode {}
 
+impl From<RoomCreateConstructionSiteErrorCode> for ErrorCode {
+    fn from(value: RoomCreateConstructionSiteErrorCode) -> Self {
+        // Safety: RoomCreateConstructionSiteErrorCode is repr(i8), so we can cast it to
+        // get the discriminant value, which will match the raw return code value that
+        // ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RoomCreateConstructionSiteErrorCode discriminants are always error
+        // code values, and thus the Result returned here will always be an `Err`
+        // variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Room::create_flag](crate::Room::create_flag).
 ///
-/// Screeps API Docs: [Room.createFlag](https://docs.screeps.com/api/#Room.createFlag).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Room.createFlag).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L978)
 #[derive(
@@ -121,9 +135,23 @@ impl fmt::Display for RoomCreateFlagErrorCode {
 
 impl Error for RoomCreateFlagErrorCode {}
 
+impl From<RoomCreateFlagErrorCode> for ErrorCode {
+    fn from(value: RoomCreateFlagErrorCode) -> Self {
+        // Safety: RoomCreateFlagErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RoomCreateFlagErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [Room::find_exit_to](crate::Room::find_exit_to).
 ///
-/// Screeps API Docs: [Room.findExitTo](https://docs.screeps.com/api/#Room.findExitTo).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Room.findExitTo).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1130)
 #[derive(
@@ -169,3 +197,17 @@ impl fmt::Display for FindExitToErrorCode {
 }
 
 impl Error for FindExitToErrorCode {}
+
+impl From<FindExitToErrorCode> for ErrorCode {
+    fn from(value: FindExitToErrorCode) -> Self {
+        // Safety: FindExitToErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: FindExitToErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/roomposition_error_codes.rs
+++ b/src/enums/action_error_codes/roomposition_error_codes.rs
@@ -3,13 +3,13 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [RoomPosition::create_construction_site](crate::RoomPosition::create_construction_site).
 ///
 ///
-/// Screeps API Docs: [RoomPosition.createConstructionSite](https://docs.screeps.com/api/#RoomPosition.createConstructionSite).
+/// [Screeps API Docs](https://docs.screeps.com/api/#RoomPosition.createConstructionSite).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1630)
 #[derive(
@@ -75,10 +75,24 @@ impl fmt::Display for RoomPositionCreateConstructionSiteErrorCode {
 
 impl Error for RoomPositionCreateConstructionSiteErrorCode {}
 
+impl From<RoomPositionCreateConstructionSiteErrorCode> for ErrorCode {
+    fn from(value: RoomPositionCreateConstructionSiteErrorCode) -> Self {
+        // Safety: RoomPositionCreateConstructionSiteErrorCode is repr(i8), so we can
+        // cast it to get the discriminant value, which will match the raw return code
+        // value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RoomPositionCreateConstructionSiteErrorCode discriminants are always
+        // error code values, and thus the Result returned here will always be an `Err`
+        // variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [RoomPosition::create_flag](crate::RoomPosition::create_flag).
 ///
-/// Screeps API Docs: [RoomPosition.createFlag](https://docs.screeps.com/api/#RoomPosition.createFlag).
+/// [Screeps API Docs](https://docs.screeps.com/api/#RoomPosition.createFlag).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1622)
 #[derive(
@@ -136,3 +150,17 @@ impl fmt::Display for RoomPositionCreateFlagErrorCode {
 }
 
 impl Error for RoomPositionCreateFlagErrorCode {}
+
+impl From<RoomPositionCreateFlagErrorCode> for ErrorCode {
+    fn from(value: RoomPositionCreateFlagErrorCode) -> Self {
+        // Safety: RoomPositionCreateFlagErrorCode is repr(i8), so we can cast it to get
+        // the discriminant value, which will match the raw return code value that
+        // ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RoomPositionCreateFlagErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/roomposition_error_codes.rs
+++ b/src/enums/action_error_codes/roomposition_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/roomposition_error_codes.rs
+++ b/src/enums/action_error_codes/roomposition_error_codes.rs
@@ -1,0 +1,119 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [RoomPosition::create_construction_site](crate::RoomPosition::create_construction_site).
+///
+/// Screeps API Docs: [RoomPosition.createConstructionSite](https://docs.screeps.com/api/#RoomPosition.createConstructionSite).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1630)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RoomPositionCreateConstructionSiteErrorCode {
+    NotOwner = -1,
+    InvalidTarget = -7,
+    Full = -8,
+    InvalidArgs = -10,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for RoomPositionCreateConstructionSiteErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::NotOwner)),
+            -7 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::InvalidTarget)),
+            -8 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::Full)),
+            -10 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::InvalidArgs)),
+            -14 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RoomPositionCreateConstructionSiteErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RoomPositionCreateConstructionSiteErrorCode::NotOwner => "the room is claimed or reserved by a hostile player",
+            RoomPositionCreateConstructionSiteErrorCode::InvalidTarget => "the structure cannot be placed at the specified location",
+            RoomPositionCreateConstructionSiteErrorCode::Full => "you have too many construction sites. the maximum number of construction sites per player is 100",
+            RoomPositionCreateConstructionSiteErrorCode::InvalidArgs => "the location is incorrect",
+            RoomPositionCreateConstructionSiteErrorCode::RclNotEnough => "room controller level insufficient. learn more",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RoomPositionCreateConstructionSiteErrorCode {}
+
+/// Error codes used by [RoomPosition::create_flag](crate::RoomPosition::create_flag).
+///
+/// Screeps API Docs: [RoomPosition.createFlag](https://docs.screeps.com/api/#RoomPosition.createFlag).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/rooms.js#L1622)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RoomPositionCreateFlagErrorCode {
+    NameExists = -3,
+    Full = -8,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for RoomPositionCreateFlagErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            -3 => Some(Err(RoomPositionCreateFlagErrorCode::NameExists)),
+            -8 => Some(Err(RoomPositionCreateFlagErrorCode::Full)),
+            -10 => Some(Err(RoomPositionCreateFlagErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RoomPositionCreateFlagErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RoomPositionCreateFlagErrorCode::NameExists => "there is a flag with the same name already",
+            RoomPositionCreateFlagErrorCode::Full => "you have too many flags. the maximum number of flags per player is 10000",
+            RoomPositionCreateFlagErrorCode::InvalidArgs => "the location or the color constant is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RoomPositionCreateFlagErrorCode {}

--- a/src/enums/action_error_codes/roomposition_error_codes.rs
+++ b/src/enums/action_error_codes/roomposition_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,9 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [RoomPosition::create_construction_site](crate::RoomPosition::create_construction_site).
+/// Error codes used by
+/// [RoomPosition::create_construction_site](crate::RoomPosition::create_construction_site).
+///
 ///
 /// Screeps API Docs: [RoomPosition.createConstructionSite](https://docs.screeps.com/api/#RoomPosition.createConstructionSite).
 ///
@@ -30,11 +31,11 @@ impl FromReturnCode for RoomPositionCreateConstructionSiteErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -42,11 +43,17 @@ impl FromReturnCode for RoomPositionCreateConstructionSiteErrorCode {
         match val {
             0 => Some(Ok(())),
             -1 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::NotOwner)),
-            -7 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::InvalidTarget)),
+            -7 => Some(Err(
+                RoomPositionCreateConstructionSiteErrorCode::InvalidTarget,
+            )),
             -8 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::Full)),
             -9 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::NotInRange)),
-            -10 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::InvalidArgs)),
-            -14 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::RclNotEnough)),
+            -10 => Some(Err(
+                RoomPositionCreateConstructionSiteErrorCode::InvalidArgs,
+            )),
+            -14 => Some(Err(
+                RoomPositionCreateConstructionSiteErrorCode::RclNotEnough,
+            )),
             _ => None,
         }
     }
@@ -69,7 +76,8 @@ impl fmt::Display for RoomPositionCreateConstructionSiteErrorCode {
 
 impl Error for RoomPositionCreateConstructionSiteErrorCode {}
 
-/// Error codes used by [RoomPosition::create_flag](crate::RoomPosition::create_flag).
+/// Error codes used by
+/// [RoomPosition::create_flag](crate::RoomPosition::create_flag).
 ///
 /// Screeps API Docs: [RoomPosition.createFlag](https://docs.screeps.com/api/#RoomPosition.createFlag).
 ///
@@ -90,11 +98,11 @@ impl FromReturnCode for RoomPositionCreateFlagErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -112,10 +120,16 @@ impl FromReturnCode for RoomPositionCreateFlagErrorCode {
 impl fmt::Display for RoomPositionCreateFlagErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            RoomPositionCreateFlagErrorCode::NameExists => "there is a flag with the same name already",
-            RoomPositionCreateFlagErrorCode::Full => "you have too many flags. the maximum number of flags per player is 10000",
+            RoomPositionCreateFlagErrorCode::NameExists => {
+                "there is a flag with the same name already"
+            }
+            RoomPositionCreateFlagErrorCode::Full => {
+                "you have too many flags. the maximum number of flags per player is 10000"
+            }
             RoomPositionCreateFlagErrorCode::NotInRange => "room not visible",
-            RoomPositionCreateFlagErrorCode::InvalidArgs => "the location or the color constant is incorrect",
+            RoomPositionCreateFlagErrorCode::InvalidArgs => {
+                "the location or the color constant is incorrect"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/roomposition_error_codes.rs
+++ b/src/enums/action_error_codes/roomposition_error_codes.rs
@@ -83,9 +83,7 @@ impl From<RoomPositionCreateConstructionSiteErrorCode> for ErrorCode {
         // Safety: RoomPositionCreateConstructionSiteErrorCode discriminants are always
         // error code values, and thus the Result returned here will always be an `Err`
         // variant, so we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -159,8 +157,6 @@ impl From<RoomPositionCreateFlagErrorCode> for ErrorCode {
         // Safety: RoomPositionCreateFlagErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/roomposition_error_codes.rs
+++ b/src/enums/action_error_codes/roomposition_error_codes.rs
@@ -20,6 +20,7 @@ pub enum RoomPositionCreateConstructionSiteErrorCode {
     NotOwner = -1,
     InvalidTarget = -7,
     Full = -8,
+    NotInRange = -9,
     InvalidArgs = -10,
     RclNotEnough = -14,
 }
@@ -43,6 +44,7 @@ impl FromReturnCode for RoomPositionCreateConstructionSiteErrorCode {
             -1 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::NotOwner)),
             -7 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::InvalidTarget)),
             -8 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::Full)),
+            -9 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::NotInRange)),
             -10 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::InvalidArgs)),
             -14 => Some(Err(RoomPositionCreateConstructionSiteErrorCode::RclNotEnough)),
             _ => None,
@@ -56,6 +58,7 @@ impl fmt::Display for RoomPositionCreateConstructionSiteErrorCode {
             RoomPositionCreateConstructionSiteErrorCode::NotOwner => "the room is claimed or reserved by a hostile player",
             RoomPositionCreateConstructionSiteErrorCode::InvalidTarget => "the structure cannot be placed at the specified location",
             RoomPositionCreateConstructionSiteErrorCode::Full => "you have too many construction sites. the maximum number of construction sites per player is 100",
+            RoomPositionCreateConstructionSiteErrorCode::NotInRange => "room not visible",
             RoomPositionCreateConstructionSiteErrorCode::InvalidArgs => "the location is incorrect",
             RoomPositionCreateConstructionSiteErrorCode::RclNotEnough => "room controller level insufficient. learn more",
         };
@@ -78,6 +81,7 @@ impl Error for RoomPositionCreateConstructionSiteErrorCode {}
 pub enum RoomPositionCreateFlagErrorCode {
     NameExists = -3,
     Full = -8,
+    NotInRange = -9,
     InvalidArgs = -10,
 }
 
@@ -98,6 +102,7 @@ impl FromReturnCode for RoomPositionCreateFlagErrorCode {
         match val {
             -3 => Some(Err(RoomPositionCreateFlagErrorCode::NameExists)),
             -8 => Some(Err(RoomPositionCreateFlagErrorCode::Full)),
+            -9 => Some(Err(RoomPositionCreateFlagErrorCode::NotInRange)),
             -10 => Some(Err(RoomPositionCreateFlagErrorCode::InvalidArgs)),
             _ => None,
         }
@@ -109,6 +114,7 @@ impl fmt::Display for RoomPositionCreateFlagErrorCode {
         let msg: &'static str = match self {
             RoomPositionCreateFlagErrorCode::NameExists => "there is a flag with the same name already",
             RoomPositionCreateFlagErrorCode::Full => "you have too many flags. the maximum number of flags per player is 10000",
+            RoomPositionCreateFlagErrorCode::NotInRange => "room not visible",
             RoomPositionCreateFlagErrorCode::InvalidArgs => "the location or the color constant is incorrect",
         };
 

--- a/src/enums/action_error_codes/sharedcreep_error_codes.rs
+++ b/src/enums/action_error_codes/sharedcreep_error_codes.rs
@@ -1,15 +1,12 @@
-use std::error::Error;
-use std::fmt;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::{
-    FromReturnCode,
-    constants::ErrorCode,
-};
+use crate::{constants::ErrorCode, FromReturnCode};
 
-/// Error codes used by [SharedCreepProperties::drop](crate::SharedCreepProperties::drop).
+/// Error codes used by
+/// [SharedCreepProperties::drop](crate::SharedCreepProperties::drop).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.drop).
 ///
@@ -52,11 +49,12 @@ impl FromReturnCode for DropErrorCode {
 
 impl fmt::Display for DropErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        
         let msg: &'static str = match self {
             DropErrorCode::NotOwner => "you are not the owner of this creep",
             DropErrorCode::Busy => "the creep is still being spawned",
-            DropErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
+            DropErrorCode::NotEnoughResources => {
+                "the creep does not have the given amount of resources"
+            }
             DropErrorCode::InvalidArgs => "the resourcetype is not a valid resource_* constants",
         };
 
@@ -68,16 +66,20 @@ impl Error for DropErrorCode {}
 
 impl From<DropErrorCode> for ErrorCode {
     fn from(value: DropErrorCode) -> Self {
-        // Safety: DropErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
-        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
-        // Safety: DropErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        // Safety: DropErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: DropErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
         Self::result_from_i8(value as i8)
             .unwrap_err()
             .expect("expect enum discriminant to be an error code")
     }
 }
 
-/// Error codes used by [SharedCreepProperties::notify_when_attacked](crate::SharedCreepProperties::notify_when_attacked).
+/// Error codes used by
+/// [SharedCreepProperties::notify_when_attacked](crate::SharedCreepProperties::notify_when_attacked).
+///
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.notifyWhenAttacked).
 ///
@@ -118,7 +120,6 @@ impl FromReturnCode for NotifyWhenAttackedErrorCode {
 
 impl fmt::Display for NotifyWhenAttackedErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        
         let msg: &'static str = match self {
             NotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this creep",
             NotifyWhenAttackedErrorCode::Busy => "the creep is still being spawned",
@@ -133,16 +134,20 @@ impl Error for NotifyWhenAttackedErrorCode {}
 
 impl From<NotifyWhenAttackedErrorCode> for ErrorCode {
     fn from(value: NotifyWhenAttackedErrorCode) -> Self {
-        // Safety: NotifyWhenAttackedErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
-        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
-        // Safety: NotifyWhenAttackedErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        // Safety: NotifyWhenAttackedErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: NotifyWhenAttackedErrorCode discriminants are always error code
+        // values, and thus the Result returned here will always be an `Err` variant, so
+        // we can always extract the error without panicking
         Self::result_from_i8(value as i8)
             .unwrap_err()
             .expect("expect enum discriminant to be an error code")
     }
 }
 
-/// Error codes used by [SharedCreepProperties::pickup](crate::SharedCreepProperties::pickup).
+/// Error codes used by
+/// [SharedCreepProperties::pickup](crate::SharedCreepProperties::pickup).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.pickup).
 ///
@@ -187,7 +192,6 @@ impl FromReturnCode for PickupErrorCode {
 
 impl fmt::Display for PickupErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        
         let msg: &'static str = match self {
             PickupErrorCode::NotOwner => "you are not the owner of this creep",
             PickupErrorCode::Busy => "the creep is still being spawned",
@@ -204,16 +208,20 @@ impl Error for PickupErrorCode {}
 
 impl From<PickupErrorCode> for ErrorCode {
     fn from(value: PickupErrorCode) -> Self {
-        // Safety: PickupErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
-        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
-        // Safety: PickupErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        // Safety: PickupErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PickupErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
         Self::result_from_i8(value as i8)
             .unwrap_err()
             .expect("expect enum discriminant to be an error code")
     }
 }
 
-/// Error codes used by [SharedCreepProperties::say](crate::SharedCreepProperties::say).
+/// Error codes used by
+/// [SharedCreepProperties::say](crate::SharedCreepProperties::say).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.say).
 ///
@@ -252,7 +260,6 @@ impl FromReturnCode for SayErrorCode {
 
 impl fmt::Display for SayErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        
         let msg: &'static str = match self {
             SayErrorCode::NotOwner => "you are not the owner of this creep",
             SayErrorCode::Busy => "the creep is still being spawned",
@@ -266,16 +273,19 @@ impl Error for SayErrorCode {}
 
 impl From<SayErrorCode> for ErrorCode {
     fn from(value: SayErrorCode) -> Self {
-        // Safety: SayErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
-        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
-        // Safety: SayErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        // Safety: SayErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SayErrorCode discriminants are always error code values, and thus the
+        // Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
         Self::result_from_i8(value as i8)
             .unwrap_err()
             .expect("expect enum discriminant to be an error code")
     }
 }
 
-/// Error codes used by [SharedCreepProperties::suicide](crate::SharedCreepProperties::suicide).
+/// Error codes used by
+/// [SharedCreepProperties::suicide](crate::SharedCreepProperties::suicide).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.suicide).
 ///
@@ -314,7 +324,6 @@ impl FromReturnCode for SuicideErrorCode {
 
 impl fmt::Display for SuicideErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        
         let msg: &'static str = match self {
             SuicideErrorCode::NotOwner => "you are not the owner of this creep",
             SuicideErrorCode::Busy => "the creep is still being spawned",
@@ -328,16 +337,20 @@ impl Error for SuicideErrorCode {}
 
 impl From<SuicideErrorCode> for ErrorCode {
     fn from(value: SuicideErrorCode) -> Self {
-        // Safety: SuicideErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
-        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
-        // Safety: SuicideErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        // Safety: SuicideErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SuicideErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
         Self::result_from_i8(value as i8)
             .unwrap_err()
             .expect("expect enum discriminant to be an error code")
     }
 }
 
-/// Error codes used by [SharedCreepProperties::transfer](crate::SharedCreepProperties::transfer).
+/// Error codes used by
+/// [SharedCreepProperties::transfer](crate::SharedCreepProperties::transfer).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.transfer).
 ///
@@ -386,7 +399,6 @@ impl FromReturnCode for TransferErrorCode {
 
 impl fmt::Display for TransferErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        
         let msg: &'static str = match self {
             TransferErrorCode::NotOwner => "you are not the owner of this creep",
             TransferErrorCode::Busy => "the creep is still being spawned",
@@ -405,16 +417,20 @@ impl Error for TransferErrorCode {}
 
 impl From<TransferErrorCode> for ErrorCode {
     fn from(value: TransferErrorCode) -> Self {
-        // Safety: TransferErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
-        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
-        // Safety: TransferErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        // Safety: TransferErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: TransferErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
         Self::result_from_i8(value as i8)
             .unwrap_err()
             .expect("expect enum discriminant to be an error code")
     }
 }
 
-/// Error codes used by [SharedCreepProperties::withdraw](crate::SharedCreepProperties::withdraw).
+/// Error codes used by
+/// [SharedCreepProperties::withdraw](crate::SharedCreepProperties::withdraw).
 ///
 /// [Screeps API Docs](https://docs.screeps.com/api/#Creep.withdraw).
 ///
@@ -463,7 +479,6 @@ impl FromReturnCode for WithdrawErrorCode {
 
 impl fmt::Display for WithdrawErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        
         let msg: &'static str = match self {
             WithdrawErrorCode::NotOwner => "you are not the owner of this creep, or there is a hostile rampart on top of the target",
             WithdrawErrorCode::Busy => "the creep is still being spawned",
@@ -482,9 +497,12 @@ impl Error for WithdrawErrorCode {}
 
 impl From<WithdrawErrorCode> for ErrorCode {
     fn from(value: WithdrawErrorCode) -> Self {
-        // Safety: WithdrawErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
-        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
-        // Safety: WithdrawErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        // Safety: WithdrawErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: WithdrawErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
         Self::result_from_i8(value as i8)
             .unwrap_err()
             .expect("expect enum discriminant to be an error code")

--- a/src/enums/action_error_codes/sharedcreep_error_codes.rs
+++ b/src/enums/action_error_codes/sharedcreep_error_codes.rs
@@ -1,0 +1,492 @@
+use std::error::Error;
+use std::fmt;
+
+use num_derive::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::{
+    FromReturnCode,
+    constants::ErrorCode,
+};
+
+/// Error codes used by [SharedCreepProperties::drop](crate::SharedCreepProperties::drop).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.drop).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L404)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum DropErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for DropErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(DropErrorCode::NotOwner)),
+            -4 => Some(Err(DropErrorCode::Busy)),
+            -6 => Some(Err(DropErrorCode::NotEnoughResources)),
+            -10 => Some(Err(DropErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DropErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        
+        let msg: &'static str = match self {
+            DropErrorCode::NotOwner => "you are not the owner of this creep",
+            DropErrorCode::Busy => "the creep is still being spawned",
+            DropErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
+            DropErrorCode::InvalidArgs => "the resourcetype is not a valid resource_* constants",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for DropErrorCode {}
+
+impl From<DropErrorCode> for ErrorCode {
+    fn from(value: DropErrorCode) -> Self {
+        // Safety: DropErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
+        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: DropErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [SharedCreepProperties::notify_when_attacked](crate::SharedCreepProperties::notify_when_attacked).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.notifyWhenAttacked).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L988)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum NotifyWhenAttackedErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for NotifyWhenAttackedErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(NotifyWhenAttackedErrorCode::NotOwner)),
+            -4 => Some(Err(NotifyWhenAttackedErrorCode::Busy)),
+            -10 => Some(Err(NotifyWhenAttackedErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for NotifyWhenAttackedErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        
+        let msg: &'static str = match self {
+            NotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this creep",
+            NotifyWhenAttackedErrorCode::Busy => "the creep is still being spawned",
+            NotifyWhenAttackedErrorCode::InvalidArgs => "enable argument is not a boolean value",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for NotifyWhenAttackedErrorCode {}
+
+impl From<NotifyWhenAttackedErrorCode> for ErrorCode {
+    fn from(value: NotifyWhenAttackedErrorCode) -> Self {
+        // Safety: NotifyWhenAttackedErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
+        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: NotifyWhenAttackedErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [SharedCreepProperties::pickup](crate::SharedCreepProperties::pickup).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.pickup).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L566)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum PickupErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+}
+
+impl FromReturnCode for PickupErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(PickupErrorCode::NotOwner)),
+            -4 => Some(Err(PickupErrorCode::Busy)),
+            -7 => Some(Err(PickupErrorCode::InvalidTarget)),
+            -8 => Some(Err(PickupErrorCode::Full)),
+            -9 => Some(Err(PickupErrorCode::NotInRange)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PickupErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        
+        let msg: &'static str = match self {
+            PickupErrorCode::NotOwner => "you are not the owner of this creep",
+            PickupErrorCode::Busy => "the creep is still being spawned",
+            PickupErrorCode::InvalidTarget => "the target is not a valid object to pick up",
+            PickupErrorCode::Full => "the creep cannot receive any more resource",
+            PickupErrorCode::NotInRange => "the target is too far away",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for PickupErrorCode {}
+
+impl From<PickupErrorCode> for ErrorCode {
+    fn from(value: PickupErrorCode) -> Self {
+        // Safety: PickupErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
+        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: PickupErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [SharedCreepProperties::say](crate::SharedCreepProperties::say).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.say).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L826)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SayErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+}
+
+impl FromReturnCode for SayErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(SayErrorCode::NotOwner)),
+            -4 => Some(Err(SayErrorCode::Busy)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SayErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        
+        let msg: &'static str = match self {
+            SayErrorCode::NotOwner => "you are not the owner of this creep",
+            SayErrorCode::Busy => "the creep is still being spawned",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SayErrorCode {}
+
+impl From<SayErrorCode> for ErrorCode {
+    fn from(value: SayErrorCode) -> Self {
+        // Safety: SayErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
+        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SayErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [SharedCreepProperties::suicide](crate::SharedCreepProperties::suicide).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.suicide).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L813)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SuicideErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+}
+
+impl FromReturnCode for SuicideErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(SuicideErrorCode::NotOwner)),
+            -4 => Some(Err(SuicideErrorCode::Busy)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SuicideErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        
+        let msg: &'static str = match self {
+            SuicideErrorCode::NotOwner => "you are not the owner of this creep",
+            SuicideErrorCode::Busy => "the creep is still being spawned",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SuicideErrorCode {}
+
+impl From<SuicideErrorCode> for ErrorCode {
+    fn from(value: SuicideErrorCode) -> Self {
+        // Safety: SuicideErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
+        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SuicideErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [SharedCreepProperties::transfer](crate::SharedCreepProperties::transfer).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.transfer).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L428)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum TransferErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for TransferErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(TransferErrorCode::NotOwner)),
+            -4 => Some(Err(TransferErrorCode::Busy)),
+            -6 => Some(Err(TransferErrorCode::NotEnoughResources)),
+            -7 => Some(Err(TransferErrorCode::InvalidTarget)),
+            -8 => Some(Err(TransferErrorCode::Full)),
+            -9 => Some(Err(TransferErrorCode::NotInRange)),
+            -10 => Some(Err(TransferErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for TransferErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        
+        let msg: &'static str = match self {
+            TransferErrorCode::NotOwner => "you are not the owner of this creep",
+            TransferErrorCode::Busy => "the creep is still being spawned",
+            TransferErrorCode::NotEnoughResources => "the creep does not have the given amount of resources",
+            TransferErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
+            TransferErrorCode::Full => "the target cannot receive any more resources",
+            TransferErrorCode::NotInRange => "the target is too far away",
+            TransferErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for TransferErrorCode {}
+
+impl From<TransferErrorCode> for ErrorCode {
+    fn from(value: TransferErrorCode) -> Self {
+        // Safety: TransferErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
+        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: TransferErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
+/// Error codes used by [SharedCreepProperties::withdraw](crate::SharedCreepProperties::withdraw).
+///
+/// [Screeps API Docs](https://docs.screeps.com/api/#Creep.withdraw).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/creeps.js#L493)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum WithdrawErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for WithdrawErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature = "unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature = "unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(WithdrawErrorCode::NotOwner)),
+            -4 => Some(Err(WithdrawErrorCode::Busy)),
+            -6 => Some(Err(WithdrawErrorCode::NotEnoughResources)),
+            -7 => Some(Err(WithdrawErrorCode::InvalidTarget)),
+            -8 => Some(Err(WithdrawErrorCode::Full)),
+            -9 => Some(Err(WithdrawErrorCode::NotInRange)),
+            -10 => Some(Err(WithdrawErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for WithdrawErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        
+        let msg: &'static str = match self {
+            WithdrawErrorCode::NotOwner => "you are not the owner of this creep, or there is a hostile rampart on top of the target",
+            WithdrawErrorCode::Busy => "the creep is still being spawned",
+            WithdrawErrorCode::NotEnoughResources => "the target does not have the given amount of resources",
+            WithdrawErrorCode::InvalidTarget => "the target is not a valid object which can contain the specified resource",
+            WithdrawErrorCode::Full => "the creep's carry is full",
+            WithdrawErrorCode::NotInRange => "the target is too far away",
+            WithdrawErrorCode::InvalidArgs => "the resourcetype is not one of the resource_* constants, or the amount is incorrect",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for WithdrawErrorCode {}
+
+impl From<WithdrawErrorCode> for ErrorCode {
+    fn from(value: WithdrawErrorCode) -> Self {
+        // Safety: WithdrawErrorCode is repr(i8), so we can cast it to get the discriminant value, which will match the raw return code value that ErrorCode expects.
+        //   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: WithdrawErrorCode discriminants are always error code values, and thus the Result returned here will always be an `Err` variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/sharedcreep_error_codes.rs
+++ b/src/enums/action_error_codes/sharedcreep_error_codes.rs
@@ -71,9 +71,7 @@ impl From<DropErrorCode> for ErrorCode {
         // Safety: DropErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -140,9 +138,7 @@ impl From<NotifyWhenAttackedErrorCode> for ErrorCode {
         // Safety: NotifyWhenAttackedErrorCode discriminants are always error code
         // values, and thus the Result returned here will always be an `Err` variant, so
         // we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -214,9 +210,7 @@ impl From<PickupErrorCode> for ErrorCode {
         // Safety: PickupErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -278,9 +272,7 @@ impl From<SayErrorCode> for ErrorCode {
         // Safety: SayErrorCode discriminants are always error code values, and thus the
         // Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -343,9 +335,7 @@ impl From<SuicideErrorCode> for ErrorCode {
         // Safety: SuicideErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -423,9 +413,7 @@ impl From<TransferErrorCode> for ErrorCode {
         // Safety: TransferErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -503,8 +491,6 @@ impl From<WithdrawErrorCode> for ErrorCode {
         // Safety: WithdrawErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/spawning_error_codes.rs
+++ b/src/enums/action_error_codes/spawning_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/spawning_error_codes.rs
+++ b/src/enums/action_error_codes/spawning_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -25,11 +24,11 @@ impl FromReturnCode for CancelErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -54,7 +53,8 @@ impl fmt::Display for CancelErrorCode {
 
 impl Error for CancelErrorCode {}
 
-/// Error codes used by [Spawning::set_directions](crate::Spawning::set_directions).
+/// Error codes used by
+/// [Spawning::set_directions](crate::Spawning::set_directions).
 ///
 /// Screeps API Docs: [Spawning.setDirections](https://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections).
 ///
@@ -73,11 +73,11 @@ impl FromReturnCode for SetDirectionsErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/spawning_error_codes.rs
+++ b/src/enums/action_error_codes/spawning_error_codes.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [Spawning::cancel](crate::Spawning::cancel).
+///
+/// Screeps API Docs: [Spawning.cancel](https://docs.screeps.com/api/#StructureSpawn.Spawning.cancel).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1328)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum CancelErrorCode {
+    NotOwner = -1,
+}
+
+impl FromReturnCode for CancelErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(CancelErrorCode::NotOwner)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for CancelErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            CancelErrorCode::NotOwner => "you are not the owner of this spawn",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for CancelErrorCode {}
+
+/// Error codes used by [Spawning::set_directions](crate::Spawning::set_directions).
+///
+/// Screeps API Docs: [Spawning.setDirections](https://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1312)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SetDirectionsErrorCode {
+    NotOwner = -1,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for SetDirectionsErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(SetDirectionsErrorCode::NotOwner)),
+            -10 => Some(Err(SetDirectionsErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SetDirectionsErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SetDirectionsErrorCode::NotOwner => "you are not the owner of this spawn",
+            SetDirectionsErrorCode::InvalidArgs => "the directions is array is invalid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SetDirectionsErrorCode {}

--- a/src/enums/action_error_codes/spawning_error_codes.rs
+++ b/src/enums/action_error_codes/spawning_error_codes.rs
@@ -3,11 +3,11 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by [Spawning::cancel](crate::Spawning::cancel).
 ///
-/// Screeps API Docs: [Spawning.cancel](https://docs.screeps.com/api/#StructureSpawn.Spawning.cancel).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureSpawn.Spawning.cancel).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1328)
 #[derive(
@@ -52,10 +52,24 @@ impl fmt::Display for CancelErrorCode {
 
 impl Error for CancelErrorCode {}
 
+impl From<CancelErrorCode> for ErrorCode {
+    fn from(value: CancelErrorCode) -> Self {
+        // Safety: CancelErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: CancelErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [Spawning::set_directions](crate::Spawning::set_directions).
 ///
-/// Screeps API Docs: [Spawning.setDirections](https://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1312)
 #[derive(
@@ -102,3 +116,17 @@ impl fmt::Display for SetDirectionsErrorCode {
 }
 
 impl Error for SetDirectionsErrorCode {}
+
+impl From<SetDirectionsErrorCode> for ErrorCode {
+    fn from(value: SetDirectionsErrorCode) -> Self {
+        // Safety: SetDirectionsErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SetDirectionsErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/spawning_error_codes.rs
+++ b/src/enums/action_error_codes/spawning_error_codes.rs
@@ -60,9 +60,7 @@ impl From<CancelErrorCode> for ErrorCode {
         // Safety: CancelErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -125,8 +123,6 @@ impl From<SetDirectionsErrorCode> for ErrorCode {
         // Safety: SetDirectionsErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structure_error_codes.rs
+++ b/src/enums/action_error_codes/structure_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structure_error_codes.rs
+++ b/src/enums/action_error_codes/structure_error_codes.rs
@@ -3,11 +3,11 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by [Structure::destroy](crate::Structure::destroy).
 ///
-/// Screeps API Docs: [Structure.destroy](https://docs.screeps.com/api/#Structure.destroy).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Structure.destroy).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L72)
 #[derive(
@@ -60,10 +60,24 @@ impl fmt::Display for DestroyErrorCode {
 
 impl Error for DestroyErrorCode {}
 
+impl From<DestroyErrorCode> for ErrorCode {
+    fn from(value: DestroyErrorCode) -> Self {
+        // Safety: DestroyErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: DestroyErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [Structure::notify_when_attacked](crate::Structure::notify_when_attacked).
 ///
-/// Screeps API Docs: [Structure.notifyWhenAttacked](https://docs.screeps.com/api/#Structure.notifyWhenAttacked).
+/// [Screeps API Docs](https://docs.screeps.com/api/#Structure.notifyWhenAttacked).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L89)
 #[derive(
@@ -117,3 +131,17 @@ impl fmt::Display for StructureNotifyWhenAttackedErrorCode {
 }
 
 impl Error for StructureNotifyWhenAttackedErrorCode {}
+
+impl From<StructureNotifyWhenAttackedErrorCode> for ErrorCode {
+    fn from(value: StructureNotifyWhenAttackedErrorCode) -> Self {
+        // Safety: StructureNotifyWhenAttackedErrorCode is repr(i8), so we can cast it
+        // to get the discriminant value, which will match the raw return code value
+        // that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: StructureNotifyWhenAttackedErrorCode discriminants are always error
+        // code values, and thus the Result returned here will always be an `Err`
+        // variant, so we can always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structure_error_codes.rs
+++ b/src/enums/action_error_codes/structure_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -27,11 +26,11 @@ impl FromReturnCode for DestroyErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -49,7 +48,9 @@ impl FromReturnCode for DestroyErrorCode {
 impl fmt::Display for DestroyErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            DestroyErrorCode::NotOwner => "you are not the owner of this structure, and it's not in your room",
+            DestroyErrorCode::NotOwner => {
+                "you are not the owner of this structure, and it's not in your room"
+            }
             DestroyErrorCode::Busy => "hostile creeps are in the room",
             DestroyErrorCode::InvalidTarget => "room property invalid",
         };
@@ -60,7 +61,8 @@ impl fmt::Display for DestroyErrorCode {
 
 impl Error for DestroyErrorCode {}
 
-/// Error codes used by [Structure::notify_when_attacked](crate::Structure::notify_when_attacked).
+/// Error codes used by
+/// [Structure::notify_when_attacked](crate::Structure::notify_when_attacked).
 ///
 /// Screeps API Docs: [Structure.notifyWhenAttacked](https://docs.screeps.com/api/#Structure.notifyWhenAttacked).
 ///
@@ -80,11 +82,11 @@ impl FromReturnCode for StructureNotifyWhenAttackedErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -102,9 +104,13 @@ impl FromReturnCode for StructureNotifyWhenAttackedErrorCode {
 impl fmt::Display for StructureNotifyWhenAttackedErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            StructureNotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this structure",
+            StructureNotifyWhenAttackedErrorCode::NotOwner => {
+                "you are not the owner of this structure"
+            }
             StructureNotifyWhenAttackedErrorCode::InvalidTarget => "room property invalid",
-            StructureNotifyWhenAttackedErrorCode::InvalidArgs => "enable argument is not a boolean value",
+            StructureNotifyWhenAttackedErrorCode::InvalidArgs => {
+                "enable argument is not a boolean value"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structure_error_codes.rs
+++ b/src/enums/action_error_codes/structure_error_codes.rs
@@ -1,0 +1,114 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [Structure::destroy](crate::Structure::destroy).
+///
+/// Screeps API Docs: [Structure.destroy](https://docs.screeps.com/api/#Structure.destroy).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L72)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum DestroyErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    InvalidTarget = -7,
+}
+
+impl FromReturnCode for DestroyErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(DestroyErrorCode::NotOwner)),
+            -4 => Some(Err(DestroyErrorCode::Busy)),
+            -7 => Some(Err(DestroyErrorCode::InvalidTarget)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DestroyErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            DestroyErrorCode::NotOwner => "you are not the owner of this structure, and it's not in your room",
+            DestroyErrorCode::Busy => "hostile creeps are in the room",
+            DestroyErrorCode::InvalidTarget => "room property invalid",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for DestroyErrorCode {}
+
+/// Error codes used by [Structure::notify_when_attacked](crate::Structure::notify_when_attacked).
+///
+/// Screeps API Docs: [Structure.notifyWhenAttacked](https://docs.screeps.com/api/#Structure.notifyWhenAttacked).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L89)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum StructureNotifyWhenAttackedErrorCode {
+    NotOwner = -1,
+    InvalidTarget = -7,
+    InvalidArgs = -10,
+}
+
+impl FromReturnCode for StructureNotifyWhenAttackedErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(StructureNotifyWhenAttackedErrorCode::NotOwner)),
+            -7 => Some(Err(StructureNotifyWhenAttackedErrorCode::InvalidTarget)),
+            -10 => Some(Err(StructureNotifyWhenAttackedErrorCode::InvalidArgs)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for StructureNotifyWhenAttackedErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            StructureNotifyWhenAttackedErrorCode::NotOwner => "you are not the owner of this structure",
+            StructureNotifyWhenAttackedErrorCode::InvalidTarget => "room property invalid",
+            StructureNotifyWhenAttackedErrorCode::InvalidArgs => "enable argument is not a boolean value",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for StructureNotifyWhenAttackedErrorCode {}

--- a/src/enums/action_error_codes/structure_error_codes.rs
+++ b/src/enums/action_error_codes/structure_error_codes.rs
@@ -68,9 +68,7 @@ impl From<DestroyErrorCode> for ErrorCode {
         // Safety: DestroyErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -140,8 +138,6 @@ impl From<StructureNotifyWhenAttackedErrorCode> for ErrorCode {
         // Safety: StructureNotifyWhenAttackedErrorCode discriminants are always error
         // code values, and thus the Result returned here will always be an `Err`
         // variant, so we can always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurecontroller_error_codes.rs
+++ b/src/enums/action_error_codes/structurecontroller_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurecontroller_error_codes.rs
+++ b/src/enums/action_error_codes/structurecontroller_error_codes.rs
@@ -71,9 +71,7 @@ impl From<ActivateSafeModeErrorCode> for ErrorCode {
         // Safety: ActivateSafeModeErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -133,8 +131,6 @@ impl From<UnclaimErrorCode> for ErrorCode {
         // Safety: UnclaimErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurecontroller_error_codes.rs
+++ b/src/enums/action_error_codes/structurecontroller_error_codes.rs
@@ -3,13 +3,13 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureController::activate_safe_mode](crate::StructureController::activate_safe_mode).
 ///
 ///
-/// Screeps API Docs: [StructureController.activateSafeMode](https://docs.screeps.com/api/#StructureController.activateSafeMode).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureController.activateSafeMode).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L211)
 #[derive(
@@ -63,10 +63,24 @@ impl fmt::Display for ActivateSafeModeErrorCode {
 
 impl Error for ActivateSafeModeErrorCode {}
 
+impl From<ActivateSafeModeErrorCode> for ErrorCode {
+    fn from(value: ActivateSafeModeErrorCode) -> Self {
+        // Safety: ActivateSafeModeErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ActivateSafeModeErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [StructureController::unclaim](crate::StructureController::unclaim).
 ///
-/// Screeps API Docs: [StructureController.unclaim](https://docs.screeps.com/api/#StructureController.unclaim).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureController.unclaim).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L201)
 #[derive(
@@ -110,3 +124,17 @@ impl fmt::Display for UnclaimErrorCode {
 }
 
 impl Error for UnclaimErrorCode {}
+
+impl From<UnclaimErrorCode> for ErrorCode {
+    fn from(value: UnclaimErrorCode) -> Self {
+        // Safety: UnclaimErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: UnclaimErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurecontroller_error_codes.rs
+++ b/src/enums/action_error_codes/structurecontroller_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,9 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureController::activate_safe_mode](crate::StructureController::activate_safe_mode).
+/// Error codes used by
+/// [StructureController::activate_safe_mode](crate::StructureController::activate_safe_mode).
+///
 ///
 /// Screeps API Docs: [StructureController.activateSafeMode](https://docs.screeps.com/api/#StructureController.activateSafeMode).
 ///
@@ -28,11 +29,11 @@ impl FromReturnCode for ActivateSafeModeErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -63,7 +64,8 @@ impl fmt::Display for ActivateSafeModeErrorCode {
 
 impl Error for ActivateSafeModeErrorCode {}
 
-/// Error codes used by [StructureController::unclaim](crate::StructureController::unclaim).
+/// Error codes used by
+/// [StructureController::unclaim](crate::StructureController::unclaim).
 ///
 /// Screeps API Docs: [StructureController.unclaim](https://docs.screeps.com/api/#StructureController.unclaim).
 ///
@@ -81,11 +83,11 @@ impl FromReturnCode for UnclaimErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/structurecontroller_error_codes.rs
+++ b/src/enums/action_error_codes/structurecontroller_error_codes.rs
@@ -1,0 +1,111 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureController::activate_safe_mode](crate::StructureController::activate_safe_mode).
+///
+/// Screeps API Docs: [StructureController.activateSafeMode](https://docs.screeps.com/api/#StructureController.activateSafeMode).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L211)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ActivateSafeModeErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    Tired = -11,
+}
+
+impl FromReturnCode for ActivateSafeModeErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ActivateSafeModeErrorCode::NotOwner)),
+            -4 => Some(Err(ActivateSafeModeErrorCode::Busy)),
+            -6 => Some(Err(ActivateSafeModeErrorCode::NotEnoughResources)),
+            -11 => Some(Err(ActivateSafeModeErrorCode::Tired)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ActivateSafeModeErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ActivateSafeModeErrorCode::NotOwner => "you are not the owner of this controller",
+            ActivateSafeModeErrorCode::Busy => "there is another room in safe mode already",
+            ActivateSafeModeErrorCode::NotEnoughResources => "there is no safe mode activations available",
+            ActivateSafeModeErrorCode::Tired => "the previous safe mode is still cooling down, or the controller is upgradeblocked, or the controller is downgraded for 50% plus 5000 ticks or more",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ActivateSafeModeErrorCode {}
+
+/// Error codes used by [StructureController::unclaim](crate::StructureController::unclaim).
+///
+/// Screeps API Docs: [StructureController.unclaim](https://docs.screeps.com/api/#StructureController.unclaim).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L201)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum UnclaimErrorCode {
+    NotOwner = -1,
+}
+
+impl FromReturnCode for UnclaimErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(UnclaimErrorCode::NotOwner)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UnclaimErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            UnclaimErrorCode::NotOwner => "you are not the owner of this controller",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for UnclaimErrorCode {}

--- a/src/enums/action_error_codes/structurefactory_error_codes.rs
+++ b/src/enums/action_error_codes/structurefactory_error_codes.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureFactory::produce](crate::StructureFactory::produce).
+///
+/// Screeps API Docs: [StructureFactory.produce](https://docs.screeps.com/api/#StructureFactory.produce).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1434)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ProduceErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    InvalidArgs = -10,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for ProduceErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ProduceErrorCode::NotOwner)),
+            -4 => Some(Err(ProduceErrorCode::Busy)),
+            -6 => Some(Err(ProduceErrorCode::NotEnoughResources)),
+            -7 => Some(Err(ProduceErrorCode::InvalidTarget)),
+            -8 => Some(Err(ProduceErrorCode::Full)),
+            -10 => Some(Err(ProduceErrorCode::InvalidArgs)),
+            -11 => Some(Err(ProduceErrorCode::Tired)),
+            -14 => Some(Err(ProduceErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ProduceErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ProduceErrorCode::NotOwner => "you are not the owner of this structure",
+            ProduceErrorCode::Busy => "the factory is not operated by the pwr_operate_factory power",
+            ProduceErrorCode::NotEnoughResources => "the structure does not have the required amount of resources",
+            ProduceErrorCode::InvalidTarget => "the factory cannot produce the commodity of this level",
+            ProduceErrorCode::Full => "the factory cannot contain the produce",
+            ProduceErrorCode::InvalidArgs => "the arguments provided are incorrect",
+            ProduceErrorCode::Tired => "the factory is still cooling down",
+            ProduceErrorCode::RclNotEnough => "your room controller level is insufficient to use the factory",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ProduceErrorCode {}

--- a/src/enums/action_error_codes/structurefactory_error_codes.rs
+++ b/src/enums/action_error_codes/structurefactory_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurefactory_error_codes.rs
+++ b/src/enums/action_error_codes/structurefactory_error_codes.rs
@@ -90,8 +90,6 @@ impl From<ProduceErrorCode> for ErrorCode {
         // Safety: ProduceErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurefactory_error_codes.rs
+++ b/src/enums/action_error_codes/structurefactory_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureFactory::produce](crate::StructureFactory::produce).
 ///
-/// Screeps API Docs: [StructureFactory.produce](https://docs.screeps.com/api/#StructureFactory.produce).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureFactory.produce).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1434)
 #[derive(
@@ -81,3 +81,17 @@ impl fmt::Display for ProduceErrorCode {
 }
 
 impl Error for ProduceErrorCode {}
+
+impl From<ProduceErrorCode> for ErrorCode {
+    fn from(value: ProduceErrorCode) -> Self {
+        // Safety: ProduceErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ProduceErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurefactory_error_codes.rs
+++ b/src/enums/action_error_codes/structurefactory_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureFactory::produce](crate::StructureFactory::produce).
+/// Error codes used by
+/// [StructureFactory::produce](crate::StructureFactory::produce).
 ///
 /// Screeps API Docs: [StructureFactory.produce](https://docs.screeps.com/api/#StructureFactory.produce).
 ///
@@ -32,11 +32,11 @@ impl FromReturnCode for ProduceErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -60,13 +60,21 @@ impl fmt::Display for ProduceErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             ProduceErrorCode::NotOwner => "you are not the owner of this structure",
-            ProduceErrorCode::Busy => "the factory is not operated by the pwr_operate_factory power",
-            ProduceErrorCode::NotEnoughResources => "the structure does not have the required amount of resources",
-            ProduceErrorCode::InvalidTarget => "the factory cannot produce the commodity of this level",
+            ProduceErrorCode::Busy => {
+                "the factory is not operated by the pwr_operate_factory power"
+            }
+            ProduceErrorCode::NotEnoughResources => {
+                "the structure does not have the required amount of resources"
+            }
+            ProduceErrorCode::InvalidTarget => {
+                "the factory cannot produce the commodity of this level"
+            }
             ProduceErrorCode::Full => "the factory cannot contain the produce",
             ProduceErrorCode::InvalidArgs => "the arguments provided are incorrect",
             ProduceErrorCode::Tired => "the factory is still cooling down",
-            ProduceErrorCode::RclNotEnough => "your room controller level is insufficient to use the factory",
+            ProduceErrorCode::RclNotEnough => {
+                "your room controller level is insufficient to use the factory"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structurelab_error_codes.rs
+++ b/src/enums/action_error_codes/structurelab_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurelab_error_codes.rs
+++ b/src/enums/action_error_codes/structurelab_error_codes.rs
@@ -82,9 +82,7 @@ impl From<BoostCreepErrorCode> for ErrorCode {
         // Safety: BoostCreepErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -171,9 +169,7 @@ impl From<ReverseReactionErrorCode> for ErrorCode {
         // Safety: ReverseReactionErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -258,9 +254,7 @@ impl From<RunReactionErrorCode> for ErrorCode {
         // Safety: RunReactionErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -339,8 +333,6 @@ impl From<UnboostCreepErrorCode> for ErrorCode {
         // Safety: UnboostCreepErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurelab_error_codes.rs
+++ b/src/enums/action_error_codes/structurelab_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureLab::boost_creep](crate::StructureLab::boost_creep).
 ///
-/// Screeps API Docs: [StructureLab.boostCreep](https://docs.screeps.com/api/#StructureLab.boostCreep).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureLab.boostCreep).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L412)
 #[derive(
@@ -74,10 +74,24 @@ impl fmt::Display for BoostCreepErrorCode {
 
 impl Error for BoostCreepErrorCode {}
 
+impl From<BoostCreepErrorCode> for ErrorCode {
+    fn from(value: BoostCreepErrorCode) -> Self {
+        // Safety: BoostCreepErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: BoostCreepErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [StructureLab::reverse_reaction](crate::StructureLab::reverse_reaction).
 ///
-/// Screeps API Docs: [StructureLab.reverseReaction](https://docs.screeps.com/api/#StructureLab.reverseReaction).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureLab.reverseReaction).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L360)
 #[derive(
@@ -149,10 +163,24 @@ impl fmt::Display for ReverseReactionErrorCode {
 
 impl Error for ReverseReactionErrorCode {}
 
+impl From<ReverseReactionErrorCode> for ErrorCode {
+    fn from(value: ReverseReactionErrorCode) -> Self {
+        // Safety: ReverseReactionErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ReverseReactionErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [StructureLab::run_reaction](crate::StructureLab::run_reaction).
 ///
-/// Screeps API Docs: [StructureLab.runReaction](https://docs.screeps.com/api/#StructureLab.runReaction).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureLab.runReaction).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L317)
 #[derive(
@@ -222,10 +250,24 @@ impl fmt::Display for RunReactionErrorCode {
 
 impl Error for RunReactionErrorCode {}
 
+impl From<RunReactionErrorCode> for ErrorCode {
+    fn from(value: RunReactionErrorCode) -> Self {
+        // Safety: RunReactionErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RunReactionErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [StructureLab::unboost_creep](crate::StructureLab::unboost_creep).
 ///
-/// Screeps API Docs: [StructureLab.unboostCreep](https://docs.screeps.com/api/#StructureLab.unboostCreep).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureLab.unboostCreep).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L443)
 #[derive(
@@ -288,3 +330,17 @@ impl fmt::Display for UnboostCreepErrorCode {
 }
 
 impl Error for UnboostCreepErrorCode {}
+
+impl From<UnboostCreepErrorCode> for ErrorCode {
+    fn from(value: UnboostCreepErrorCode) -> Self {
+        // Safety: UnboostCreepErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: UnboostCreepErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurelab_error_codes.rs
+++ b/src/enums/action_error_codes/structurelab_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureLab::boost_creep](crate::StructureLab::boost_creep).
+/// Error codes used by
+/// [StructureLab::boost_creep](crate::StructureLab::boost_creep).
 ///
 /// Screeps API Docs: [StructureLab.boostCreep](https://docs.screeps.com/api/#StructureLab.boostCreep).
 ///
@@ -30,11 +30,11 @@ impl FromReturnCode for BoostCreepErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -56,11 +56,17 @@ impl fmt::Display for BoostCreepErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             BoostCreepErrorCode::NotOwner => "you are not the owner of this lab",
-            BoostCreepErrorCode::NotFound => "the mineral containing in the lab cannot boost any of the creep's body parts",
-            BoostCreepErrorCode::NotEnoughResources => "the lab does not have enough energy or minerals",
+            BoostCreepErrorCode::NotFound => {
+                "the mineral containing in the lab cannot boost any of the creep's body parts"
+            }
+            BoostCreepErrorCode::NotEnoughResources => {
+                "the lab does not have enough energy or minerals"
+            }
             BoostCreepErrorCode::InvalidTarget => "the targets is not valid creep object",
             BoostCreepErrorCode::NotInRange => "the targets are too far away",
-            BoostCreepErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            BoostCreepErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)
@@ -69,7 +75,8 @@ impl fmt::Display for BoostCreepErrorCode {
 
 impl Error for BoostCreepErrorCode {}
 
-/// Error codes used by [StructureLab::reverse_reaction](crate::StructureLab::reverse_reaction).
+/// Error codes used by
+/// [StructureLab::reverse_reaction](crate::StructureLab::reverse_reaction).
 ///
 /// Screeps API Docs: [StructureLab.reverseReaction](https://docs.screeps.com/api/#StructureLab.reverseReaction).
 ///
@@ -94,11 +101,11 @@ impl FromReturnCode for ReverseReactionErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -122,13 +129,19 @@ impl fmt::Display for ReverseReactionErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             ReverseReactionErrorCode::NotOwner => "you are not the owner of this lab",
-            ReverseReactionErrorCode::NotEnoughResources => "the source lab do not have enough resources",
+            ReverseReactionErrorCode::NotEnoughResources => {
+                "the source lab do not have enough resources"
+            }
             ReverseReactionErrorCode::InvalidTarget => "the targets are not valid lab objects",
             ReverseReactionErrorCode::Full => "one of targets cannot receive any more resource",
             ReverseReactionErrorCode::NotInRange => "the targets are too far away",
-            ReverseReactionErrorCode::InvalidArgs => "the reaction cannot be reversed into this resources",
+            ReverseReactionErrorCode::InvalidArgs => {
+                "the reaction cannot be reversed into this resources"
+            }
             ReverseReactionErrorCode::Tired => "the lab is still cooling down",
-            ReverseReactionErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            ReverseReactionErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)
@@ -137,7 +150,8 @@ impl fmt::Display for ReverseReactionErrorCode {
 
 impl Error for ReverseReactionErrorCode {}
 
-/// Error codes used by [StructureLab::run_reaction](crate::StructureLab::run_reaction).
+/// Error codes used by
+/// [StructureLab::run_reaction](crate::StructureLab::run_reaction).
 ///
 /// Screeps API Docs: [StructureLab.runReaction](https://docs.screeps.com/api/#StructureLab.runReaction).
 ///
@@ -162,11 +176,11 @@ impl FromReturnCode for RunReactionErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -190,13 +204,17 @@ impl fmt::Display for RunReactionErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             RunReactionErrorCode::NotOwner => "you are not the owner of this lab",
-            RunReactionErrorCode::NotEnoughResources => "the source lab do not have enough resources",
+            RunReactionErrorCode::NotEnoughResources => {
+                "the source lab do not have enough resources"
+            }
             RunReactionErrorCode::InvalidTarget => "the targets are not valid lab objects",
             RunReactionErrorCode::Full => "the target cannot receive any more resource",
             RunReactionErrorCode::NotInRange => "the targets are too far away",
             RunReactionErrorCode::InvalidArgs => "the reaction cannot be run using this resources",
             RunReactionErrorCode::Tired => "the lab is still cooling down",
-            RunReactionErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            RunReactionErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)
@@ -205,7 +223,8 @@ impl fmt::Display for RunReactionErrorCode {
 
 impl Error for RunReactionErrorCode {}
 
-/// Error codes used by [StructureLab::unboost_creep](crate::StructureLab::unboost_creep).
+/// Error codes used by
+/// [StructureLab::unboost_creep](crate::StructureLab::unboost_creep).
 ///
 /// Screeps API Docs: [StructureLab.unboostCreep](https://docs.screeps.com/api/#StructureLab.unboostCreep).
 ///
@@ -228,11 +247,11 @@ impl FromReturnCode for UnboostCreepErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -253,12 +272,16 @@ impl FromReturnCode for UnboostCreepErrorCode {
 impl fmt::Display for UnboostCreepErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            UnboostCreepErrorCode::NotOwner => "you are not the owner of this lab, or the target creep",
+            UnboostCreepErrorCode::NotOwner => {
+                "you are not the owner of this lab, or the target creep"
+            }
             UnboostCreepErrorCode::NotFound => "the target has no boosted parts",
             UnboostCreepErrorCode::InvalidTarget => "the target is not a valid creep object",
             UnboostCreepErrorCode::NotInRange => "the target is too far away",
             UnboostCreepErrorCode::Tired => "the lab is still cooling down",
-            UnboostCreepErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            UnboostCreepErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structurelab_error_codes.rs
+++ b/src/enums/action_error_codes/structurelab_error_codes.rs
@@ -1,0 +1,268 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureLab::boost_creep](crate::StructureLab::boost_creep).
+///
+/// Screeps API Docs: [StructureLab.boostCreep](https://docs.screeps.com/api/#StructureLab.boostCreep).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L412)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum BoostCreepErrorCode {
+    NotOwner = -1,
+    NotFound = -5,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for BoostCreepErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(BoostCreepErrorCode::NotOwner)),
+            -5 => Some(Err(BoostCreepErrorCode::NotFound)),
+            -6 => Some(Err(BoostCreepErrorCode::NotEnoughResources)),
+            -7 => Some(Err(BoostCreepErrorCode::InvalidTarget)),
+            -9 => Some(Err(BoostCreepErrorCode::NotInRange)),
+            -14 => Some(Err(BoostCreepErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for BoostCreepErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            BoostCreepErrorCode::NotOwner => "you are not the owner of this lab",
+            BoostCreepErrorCode::NotFound => "the mineral containing in the lab cannot boost any of the creep's body parts",
+            BoostCreepErrorCode::NotEnoughResources => "the lab does not have enough energy or minerals",
+            BoostCreepErrorCode::InvalidTarget => "the targets is not valid creep object",
+            BoostCreepErrorCode::NotInRange => "the targets are too far away",
+            BoostCreepErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for BoostCreepErrorCode {}
+
+/// Error codes used by [StructureLab::reverse_reaction](crate::StructureLab::reverse_reaction).
+///
+/// Screeps API Docs: [StructureLab.reverseReaction](https://docs.screeps.com/api/#StructureLab.reverseReaction).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L360)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ReverseReactionErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for ReverseReactionErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ReverseReactionErrorCode::NotOwner)),
+            -6 => Some(Err(ReverseReactionErrorCode::NotEnoughResources)),
+            -7 => Some(Err(ReverseReactionErrorCode::InvalidTarget)),
+            -8 => Some(Err(ReverseReactionErrorCode::Full)),
+            -9 => Some(Err(ReverseReactionErrorCode::NotInRange)),
+            -10 => Some(Err(ReverseReactionErrorCode::InvalidArgs)),
+            -11 => Some(Err(ReverseReactionErrorCode::Tired)),
+            -14 => Some(Err(ReverseReactionErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ReverseReactionErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ReverseReactionErrorCode::NotOwner => "you are not the owner of this lab",
+            ReverseReactionErrorCode::NotEnoughResources => "the source lab do not have enough resources",
+            ReverseReactionErrorCode::InvalidTarget => "the targets are not valid lab objects",
+            ReverseReactionErrorCode::Full => "one of targets cannot receive any more resource",
+            ReverseReactionErrorCode::NotInRange => "the targets are too far away",
+            ReverseReactionErrorCode::InvalidArgs => "the reaction cannot be reversed into this resources",
+            ReverseReactionErrorCode::Tired => "the lab is still cooling down",
+            ReverseReactionErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ReverseReactionErrorCode {}
+
+/// Error codes used by [StructureLab::run_reaction](crate::StructureLab::run_reaction).
+///
+/// Screeps API Docs: [StructureLab.runReaction](https://docs.screeps.com/api/#StructureLab.runReaction).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L317)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RunReactionErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for RunReactionErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RunReactionErrorCode::NotOwner)),
+            -6 => Some(Err(RunReactionErrorCode::NotEnoughResources)),
+            -7 => Some(Err(RunReactionErrorCode::InvalidTarget)),
+            -8 => Some(Err(RunReactionErrorCode::Full)),
+            -9 => Some(Err(RunReactionErrorCode::NotInRange)),
+            -10 => Some(Err(RunReactionErrorCode::InvalidArgs)),
+            -11 => Some(Err(RunReactionErrorCode::Tired)),
+            -14 => Some(Err(RunReactionErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RunReactionErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RunReactionErrorCode::NotOwner => "you are not the owner of this lab",
+            RunReactionErrorCode::NotEnoughResources => "the source lab do not have enough resources",
+            RunReactionErrorCode::InvalidTarget => "the targets are not valid lab objects",
+            RunReactionErrorCode::Full => "the target cannot receive any more resource",
+            RunReactionErrorCode::NotInRange => "the targets are too far away",
+            RunReactionErrorCode::InvalidArgs => "the reaction cannot be run using this resources",
+            RunReactionErrorCode::Tired => "the lab is still cooling down",
+            RunReactionErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RunReactionErrorCode {}
+
+/// Error codes used by [StructureLab::unboost_creep](crate::StructureLab::unboost_creep).
+///
+/// Screeps API Docs: [StructureLab.unboostCreep](https://docs.screeps.com/api/#StructureLab.unboostCreep).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L443)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum UnboostCreepErrorCode {
+    NotOwner = -1,
+    NotFound = -5,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for UnboostCreepErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(UnboostCreepErrorCode::NotOwner)),
+            -5 => Some(Err(UnboostCreepErrorCode::NotFound)),
+            -7 => Some(Err(UnboostCreepErrorCode::InvalidTarget)),
+            -9 => Some(Err(UnboostCreepErrorCode::NotInRange)),
+            -11 => Some(Err(UnboostCreepErrorCode::Tired)),
+            -14 => Some(Err(UnboostCreepErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for UnboostCreepErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            UnboostCreepErrorCode::NotOwner => "you are not the owner of this lab, or the target creep",
+            UnboostCreepErrorCode::NotFound => "the target has no boosted parts",
+            UnboostCreepErrorCode::InvalidTarget => "the target is not a valid creep object",
+            UnboostCreepErrorCode::NotInRange => "the target is too far away",
+            UnboostCreepErrorCode::Tired => "the lab is still cooling down",
+            UnboostCreepErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for UnboostCreepErrorCode {}

--- a/src/enums/action_error_codes/structurelink_error_codes.rs
+++ b/src/enums/action_error_codes/structurelink_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurelink_error_codes.rs
+++ b/src/enums/action_error_codes/structurelink_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureLink::transfer_energy](crate::StructureLink::transfer_energy).
 ///
-/// Screeps API Docs: [StructureLink.transferEnergy](https://docs.screeps.com/api/#StructureLink.transferEnergy).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureLink.transferEnergy).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L488)
 #[derive(
@@ -79,3 +79,17 @@ impl fmt::Display for TransferEnergyErrorCode {
 }
 
 impl Error for TransferEnergyErrorCode {}
+
+impl From<TransferEnergyErrorCode> for ErrorCode {
+    fn from(value: TransferEnergyErrorCode) -> Self {
+        // Safety: TransferEnergyErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: TransferEnergyErrorCode discriminants are always error code values,
+        // and thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurelink_error_codes.rs
+++ b/src/enums/action_error_codes/structurelink_error_codes.rs
@@ -88,8 +88,6 @@ impl From<TransferEnergyErrorCode> for ErrorCode {
         // Safety: TransferEnergyErrorCode discriminants are always error code values,
         // and thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurelink_error_codes.rs
+++ b/src/enums/action_error_codes/structurelink_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureLink::transfer_energy](crate::StructureLink::transfer_energy).
+/// Error codes used by
+/// [StructureLink::transfer_energy](crate::StructureLink::transfer_energy).
 ///
 /// Screeps API Docs: [StructureLink.transferEnergy](https://docs.screeps.com/api/#StructureLink.transferEnergy).
 ///
@@ -32,11 +32,11 @@ impl FromReturnCode for TransferEnergyErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -60,13 +60,19 @@ impl fmt::Display for TransferEnergyErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             TransferEnergyErrorCode::NotOwner => "you are not the owner of this link",
-            TransferEnergyErrorCode::NotEnoughEnergy => "the structure does not have the given amount of energy",
-            TransferEnergyErrorCode::InvalidTarget => "the target is not a valid structurelink object",
+            TransferEnergyErrorCode::NotEnoughEnergy => {
+                "the structure does not have the given amount of energy"
+            }
+            TransferEnergyErrorCode::InvalidTarget => {
+                "the target is not a valid structurelink object"
+            }
             TransferEnergyErrorCode::Full => "the target cannot receive any more energy",
             TransferEnergyErrorCode::NotInRange => "the target is too far away",
             TransferEnergyErrorCode::InvalidArgs => "the energy amount is incorrect",
             TransferEnergyErrorCode::Tired => "the link is still cooling down",
-            TransferEnergyErrorCode::RclNotEnough => "room controller level insufficient to use this link",
+            TransferEnergyErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this link"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structurelink_error_codes.rs
+++ b/src/enums/action_error_codes/structurelink_error_codes.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureLink::transfer_energy](crate::StructureLink::transfer_energy).
+///
+/// Screeps API Docs: [StructureLink.transferEnergy](https://docs.screeps.com/api/#StructureLink.transferEnergy).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L488)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum TransferEnergyErrorCode {
+    NotOwner = -1,
+    NotEnoughEnergy = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for TransferEnergyErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(TransferEnergyErrorCode::NotOwner)),
+            -6 => Some(Err(TransferEnergyErrorCode::NotEnoughEnergy)),
+            -7 => Some(Err(TransferEnergyErrorCode::InvalidTarget)),
+            -8 => Some(Err(TransferEnergyErrorCode::Full)),
+            -9 => Some(Err(TransferEnergyErrorCode::NotInRange)),
+            -10 => Some(Err(TransferEnergyErrorCode::InvalidArgs)),
+            -11 => Some(Err(TransferEnergyErrorCode::Tired)),
+            -14 => Some(Err(TransferEnergyErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for TransferEnergyErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            TransferEnergyErrorCode::NotOwner => "you are not the owner of this link",
+            TransferEnergyErrorCode::NotEnoughEnergy => "the structure does not have the given amount of energy",
+            TransferEnergyErrorCode::InvalidTarget => "the target is not a valid structurelink object",
+            TransferEnergyErrorCode::Full => "the target cannot receive any more energy",
+            TransferEnergyErrorCode::NotInRange => "the target is too far away",
+            TransferEnergyErrorCode::InvalidArgs => "the energy amount is incorrect",
+            TransferEnergyErrorCode::Tired => "the link is still cooling down",
+            TransferEnergyErrorCode::RclNotEnough => "room controller level insufficient to use this link",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for TransferEnergyErrorCode {}

--- a/src/enums/action_error_codes/structurenuker_error_codes.rs
+++ b/src/enums/action_error_codes/structurenuker_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureNuker::launch_nuke](crate::StructureNuker::launch_nuke).
 ///
-/// Screeps API Docs: [StructureNuker.launchNuke](https://docs.screeps.com/api/#StructureNuker.launchNuke).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureNuker.launchNuke).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1356)
 #[derive(
@@ -76,3 +76,17 @@ impl fmt::Display for LaunchNukeErrorCode {
 }
 
 impl Error for LaunchNukeErrorCode {}
+
+impl From<LaunchNukeErrorCode> for ErrorCode {
+    fn from(value: LaunchNukeErrorCode) -> Self {
+        // Safety: LaunchNukeErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: LaunchNukeErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurenuker_error_codes.rs
+++ b/src/enums/action_error_codes/structurenuker_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurenuker_error_codes.rs
+++ b/src/enums/action_error_codes/structurenuker_error_codes.rs
@@ -1,0 +1,73 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureNuker::launch_nuke](crate::StructureNuker::launch_nuke).
+///
+/// Screeps API Docs: [StructureNuker.launchNuke](https://docs.screeps.com/api/#StructureNuker.launchNuke).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1356)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum LaunchNukeErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for LaunchNukeErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(LaunchNukeErrorCode::NotOwner)),
+            -6 => Some(Err(LaunchNukeErrorCode::NotEnoughResources)),
+            -7 => Some(Err(LaunchNukeErrorCode::InvalidTarget)),
+            -9 => Some(Err(LaunchNukeErrorCode::NotInRange)),
+            -10 => Some(Err(LaunchNukeErrorCode::InvalidArgs)),
+            -11 => Some(Err(LaunchNukeErrorCode::Tired)),
+            -14 => Some(Err(LaunchNukeErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for LaunchNukeErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            LaunchNukeErrorCode::NotOwner => "you are not the owner of this structure",
+            LaunchNukeErrorCode::NotEnoughResources => "the structure does not have enough energy and/or ghodium",
+            LaunchNukeErrorCode::InvalidTarget => "the nuke can't be launched to the specified roomposition (see start areas)",
+            LaunchNukeErrorCode::NotInRange => "the target room is out of range",
+            LaunchNukeErrorCode::InvalidArgs => "the target is not a valid roomposition",
+            LaunchNukeErrorCode::Tired => "this structure is still cooling down",
+            LaunchNukeErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for LaunchNukeErrorCode {}

--- a/src/enums/action_error_codes/structurenuker_error_codes.rs
+++ b/src/enums/action_error_codes/structurenuker_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureNuker::launch_nuke](crate::StructureNuker::launch_nuke).
+/// Error codes used by
+/// [StructureNuker::launch_nuke](crate::StructureNuker::launch_nuke).
 ///
 /// Screeps API Docs: [StructureNuker.launchNuke](https://docs.screeps.com/api/#StructureNuker.launchNuke).
 ///
@@ -31,11 +31,11 @@ impl FromReturnCode for LaunchNukeErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -58,12 +58,18 @@ impl fmt::Display for LaunchNukeErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             LaunchNukeErrorCode::NotOwner => "you are not the owner of this structure",
-            LaunchNukeErrorCode::NotEnoughResources => "the structure does not have enough energy and/or ghodium",
-            LaunchNukeErrorCode::InvalidTarget => "the nuke can't be launched to the specified roomposition (see start areas)",
+            LaunchNukeErrorCode::NotEnoughResources => {
+                "the structure does not have enough energy and/or ghodium"
+            }
+            LaunchNukeErrorCode::InvalidTarget => {
+                "the nuke can't be launched to the specified roomposition (see start areas)"
+            }
             LaunchNukeErrorCode::NotInRange => "the target room is out of range",
             LaunchNukeErrorCode::InvalidArgs => "the target is not a valid roomposition",
             LaunchNukeErrorCode::Tired => "this structure is still cooling down",
-            LaunchNukeErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            LaunchNukeErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structurenuker_error_codes.rs
+++ b/src/enums/action_error_codes/structurenuker_error_codes.rs
@@ -85,8 +85,6 @@ impl From<LaunchNukeErrorCode> for ErrorCode {
         // Safety: LaunchNukeErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structureobserver_error_codes.rs
+++ b/src/enums/action_error_codes/structureobserver_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structureobserver_error_codes.rs
+++ b/src/enums/action_error_codes/structureobserver_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureObserver::observe_room](crate::StructureObserver::observe_room).
+/// Error codes used by
+/// [StructureObserver::observe_room](crate::StructureObserver::observe_room).
 ///
 /// Screeps API Docs: [StructureObserver.observeRoom](https://docs.screeps.com/api/#StructureObserver.observeRoom).
 ///
@@ -28,11 +28,11 @@ impl FromReturnCode for ObserveRoomErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -54,7 +54,9 @@ impl fmt::Display for ObserveRoomErrorCode {
             ObserveRoomErrorCode::NotOwner => "you are not the owner of this structure",
             ObserveRoomErrorCode::NotInRange => "room roomname is not in observing range",
             ObserveRoomErrorCode::InvalidArgs => "roomname argument is not a valid room name value",
-            ObserveRoomErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            ObserveRoomErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structureobserver_error_codes.rs
+++ b/src/enums/action_error_codes/structureobserver_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureObserver::observe_room](crate::StructureObserver::observe_room).
 ///
-/// Screeps API Docs: [StructureObserver.observeRoom](https://docs.screeps.com/api/#StructureObserver.observeRoom).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureObserver.observeRoom).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L548)
 #[derive(
@@ -63,3 +63,17 @@ impl fmt::Display for ObserveRoomErrorCode {
 }
 
 impl Error for ObserveRoomErrorCode {}
+
+impl From<ObserveRoomErrorCode> for ErrorCode {
+    fn from(value: ObserveRoomErrorCode) -> Self {
+        // Safety: ObserveRoomErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ObserveRoomErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structureobserver_error_codes.rs
+++ b/src/enums/action_error_codes/structureobserver_error_codes.rs
@@ -1,0 +1,64 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureObserver::observe_room](crate::StructureObserver::observe_room).
+///
+/// Screeps API Docs: [StructureObserver.observeRoom](https://docs.screeps.com/api/#StructureObserver.observeRoom).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L548)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ObserveRoomErrorCode {
+    NotOwner = -1,
+    NotInRange = -9,
+    InvalidArgs = -10,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for ObserveRoomErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ObserveRoomErrorCode::NotOwner)),
+            -9 => Some(Err(ObserveRoomErrorCode::NotInRange)),
+            -10 => Some(Err(ObserveRoomErrorCode::InvalidArgs)),
+            -14 => Some(Err(ObserveRoomErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ObserveRoomErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ObserveRoomErrorCode::NotOwner => "you are not the owner of this structure",
+            ObserveRoomErrorCode::NotInRange => "room roomname is not in observing range",
+            ObserveRoomErrorCode::InvalidArgs => "roomname argument is not a valid room name value",
+            ObserveRoomErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ObserveRoomErrorCode {}

--- a/src/enums/action_error_codes/structureobserver_error_codes.rs
+++ b/src/enums/action_error_codes/structureobserver_error_codes.rs
@@ -72,8 +72,6 @@ impl From<ObserveRoomErrorCode> for ErrorCode {
         // Safety: ObserveRoomErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
@@ -1,0 +1,61 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructurePowerSpawn::process_power](crate::StructurePowerSpawn::process_power).
+///
+/// Screeps API Docs: [StructurePowerSpawn.processPower](https://docs.screeps.com/api/#StructurePowerSpawn.processPower).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L613)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum ProcessPowerErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for ProcessPowerErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(ProcessPowerErrorCode::NotOwner)),
+            -6 => Some(Err(ProcessPowerErrorCode::NotEnoughResources)),
+            -14 => Some(Err(ProcessPowerErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ProcessPowerErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            ProcessPowerErrorCode::NotOwner => "you are not the owner of this structure",
+            ProcessPowerErrorCode::NotEnoughResources => "the structure does not have enough energy or power resource units",
+            ProcessPowerErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for ProcessPowerErrorCode {}

--- a/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,9 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructurePowerSpawn::process_power](crate::StructurePowerSpawn::process_power).
+/// Error codes used by
+/// [StructurePowerSpawn::process_power](crate::StructurePowerSpawn::process_power).
+///
 ///
 /// Screeps API Docs: [StructurePowerSpawn.processPower](https://docs.screeps.com/api/#StructurePowerSpawn.processPower).
 ///
@@ -27,11 +28,11 @@ impl FromReturnCode for ProcessPowerErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -50,8 +51,12 @@ impl fmt::Display for ProcessPowerErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             ProcessPowerErrorCode::NotOwner => "you are not the owner of this structure",
-            ProcessPowerErrorCode::NotEnoughResources => "the structure does not have enough energy or power resource units",
-            ProcessPowerErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            ProcessPowerErrorCode::NotEnoughResources => {
+                "the structure does not have enough energy or power resource units"
+            }
+            ProcessPowerErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
@@ -3,13 +3,13 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructurePowerSpawn::process_power](crate::StructurePowerSpawn::process_power).
 ///
 ///
-/// Screeps API Docs: [StructurePowerSpawn.processPower](https://docs.screeps.com/api/#StructurePowerSpawn.processPower).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructurePowerSpawn.processPower).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L613)
 #[derive(
@@ -63,3 +63,17 @@ impl fmt::Display for ProcessPowerErrorCode {
 }
 
 impl Error for ProcessPowerErrorCode {}
+
+impl From<ProcessPowerErrorCode> for ErrorCode {
+    fn from(value: ProcessPowerErrorCode) -> Self {
+        // Safety: ProcessPowerErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: ProcessPowerErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurepowerspawn_error_codes.rs
@@ -72,8 +72,6 @@ impl From<ProcessPowerErrorCode> for ErrorCode {
         // Safety: ProcessPowerErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurerampart_error_codes.rs
+++ b/src/enums/action_error_codes/structurerampart_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurerampart_error_codes.rs
+++ b/src/enums/action_error_codes/structurerampart_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureRampart::set_public](crate::StructureRampart::set_public).
+/// Error codes used by
+/// [StructureRampart::set_public](crate::StructureRampart::set_public).
 ///
 /// Screeps API Docs: [StructureRampart.setPublic](https://docs.screeps.com/api/#StructureRampart.setPublic).
 ///
@@ -25,11 +25,11 @@ impl FromReturnCode for SetPublicErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 

--- a/src/enums/action_error_codes/structurerampart_error_codes.rs
+++ b/src/enums/action_error_codes/structurerampart_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureRampart::set_public](crate::StructureRampart::set_public).
 ///
-/// Screeps API Docs: [StructureRampart.setPublic](https://docs.screeps.com/api/#StructureRampart.setPublic).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureRampart.setPublic).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L651)
 #[derive(
@@ -52,3 +52,17 @@ impl fmt::Display for SetPublicErrorCode {
 }
 
 impl Error for SetPublicErrorCode {}
+
+impl From<SetPublicErrorCode> for ErrorCode {
+    fn from(value: SetPublicErrorCode) -> Self {
+        // Safety: SetPublicErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SetPublicErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurerampart_error_codes.rs
+++ b/src/enums/action_error_codes/structurerampart_error_codes.rs
@@ -61,8 +61,6 @@ impl From<SetPublicErrorCode> for ErrorCode {
         // Safety: SetPublicErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structurerampart_error_codes.rs
+++ b/src/enums/action_error_codes/structurerampart_error_codes.rs
@@ -1,0 +1,55 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureRampart::set_public](crate::StructureRampart::set_public).
+///
+/// Screeps API Docs: [StructureRampart.setPublic](https://docs.screeps.com/api/#StructureRampart.setPublic).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L651)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SetPublicErrorCode {
+    NotOwner = -1,
+}
+
+impl FromReturnCode for SetPublicErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(SetPublicErrorCode::NotOwner)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SetPublicErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SetPublicErrorCode::NotOwner => "you are not the owner of this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SetPublicErrorCode {}

--- a/src/enums/action_error_codes/structurespawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurespawn_error_codes.rs
@@ -1,0 +1,191 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureSpawn::spawn_creep](crate::StructureSpawn::spawn_creep).
+///
+/// Screeps API Docs: [StructureSpawn.spawnCreep](https://docs.screeps.com/api/#StructureSpawn.spawnCreep).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1063)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SpawnCreepErrorCode {
+    NotOwner = -1,
+    NameExists = -3,
+    Busy = -4,
+    NotEnoughEnergy = -6,
+    InvalidArgs = -10,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for SpawnCreepErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(SpawnCreepErrorCode::NotOwner)),
+            -3 => Some(Err(SpawnCreepErrorCode::NameExists)),
+            -4 => Some(Err(SpawnCreepErrorCode::Busy)),
+            -6 => Some(Err(SpawnCreepErrorCode::NotEnoughEnergy)),
+            -10 => Some(Err(SpawnCreepErrorCode::InvalidArgs)),
+            -14 => Some(Err(SpawnCreepErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SpawnCreepErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SpawnCreepErrorCode::NotOwner => "you are not the owner of this spawn",
+            SpawnCreepErrorCode::NameExists => "there is a creep with the same name already",
+            SpawnCreepErrorCode::Busy => "the spawn is already in process of spawning another creep",
+            SpawnCreepErrorCode::NotEnoughEnergy => "the spawn and its extensions contain not enough energy to create a creep with the given body",
+            SpawnCreepErrorCode::InvalidArgs => "body is not properly described or name was not provided",
+            SpawnCreepErrorCode::RclNotEnough => "your room controller level is insufficient to use this spawn",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SpawnCreepErrorCode {}
+
+/// Error codes used by [StructureSpawn::recycle_creep](crate::StructureSpawn::recycle_creep).
+///
+/// Screeps API Docs: [StructureSpawn.recycleCreep](https://docs.screeps.com/api/#StructureSpawn.recycleCreep).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1269)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RecycleCreepErrorCode {
+    NotOwner = -1,
+    InvalidTarget = -7,
+    NotInRange = -9,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for RecycleCreepErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RecycleCreepErrorCode::NotOwner)),
+            -7 => Some(Err(RecycleCreepErrorCode::InvalidTarget)),
+            -9 => Some(Err(RecycleCreepErrorCode::NotInRange)),
+            -14 => Some(Err(RecycleCreepErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RecycleCreepErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RecycleCreepErrorCode::NotOwner => "you are not the owner of this spawn or the target creep",
+            RecycleCreepErrorCode::InvalidTarget => "the specified target object is not a creep",
+            RecycleCreepErrorCode::NotInRange => "the target creep is too far away",
+            RecycleCreepErrorCode::RclNotEnough => "your room controller level is insufficient to use this spawn",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RecycleCreepErrorCode {}
+
+/// Error codes used by [StructureSpawn::renew_creep](crate::StructureSpawn::renew_creep).
+///
+/// Screeps API Docs: [StructureSpawn.renewCreep](https://docs.screeps.com/api/#StructureSpawn.renewCreep).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1237)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum RenewCreepErrorCode {
+    NotOwner = -1,
+    Busy = -4,
+    NotEnoughEnergy = -6,
+    InvalidTarget = -7,
+    Full = -8,
+    NotInRange = -9,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for RenewCreepErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(RenewCreepErrorCode::NotOwner)),
+            -4 => Some(Err(RenewCreepErrorCode::Busy)),
+            -6 => Some(Err(RenewCreepErrorCode::NotEnoughEnergy)),
+            -7 => Some(Err(RenewCreepErrorCode::InvalidTarget)),
+            -8 => Some(Err(RenewCreepErrorCode::Full)),
+            -9 => Some(Err(RenewCreepErrorCode::NotInRange)),
+            -14 => Some(Err(RenewCreepErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RenewCreepErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            RenewCreepErrorCode::NotOwner => "you are not the owner of the spawn, or the creep",
+            RenewCreepErrorCode::Busy => "the spawn is spawning another creep",
+            RenewCreepErrorCode::NotEnoughEnergy => "the spawn does not have enough energy",
+            RenewCreepErrorCode::InvalidTarget => "the specified target object is not a creep, or the creep has claim body part",
+            RenewCreepErrorCode::Full => "the target creep's time to live timer is full",
+            RenewCreepErrorCode::NotInRange => "the target creep is too far away",
+            RenewCreepErrorCode::RclNotEnough => "your room controller level is insufficient to use this spawn",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for RenewCreepErrorCode {}

--- a/src/enums/action_error_codes/structurespawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurespawn_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureSpawn::spawn_creep](crate::StructureSpawn::spawn_creep).
+/// Error codes used by
+/// [StructureSpawn::spawn_creep](crate::StructureSpawn::spawn_creep).
 ///
 /// Screeps API Docs: [StructureSpawn.spawnCreep](https://docs.screeps.com/api/#StructureSpawn.spawnCreep).
 ///
@@ -30,11 +30,11 @@ impl FromReturnCode for SpawnCreepErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -69,7 +69,8 @@ impl fmt::Display for SpawnCreepErrorCode {
 
 impl Error for SpawnCreepErrorCode {}
 
-/// Error codes used by [StructureSpawn::recycle_creep](crate::StructureSpawn::recycle_creep).
+/// Error codes used by
+/// [StructureSpawn::recycle_creep](crate::StructureSpawn::recycle_creep).
 ///
 /// Screeps API Docs: [StructureSpawn.recycleCreep](https://docs.screeps.com/api/#StructureSpawn.recycleCreep).
 ///
@@ -90,11 +91,11 @@ impl FromReturnCode for RecycleCreepErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -113,10 +114,14 @@ impl FromReturnCode for RecycleCreepErrorCode {
 impl fmt::Display for RecycleCreepErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
-            RecycleCreepErrorCode::NotOwner => "you are not the owner of this spawn or the target creep",
+            RecycleCreepErrorCode::NotOwner => {
+                "you are not the owner of this spawn or the target creep"
+            }
             RecycleCreepErrorCode::InvalidTarget => "the specified target object is not a creep",
             RecycleCreepErrorCode::NotInRange => "the target creep is too far away",
-            RecycleCreepErrorCode::RclNotEnough => "your room controller level is insufficient to use this spawn",
+            RecycleCreepErrorCode::RclNotEnough => {
+                "your room controller level is insufficient to use this spawn"
+            }
         };
 
         write!(f, "{}", msg)
@@ -125,7 +130,8 @@ impl fmt::Display for RecycleCreepErrorCode {
 
 impl Error for RecycleCreepErrorCode {}
 
-/// Error codes used by [StructureSpawn::renew_creep](crate::StructureSpawn::renew_creep).
+/// Error codes used by
+/// [StructureSpawn::renew_creep](crate::StructureSpawn::renew_creep).
 ///
 /// Screeps API Docs: [StructureSpawn.renewCreep](https://docs.screeps.com/api/#StructureSpawn.renewCreep).
 ///
@@ -149,11 +155,11 @@ impl FromReturnCode for RenewCreepErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -178,10 +184,14 @@ impl fmt::Display for RenewCreepErrorCode {
             RenewCreepErrorCode::NotOwner => "you are not the owner of the spawn, or the creep",
             RenewCreepErrorCode::Busy => "the spawn is spawning another creep",
             RenewCreepErrorCode::NotEnoughEnergy => "the spawn does not have enough energy",
-            RenewCreepErrorCode::InvalidTarget => "the specified target object is not a creep, or the creep has claim body part",
+            RenewCreepErrorCode::InvalidTarget => {
+                "the specified target object is not a creep, or the creep has claim body part"
+            }
             RenewCreepErrorCode::Full => "the target creep's time to live timer is full",
             RenewCreepErrorCode::NotInRange => "the target creep is too far away",
-            RenewCreepErrorCode::RclNotEnough => "your room controller level is insufficient to use this spawn",
+            RenewCreepErrorCode::RclNotEnough => {
+                "your room controller level is insufficient to use this spawn"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structurespawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurespawn_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structurespawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurespawn_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureSpawn::spawn_creep](crate::StructureSpawn::spawn_creep).
 ///
-/// Screeps API Docs: [StructureSpawn.spawnCreep](https://docs.screeps.com/api/#StructureSpawn.spawnCreep).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureSpawn.spawnCreep).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1063)
 #[derive(
@@ -68,10 +68,24 @@ impl fmt::Display for SpawnCreepErrorCode {
 
 impl Error for SpawnCreepErrorCode {}
 
+impl From<SpawnCreepErrorCode> for ErrorCode {
+    fn from(value: SpawnCreepErrorCode) -> Self {
+        // Safety: SpawnCreepErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SpawnCreepErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [StructureSpawn::recycle_creep](crate::StructureSpawn::recycle_creep).
 ///
-/// Screeps API Docs: [StructureSpawn.recycleCreep](https://docs.screeps.com/api/#StructureSpawn.recycleCreep).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureSpawn.recycleCreep).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1269)
 #[derive(
@@ -129,10 +143,24 @@ impl fmt::Display for RecycleCreepErrorCode {
 
 impl Error for RecycleCreepErrorCode {}
 
+impl From<RecycleCreepErrorCode> for ErrorCode {
+    fn from(value: RecycleCreepErrorCode) -> Self {
+        // Safety: RecycleCreepErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RecycleCreepErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by
 /// [StructureSpawn::renew_creep](crate::StructureSpawn::renew_creep).
 ///
-/// Screeps API Docs: [StructureSpawn.renewCreep](https://docs.screeps.com/api/#StructureSpawn.renewCreep).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureSpawn.renewCreep).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L1237)
 #[derive(
@@ -198,3 +226,17 @@ impl fmt::Display for RenewCreepErrorCode {
 }
 
 impl Error for RenewCreepErrorCode {}
+
+impl From<RenewCreepErrorCode> for ErrorCode {
+    fn from(value: RenewCreepErrorCode) -> Self {
+        // Safety: RenewCreepErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: RenewCreepErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structurespawn_error_codes.rs
+++ b/src/enums/action_error_codes/structurespawn_error_codes.rs
@@ -76,9 +76,7 @@ impl From<SpawnCreepErrorCode> for ErrorCode {
         // Safety: SpawnCreepErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -151,9 +149,7 @@ impl From<RecycleCreepErrorCode> for ErrorCode {
         // Safety: RecycleCreepErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -235,8 +231,6 @@ impl From<RenewCreepErrorCode> for ErrorCode {
         // Safety: RenewCreepErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structureterminal_error_codes.rs
+++ b/src/enums/action_error_codes/structureterminal_error_codes.rs
@@ -76,8 +76,6 @@ impl From<SendErrorCode> for ErrorCode {
         // Safety: SendErrorCode discriminants are always error code values, and thus
         // the Result returned here will always be an `Err` variant, so we can always
         // extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structureterminal_error_codes.rs
+++ b/src/enums/action_error_codes/structureterminal_error_codes.rs
@@ -3,12 +3,12 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by
 /// [StructureTerminal::send](crate::StructureTerminal::send).
 ///
-/// Screeps API Docs: [StructureTerminal.send](https://docs.screeps.com/api/#StructureTerminal.send).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureTerminal.send).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L714)
 #[derive(
@@ -68,3 +68,16 @@ impl fmt::Display for SendErrorCode {
 }
 
 impl Error for SendErrorCode {}
+
+impl From<SendErrorCode> for ErrorCode {
+    fn from(value: SendErrorCode) -> Self {
+        // Safety: SendErrorCode is repr(i8), so we can cast it to get the discriminant
+        // value, which will match the raw return code value that ErrorCode expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: SendErrorCode discriminants are always error code values, and thus
+        // the Result returned here will always be an `Err` variant, so we can always
+        // extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structureterminal_error_codes.rs
+++ b/src/enums/action_error_codes/structureterminal_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structureterminal_error_codes.rs
+++ b/src/enums/action_error_codes/structureterminal_error_codes.rs
@@ -1,0 +1,67 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureTerminal::send](crate::StructureTerminal::send).
+///
+/// Screeps API Docs: [StructureTerminal.send](https://docs.screeps.com/api/#StructureTerminal.send).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L714)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum SendErrorCode {
+    NotOwner = -1,
+    NotEnoughResources = -6,
+    InvalidArgs = -10,
+    Tired = -11,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for SendErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(SendErrorCode::NotOwner)),
+            -6 => Some(Err(SendErrorCode::NotEnoughResources)),
+            -10 => Some(Err(SendErrorCode::InvalidArgs)),
+            -11 => Some(Err(SendErrorCode::Tired)),
+            -14 => Some(Err(SendErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SendErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            SendErrorCode::NotOwner => "you are not the owner of this structure",
+            SendErrorCode::NotEnoughResources => "the structure does not have the required amount of resources",
+            SendErrorCode::InvalidArgs => "the arguments provided are incorrect",
+            SendErrorCode::Tired => "the terminal is still cooling down",
+            SendErrorCode::RclNotEnough => "your room controller level is insufficient to use this terminal",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for SendErrorCode {}

--- a/src/enums/action_error_codes/structureterminal_error_codes.rs
+++ b/src/enums/action_error_codes/structureterminal_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -7,7 +6,8 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;
 
-/// Error codes used by [StructureTerminal::send](crate::StructureTerminal::send).
+/// Error codes used by
+/// [StructureTerminal::send](crate::StructureTerminal::send).
 ///
 /// Screeps API Docs: [StructureTerminal.send](https://docs.screeps.com/api/#StructureTerminal.send).
 ///
@@ -29,11 +29,11 @@ impl FromReturnCode for SendErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -54,10 +54,14 @@ impl fmt::Display for SendErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg: &'static str = match self {
             SendErrorCode::NotOwner => "you are not the owner of this structure",
-            SendErrorCode::NotEnoughResources => "the structure does not have the required amount of resources",
+            SendErrorCode::NotEnoughResources => {
+                "the structure does not have the required amount of resources"
+            }
             SendErrorCode::InvalidArgs => "the arguments provided are incorrect",
             SendErrorCode::Tired => "the terminal is still cooling down",
-            SendErrorCode::RclNotEnough => "your room controller level is insufficient to use this terminal",
+            SendErrorCode::RclNotEnough => {
+                "your room controller level is insufficient to use this terminal"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/enums/action_error_codes/structuretower_error_codes.rs
+++ b/src/enums/action_error_codes/structuretower_error_codes.rs
@@ -1,7 +1,6 @@
 use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::FromReturnCode;

--- a/src/enums/action_error_codes/structuretower_error_codes.rs
+++ b/src/enums/action_error_codes/structuretower_error_codes.rs
@@ -3,11 +3,11 @@ use std::{error::Error, fmt};
 use num_derive::FromPrimitive;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::FromReturnCode;
+use crate::{constants::ErrorCode, FromReturnCode};
 
 /// Error codes used by [StructureTower::attack](crate::StructureTower::attack).
 ///
-/// Screeps API Docs: [StructureTower.attack](https://docs.screeps.com/api/#StructureTower.attack).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureTower.attack).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L766)
 #[derive(
@@ -63,9 +63,23 @@ impl fmt::Display for TowerAttackErrorCode {
 
 impl Error for TowerAttackErrorCode {}
 
+impl From<TowerAttackErrorCode> for ErrorCode {
+    fn from(value: TowerAttackErrorCode) -> Self {
+        // Safety: TowerAttackErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: TowerAttackErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [StructureTower::heal](crate::StructureTower::heal).
 ///
-/// Screeps API Docs: [StructureTower.heal](https://docs.screeps.com/api/#StructureTower.heal).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureTower.heal).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L786)
 #[derive(
@@ -121,9 +135,23 @@ impl fmt::Display for TowerHealErrorCode {
 
 impl Error for TowerHealErrorCode {}
 
+impl From<TowerHealErrorCode> for ErrorCode {
+    fn from(value: TowerHealErrorCode) -> Self {
+        // Safety: TowerHealErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: TowerHealErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}
+
 /// Error codes used by [StructureTower::repair](crate::StructureTower::repair).
 ///
-/// Screeps API Docs: [StructureTower.repair](https://docs.screeps.com/api/#StructureTower.repair).
+/// [Screeps API Docs](https://docs.screeps.com/api/#StructureTower.repair).
 ///
 /// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L806)
 #[derive(
@@ -178,3 +206,17 @@ impl fmt::Display for TowerRepairErrorCode {
 }
 
 impl Error for TowerRepairErrorCode {}
+
+impl From<TowerRepairErrorCode> for ErrorCode {
+    fn from(value: TowerRepairErrorCode) -> Self {
+        // Safety: TowerRepairErrorCode is repr(i8), so we can cast it to get the
+        // discriminant value, which will match the raw return code value that ErrorCode
+        // expects.   Ref: https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.discriminant.coercion.intro
+        // Safety: TowerRepairErrorCode discriminants are always error code values, and
+        // thus the Result returned here will always be an `Err` variant, so we can
+        // always extract the error without panicking
+        Self::result_from_i8(value as i8)
+            .unwrap_err()
+            .expect("expect enum discriminant to be an error code")
+    }
+}

--- a/src/enums/action_error_codes/structuretower_error_codes.rs
+++ b/src/enums/action_error_codes/structuretower_error_codes.rs
@@ -1,0 +1,176 @@
+use std::fmt;
+use std::error::Error;
+
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+use crate::FromReturnCode;
+
+/// Error codes used by [StructureTower::attack](crate::StructureTower::attack).
+///
+/// Screeps API Docs: [StructureTower.attack](https://docs.screeps.com/api/#StructureTower.attack).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L766)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum TowerAttackErrorCode {
+    NotOwner = -1,
+    NotEnoughEnergy = -6,
+    InvalidTarget = -7,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for TowerAttackErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(TowerAttackErrorCode::NotOwner)),
+            -6 => Some(Err(TowerAttackErrorCode::NotEnoughEnergy)),
+            -7 => Some(Err(TowerAttackErrorCode::InvalidTarget)),
+            -14 => Some(Err(TowerAttackErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for TowerAttackErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            TowerAttackErrorCode::NotOwner => "you are not the owner of this structure",
+            TowerAttackErrorCode::NotEnoughEnergy => "the tower does not have enough energy",
+            TowerAttackErrorCode::InvalidTarget => "the target is not a valid attackable object",
+            TowerAttackErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for TowerAttackErrorCode {}
+
+/// Error codes used by [StructureTower::heal](crate::StructureTower::heal).
+///
+/// Screeps API Docs: [StructureTower.heal](https://docs.screeps.com/api/#StructureTower.heal).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L786)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum TowerHealErrorCode {
+    NotOwner = -1,
+    NotEnoughEnergy = -6,
+    InvalidTarget = -7,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for TowerHealErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(TowerHealErrorCode::NotOwner)),
+            -6 => Some(Err(TowerHealErrorCode::NotEnoughEnergy)),
+            -7 => Some(Err(TowerHealErrorCode::InvalidTarget)),
+            -14 => Some(Err(TowerHealErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for TowerHealErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            TowerHealErrorCode::NotOwner => "you are not the owner of this structure",
+            TowerHealErrorCode::NotEnoughEnergy => "the tower does not have enough energy",
+            TowerHealErrorCode::InvalidTarget => "the target is not a valid creep object",
+            TowerHealErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for TowerHealErrorCode {}
+
+/// Error codes used by [StructureTower::repair](crate::StructureTower::repair).
+///
+/// Screeps API Docs: [StructureTower.repair](https://docs.screeps.com/api/#StructureTower.repair).
+///
+/// [Screeps Engine Source Code](https://github.com/screeps/engine/blob/97c9d12385fed686655c13b09f5f2457dd83a2bf/src/game/structures.js#L806)
+#[derive(
+    Debug, PartialEq, Eq, Clone, Copy, Hash, FromPrimitive, Deserialize_repr, Serialize_repr,
+)]
+#[repr(i8)]
+pub enum TowerRepairErrorCode {
+    NotOwner = -1,
+    NotEnoughEnergy = -6,
+    InvalidTarget = -7,
+    RclNotEnough = -14,
+}
+
+impl FromReturnCode for TowerRepairErrorCode {
+    type Error = Self;
+
+    fn result_from_i8(val: i8) -> Result<(), Self::Error> {
+        let maybe_result = Self::try_result_from_i8(val);
+        #[cfg(feature="unsafe-return-conversion")]
+        unsafe {
+            maybe_result.unwrap_unchecked()
+        }
+        #[cfg(not(feature="unsafe-return-conversion"))]
+        maybe_result.unwrap()
+    }
+
+    fn try_result_from_i8(val: i8) -> Option<Result<(), Self::Error>> {
+        match val {
+            0 => Some(Ok(())),
+            -1 => Some(Err(TowerRepairErrorCode::NotOwner)),
+            -6 => Some(Err(TowerRepairErrorCode::NotEnoughEnergy)),
+            -7 => Some(Err(TowerRepairErrorCode::InvalidTarget)),
+            -14 => Some(Err(TowerRepairErrorCode::RclNotEnough)),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for TowerRepairErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg: &'static str = match self {
+            TowerRepairErrorCode::NotOwner => "you are not the owner of this structure",
+            TowerRepairErrorCode::NotEnoughEnergy => "the tower does not have enough energy",
+            TowerRepairErrorCode::InvalidTarget => "the target is not a valid repairable object",
+            TowerRepairErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+        };
+
+        write!(f, "{}", msg)
+    }
+}
+
+impl Error for TowerRepairErrorCode {}

--- a/src/enums/action_error_codes/structuretower_error_codes.rs
+++ b/src/enums/action_error_codes/structuretower_error_codes.rs
@@ -71,9 +71,7 @@ impl From<TowerAttackErrorCode> for ErrorCode {
         // Safety: TowerAttackErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -143,9 +141,7 @@ impl From<TowerHealErrorCode> for ErrorCode {
         // Safety: TowerHealErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }
 
@@ -215,8 +211,6 @@ impl From<TowerRepairErrorCode> for ErrorCode {
         // Safety: TowerRepairErrorCode discriminants are always error code values, and
         // thus the Result returned here will always be an `Err` variant, so we can
         // always extract the error without panicking
-        Self::result_from_i8(value as i8)
-            .unwrap_err()
-            .expect("expect enum discriminant to be an error code")
+        Self::result_from_i8(value as i8).unwrap_err()
     }
 }

--- a/src/enums/action_error_codes/structuretower_error_codes.rs
+++ b/src/enums/action_error_codes/structuretower_error_codes.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::error::Error;
+use std::{error::Error, fmt};
 
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
@@ -28,11 +27,11 @@ impl FromReturnCode for TowerAttackErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -54,7 +53,9 @@ impl fmt::Display for TowerAttackErrorCode {
             TowerAttackErrorCode::NotOwner => "you are not the owner of this structure",
             TowerAttackErrorCode::NotEnoughEnergy => "the tower does not have enough energy",
             TowerAttackErrorCode::InvalidTarget => "the target is not a valid attackable object",
-            TowerAttackErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            TowerAttackErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)
@@ -84,11 +85,11 @@ impl FromReturnCode for TowerHealErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -110,7 +111,9 @@ impl fmt::Display for TowerHealErrorCode {
             TowerHealErrorCode::NotOwner => "you are not the owner of this structure",
             TowerHealErrorCode::NotEnoughEnergy => "the tower does not have enough energy",
             TowerHealErrorCode::InvalidTarget => "the target is not a valid creep object",
-            TowerHealErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            TowerHealErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)
@@ -140,11 +143,11 @@ impl FromReturnCode for TowerRepairErrorCode {
 
     fn result_from_i8(val: i8) -> Result<(), Self::Error> {
         let maybe_result = Self::try_result_from_i8(val);
-        #[cfg(feature="unsafe-return-conversion")]
+        #[cfg(feature = "unsafe-return-conversion")]
         unsafe {
             maybe_result.unwrap_unchecked()
         }
-        #[cfg(not(feature="unsafe-return-conversion"))]
+        #[cfg(not(feature = "unsafe-return-conversion"))]
         maybe_result.unwrap()
     }
 
@@ -166,7 +169,9 @@ impl fmt::Display for TowerRepairErrorCode {
             TowerRepairErrorCode::NotOwner => "you are not the owner of this structure",
             TowerRepairErrorCode::NotEnoughEnergy => "the tower does not have enough energy",
             TowerRepairErrorCode::InvalidTarget => "the target is not a valid repairable object",
-            TowerRepairErrorCode::RclNotEnough => "room controller level insufficient to use this structure",
+            TowerRepairErrorCode::RclNotEnough => {
+                "room controller level insufficient to use this structure"
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -4,7 +4,10 @@
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "mmo")]
-use crate::{constants::ErrorCode, prelude::*};
+use crate::{
+    enums::action_error_codes::game::cpu::*,
+    prelude::*,
+};
 #[cfg(feature = "mmo")]
 use js_sys::{JsString, Object};
 
@@ -137,8 +140,8 @@ pub fn halt() {
 ///
 /// [`CPU_SET_SHARD_LIMITS_COOLDOWN`]: crate::constants::CPU_SET_SHARD_LIMITS_COOLDOWN
 #[cfg(feature = "mmo")]
-pub fn set_shard_limits(limits: &Object) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(Cpu::set_shard_limits(limits))
+pub fn set_shard_limits(limits: &Object) -> Result<(), SetShardLimitsErrorCode> {
+    SetShardLimitsErrorCode::result_from_i8(Cpu::set_shard_limits(limits))
 }
 
 /// Consume a [`CpuUnlock`] to unlock your full CPU for 24 hours.
@@ -147,8 +150,8 @@ pub fn set_shard_limits(limits: &Object) -> Result<(), ErrorCode> {
 ///
 /// [`CpuUnlock`]: crate::constants::IntershardResourceType::CpuUnlock
 #[cfg(feature = "mmo")]
-pub fn unlock() -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(Cpu::unlock())
+pub fn unlock() -> Result<(), UnlockErrorCode> {
+    UnlockErrorCode::result_from_i8(Cpu::unlock())
 }
 
 /// Generate a [`Pixel`], consuming [`PIXEL_CPU_COST`] CPU from your bucket.
@@ -158,8 +161,8 @@ pub fn unlock() -> Result<(), ErrorCode> {
 /// [`Pixel`]: crate::constants::IntershardResourceType::Pixel
 /// [`PIXEL_CPU_COST`]: crate::constants::PIXEL_CPU_COST
 #[cfg(feature = "mmo")]
-pub fn generate_pixel() -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(Cpu::generate_pixel())
+pub fn generate_pixel() -> Result<(), GeneratePixelErrorCode> {
+    GeneratePixelErrorCode::result_from_i8(Cpu::generate_pixel())
 }
 
 #[wasm_bindgen]

--- a/src/game/cpu.rs
+++ b/src/game/cpu.rs
@@ -4,10 +4,7 @@
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "mmo")]
-use crate::{
-    enums::action_error_codes::game::cpu::*,
-    prelude::*,
-};
+use crate::{enums::action_error_codes::game::cpu::*, prelude::*};
 #[cfg(feature = "mmo")]
 use js_sys::{JsString, Object};
 

--- a/src/game/map.rs
+++ b/src/game/map.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{Direction, ErrorCode, ExitDirection},
+    constants::{Direction, ExitDirection},
+    enums::action_error_codes::game::map::*,
     local::RoomName,
     objects::RoomTerrain,
     prelude::*,
@@ -277,7 +278,7 @@ pub fn find_route<F>(
     from: RoomName,
     to: RoomName,
     options: Option<FindRouteOptions<F>>,
-) -> Result<Vec<RouteStep>, ErrorCode>
+) -> Result<Vec<RouteStep>, FindRouteErrorCode>
 where
     F: FnMut(RoomName, RoomName) -> f64,
 {
@@ -302,7 +303,7 @@ where
     } else {
         // SAFETY: can never be a 0 return from the find_route API function
         Err(unsafe {
-            ErrorCode::try_result_from_jsvalue(&result)
+            FindRouteErrorCode::try_result_from_jsvalue(&result)
                 .expect("expected return code for pathing failure")
                 .unwrap_err_unchecked()
         })
@@ -318,7 +319,7 @@ pub fn find_exit<F>(
     from: RoomName,
     to: RoomName,
     options: Option<FindRouteOptions<F>>,
-) -> Result<ExitDirection, ErrorCode>
+) -> Result<ExitDirection, FindExitErrorCode>
 where
     F: FnMut(RoomName, RoomName) -> f64,
 {
@@ -336,6 +337,6 @@ where
     } else {
         // SAFETY: can never be an `Ok()` return from `result_from_i8` because
         // non-negative values are handled by the first branch above
-        Err(unsafe { ErrorCode::result_from_i8(result).unwrap_err_unchecked() })
+        Err(unsafe { FindExitErrorCode::result_from_i8(result).unwrap_err_unchecked() })
     }
 }

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -5,7 +5,8 @@ use js_sys::{Array, JsString, Object};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ErrorCode, MarketResourceType, OrderType, ResourceType},
+    constants::{MarketResourceType, OrderType, ResourceType},
+    enums::action_error_codes::game::market::*,
     local::{LodashFilter, RoomName},
     prelude::*,
 };
@@ -114,8 +115,8 @@ pub fn calc_transaction_cost(amount: u32, room_1: &JsString, room_2: &JsString) 
 /// associated fees.
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.cancelOrder)
-pub fn cancel_order(order_id: &JsString) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(Market::cancel_order(order_id))
+pub fn cancel_order(order_id: &JsString) -> Result<(), MarketCancelOrderErrorCode> {
+    MarketCancelOrderErrorCode::result_from_i8(Market::cancel_order(order_id))
 }
 
 /// Change the price of an existing order. If new_price is greater than old
@@ -125,16 +126,16 @@ pub fn cancel_order(order_id: &JsString) -> Result<(), ErrorCode> {
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.changeOrderPrice)
 ///
 /// [`MARKET_FEE`]: crate::constants::MARKET_FEE
-pub fn change_order_price(order_id: &JsString, new_price: f64) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(Market::change_order_price(order_id, new_price))
+pub fn change_order_price(order_id: &JsString, new_price: f64) -> Result<(), ChangeOrderPriceErrorCode> {
+    ChangeOrderPriceErrorCode::result_from_i8(Market::change_order_price(order_id, new_price))
 }
 
 // todo type to serialize call options into
 /// Create a new order on the market.
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.createOrder)
-pub fn create_order(order_parameters: &Object) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(Market::create_order(order_parameters))
+pub fn create_order(order_parameters: &Object) -> Result<(), CreateOrderErrorCode> {
+    CreateOrderErrorCode::result_from_i8(Market::create_order(order_parameters))
 }
 
 /// Execute a trade on an order on the market. Name of a room with a
@@ -146,8 +147,8 @@ pub fn deal(
     order_id: &JsString,
     amount: u32,
     room_name: Option<RoomName>,
-) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(match room_name {
+) -> Result<(), DealErrorCode> {
+    DealErrorCode::result_from_i8(match room_name {
         Some(r) => Market::deal(order_id, amount, Some(&r.into())),
         None => Market::deal(order_id, amount, None),
     })
@@ -157,8 +158,8 @@ pub fn deal(
 /// requesting more of the resource and incurring additional fees.
 ///
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.extendOrder)
-pub fn extend_order(order_id: &JsString, add_amount: u32) -> Result<(), ErrorCode> {
-    ErrorCode::result_from_i8(Market::extend_order(order_id, add_amount))
+pub fn extend_order(order_id: &JsString, add_amount: u32) -> Result<(), ExtendOrderErrorCode> {
+    ExtendOrderErrorCode::result_from_i8(Market::extend_order(order_id, add_amount))
 }
 
 /// Get all [`Order`]s on the market, with an optional

--- a/src/game/market.rs
+++ b/src/game/market.rs
@@ -126,7 +126,10 @@ pub fn cancel_order(order_id: &JsString) -> Result<(), MarketCancelOrderErrorCod
 /// [Screeps documentation](https://docs.screeps.com/api/#Game.market.changeOrderPrice)
 ///
 /// [`MARKET_FEE`]: crate::constants::MARKET_FEE
-pub fn change_order_price(order_id: &JsString, new_price: f64) -> Result<(), ChangeOrderPriceErrorCode> {
+pub fn change_order_price(
+    order_id: &JsString,
+    new_price: f64,
+) -> Result<(), ChangeOrderPriceErrorCode> {
     ChangeOrderPriceErrorCode::result_from_i8(Market::change_order_price(order_id, new_price))
 }
 

--- a/src/local/object_id/raw.rs
+++ b/src/local/object_id/raw.rs
@@ -122,7 +122,7 @@ impl FromStr for RawObjectId {
             return Err(RawObjectIdParseError::value_too_large(u128_id));
         }
 
-        Ok(Self::from(u128_id << 32 | pad_length))
+        Ok(Self::from((u128_id << 32) | pad_length))
     }
 }
 

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -284,7 +284,7 @@ impl Position {
 
     #[inline]
     pub fn from_packed(packed: u32) -> Self {
-        let x = packed >> 8 & 0xFF;
+        let x = (packed >> 8) & 0xFF;
         let y = packed & 0xFF;
         assert!(x < ROOM_SIZE as u32, "out of bounds x: {x}");
         assert!(y < ROOM_SIZE as u32, "out of bounds y: {y}");
@@ -307,7 +307,7 @@ impl Position {
     #[inline]
     pub fn x(self) -> RoomCoordinate {
         // SAFETY: packed always contains a valid x coordinate
-        unsafe { RoomCoordinate::unchecked_new((self.packed >> 8 & 0xFF) as u8) }
+        unsafe { RoomCoordinate::unchecked_new(((self.packed >> 8) & 0xFF) as u8) }
     }
 
     /// Gets this position's in-room y coordinate.
@@ -322,7 +322,7 @@ impl Position {
     pub fn xy(self) -> RoomXY {
         // SAFETY: packed always contains a valid pair
         unsafe {
-            RoomXY::unchecked_new((self.packed >> 8 & 0xFF) as u8, (self.packed & 0xFF) as u8)
+            RoomXY::unchecked_new(((self.packed >> 8) & 0xFF) as u8, (self.packed & 0xFF) as u8)
         }
     }
 

--- a/src/local/position.rs
+++ b/src/local/position.rs
@@ -322,7 +322,10 @@ impl Position {
     pub fn xy(self) -> RoomXY {
         // SAFETY: packed always contains a valid pair
         unsafe {
-            RoomXY::unchecked_new(((self.packed >> 8) & 0xFF) as u8, (self.packed & 0xFF) as u8)
+            RoomXY::unchecked_new(
+                ((self.packed >> 8) & 0xFF) as u8,
+                (self.packed & 0xFF) as u8,
+            )
         }
     }
 

--- a/src/local/position/game_methods.rs
+++ b/src/local/position/game_methods.rs
@@ -7,6 +7,10 @@ use crate::{
         look::{LookConstant, LookResult},
         Color, ErrorCode, FindConstant, StructureType,
     },
+    enums::action_error_codes::{
+        RoomPositionCreateConstructionSiteErrorCode,
+        RoomPositionCreateFlagErrorCode,
+    },
     local::{RoomCoordinate, RoomName},
     objects::{CostMatrix, FindPathOptions, Path, RoomPosition},
     pathfinder::RoomCostResult,
@@ -28,7 +32,7 @@ impl Position {
         self,
         ty: StructureType,
         name: Option<&JsString>,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), RoomPositionCreateConstructionSiteErrorCode> {
         RoomPosition::from(self).create_construction_site(ty, name)
     }
 
@@ -44,7 +48,7 @@ impl Position {
         name: Option<&JsString>,
         color: Option<Color>,
         secondary_color: Option<Color>,
-    ) -> Result<JsString, ErrorCode> {
+    ) -> Result<JsString, RoomPositionCreateFlagErrorCode> {
         RoomPosition::from(self).create_flag(name, color, secondary_color)
     }
 

--- a/src/local/position/game_methods.rs
+++ b/src/local/position/game_methods.rs
@@ -8,8 +8,7 @@ use crate::{
         Color, ErrorCode, FindConstant, StructureType,
     },
     enums::action_error_codes::{
-        RoomPositionCreateConstructionSiteErrorCode,
-        RoomPositionCreateFlagErrorCode,
+        RoomPositionCreateConstructionSiteErrorCode, RoomPositionCreateFlagErrorCode,
     },
     local::{RoomCoordinate, RoomName},
     objects::{CostMatrix, FindPathOptions, Path, RoomPosition},

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ErrorCode, StructureType},
+    constants::StructureType,
     enums::action_error_codes::construction_site::*,
     objects::{Owner, RoomObject},
     prelude::*,

--- a/src/objects/impls/construction_site.rs
+++ b/src/objects/impls/construction_site.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{ErrorCode, StructureType},
+    enums::action_error_codes::construction_site::*,
     objects::{Owner, RoomObject},
     prelude::*,
 };
@@ -80,8 +81,8 @@ impl ConstructionSite {
     /// Remove the [`ConstructionSite`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#ConstructionSite.remove)
-    pub fn remove(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.remove_internal())
+    pub fn remove(&self) -> Result<(), ConstructionSiteRemoveErrorCode> {
+        ConstructionSiteRemoveErrorCode::result_from_i8(self.remove_internal())
     }
 }
 

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -3,6 +3,10 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{Direction, ErrorCode, Part, ResourceType},
+    enums::action_error_codes::{
+        DropErrorCode, NotifyWhenAttackedErrorCode, PickupErrorCode, SayErrorCode,
+        SuicideErrorCode, TransferErrorCode, WithdrawErrorCode,
+    },
     objects::{
         ConstructionSite, Owner, Resource, RoomObject, Store, Structure, StructureController,
     },
@@ -335,8 +339,8 @@ impl Creep {
     /// Drop a resource on the ground from the creep's [`Store`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.drop)
-    pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.drop_internal(ty, amount))
+    pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), DropErrorCode> {
+        DropErrorCode::result_from_i8(self.drop_internal(ty, amount))
     }
 
     /// Consume [`ResourceType::Ghodium`] (in the amount of [`SAFE_MODE_COST`])
@@ -409,16 +413,16 @@ impl Creep {
     /// Whether to send an email notification when this creep is attacked.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.notifyWhenAttacked)
-    pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
+    pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), NotifyWhenAttackedErrorCode> {
+        NotifyWhenAttackedErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
     }
 
     /// Pick up a [`Resource`] in melee range (or at the same position as the
     /// creep).
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.pickup)
-    pub fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.pickup_internal(target))
+    pub fn pickup(&self, target: &Resource) -> Result<(), PickupErrorCode> {
+        PickupErrorCode::result_from_i8(self.pickup_internal(target))
     }
 
     /// Help another creep to move by pulling, if the second creep accepts.
@@ -479,8 +483,8 @@ impl Creep {
     /// limit.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.say)
-    pub fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.say_internal(message, public))
+    pub fn say(&self, message: &str, public: bool) -> Result<(), SayErrorCode> {
+        SayErrorCode::result_from_i8(self.say_internal(message, public))
     }
 
     /// Add (or remove, using an empty string) a sign to a
@@ -500,8 +504,8 @@ impl Creep {
     /// Actions taken by the creep earlier in the tick may be cancelled.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.suicide)
-    pub fn suicide(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.suicide_internal())
+    pub fn suicide(&self) -> Result<(), SuicideErrorCode> {
+        SuicideErrorCode::result_from_i8(self.suicide_internal())
     }
 
     /// Upgrade a [`StructureController`] in range 3 using carried energy and
@@ -586,7 +590,7 @@ impl SharedCreepProperties for Creep {
         self.cancel_order(target)
     }
 
-    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
+    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), DropErrorCode> {
         self.drop(ty, amount)
     }
 
@@ -626,19 +630,19 @@ impl SharedCreepProperties for Creep {
         }
     }
 
-    fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
+    fn notify_when_attacked(&self, enabled: bool) -> Result<(), NotifyWhenAttackedErrorCode> {
         self.notify_when_attacked(enabled)
     }
 
-    fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
+    fn pickup(&self, target: &Resource) -> Result<(), PickupErrorCode> {
         self.pickup(target)
     }
 
-    fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
+    fn say(&self, message: &str, public: bool) -> Result<(), SayErrorCode> {
         self.say(message, public)
     }
 
-    fn suicide(&self) -> Result<(), ErrorCode> {
+    fn suicide(&self) -> Result<(), SuicideErrorCode> {
         self.suicide()
     }
 
@@ -647,11 +651,11 @@ impl SharedCreepProperties for Creep {
         target: &T,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    ) -> Result<(), TransferErrorCode>
     where
         T: Transferable + ?Sized,
     {
-        ErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
+        TransferErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
     }
 
     fn withdraw<T>(
@@ -659,11 +663,11 @@ impl SharedCreepProperties for Creep {
         target: &T,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    ) -> Result<(), WithdrawErrorCode>
     where
         T: Withdrawable + ?Sized,
     {
-        ErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
+        WithdrawErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
     }
 }
 

--- a/src/objects/impls/creep.rs
+++ b/src/objects/impls/creep.rs
@@ -2,12 +2,16 @@ use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{Direction, ErrorCode, Part, ResourceType},
+    constants::{Direction, Part, ResourceType},
     enums::action_error_codes::{
-        CreepCancelOrderErrorCode, CreepMoveByPathErrorCode, CreepMoveDirectionErrorCode,
-        CreepMovePulledByErrorCode, CreepMoveToErrorCode, DropErrorCode,
-        NotifyWhenAttackedErrorCode, PickupErrorCode, SayErrorCode, SuicideErrorCode,
-        TransferErrorCode, WithdrawErrorCode,
+        AttackControllerErrorCode, BuildErrorCode, ClaimControllerErrorCode, CreepAttackErrorCode,
+        CreepCancelOrderErrorCode, CreepHealErrorCode, CreepMoveByPathErrorCode,
+        CreepMoveDirectionErrorCode, CreepMovePulledByErrorCode, CreepMoveToErrorCode,
+        CreepRepairErrorCode, DismantleErrorCode, DropErrorCode, GenerateSafeModeErrorCode,
+        HarvestErrorCode, NotifyWhenAttackedErrorCode, PickupErrorCode, PullErrorCode,
+        RangedAttackErrorCode, RangedHealErrorCode, RangedMassAttackErrorCode,
+        ReserveControllerErrorCode, SayErrorCode, SignControllerErrorCode, SuicideErrorCode,
+        TransferErrorCode, UpgradeControllerErrorCode, WithdrawErrorCode,
     },
     objects::{
         ConstructionSite, Owner, Resource, RoomObject, Store, Structure, StructureController,
@@ -19,6 +23,9 @@ use crate::{
 
 #[cfg(feature = "seasonal-season-5")]
 use crate::objects::Reactor;
+
+#[cfg(feature = "seasonal-season-5")]
+use crate::enums::action_error_codes::CreepClaimReactorErrorCode;
 
 #[wasm_bindgen]
 extern "C" {
@@ -271,27 +278,30 @@ impl Creep {
     /// Attack a target in melee range using a creep's attack parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.attack)
-    pub fn attack<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn attack<T>(&self, target: &T) -> Result<(), CreepAttackErrorCode>
     where
         T: ?Sized + Attackable,
     {
-        ErrorCode::result_from_i8(self.attack_internal(target.as_ref()))
+        CreepAttackErrorCode::result_from_i8(self.attack_internal(target.as_ref()))
     }
 
     /// Attack a [`StructureController`] in melee range using a creep's claim
     /// parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.attackController)
-    pub fn attack_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.attack_controller_internal(target))
+    pub fn attack_controller(
+        &self,
+        target: &StructureController,
+    ) -> Result<(), AttackControllerErrorCode> {
+        AttackControllerErrorCode::result_from_i8(self.attack_controller_internal(target))
     }
 
     /// Use a creep's work parts to consume carried energy, putting it toward
     /// progress in a [`ConstructionSite`] in range 3.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.build)
-    pub fn build(&self, target: &ConstructionSite) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.build_internal(target))
+    pub fn build(&self, target: &ConstructionSite) -> Result<(), BuildErrorCode> {
+        BuildErrorCode::result_from_i8(self.build_internal(target))
     }
 
     /// Cancel a successfully called creep function from earlier in the tick,
@@ -307,8 +317,11 @@ impl Creep {
     /// using a creep's claim parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.claimController)
-    pub fn claim_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.claim_controller_internal(target))
+    pub fn claim_controller(
+        &self,
+        target: &StructureController,
+    ) -> Result<(), ClaimControllerErrorCode> {
+        ClaimControllerErrorCode::result_from_i8(self.claim_controller_internal(target))
     }
 
     /// Claim a [`Reactor`] in melee range as your own using a creep's claim
@@ -316,8 +329,8 @@ impl Creep {
     ///
     /// [Screeps documentation](https://docs-season.screeps.com/api/#Creep.claimReactor)
     #[cfg(feature = "seasonal-season-5")]
-    pub fn claim_reactor(&self, target: &Reactor) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.claim_reactor_internal(target))
+    pub fn claim_reactor(&self, target: &Reactor) -> Result<(), CreepClaimReactorErrorCode> {
+        CreepClaimReactorErrorCode::result_from_i8(self.claim_reactor_internal(target))
     }
 
     /// Dismantle a [`Structure`] in melee range, removing [`DISMANTLE_POWER`]
@@ -331,11 +344,11 @@ impl Creep {
     ///
     /// [`DISMANTLE_POWER`]: crate::constants::DISMANTLE_POWER
     /// [`StructureType::construction_cost`]: crate::constants::StructureType::construction_cost
-    pub fn dismantle<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn dismantle<T>(&self, target: &T) -> Result<(), DismantleErrorCode>
     where
         T: ?Sized + Dismantleable,
     {
-        ErrorCode::result_from_i8(self.dismantle_internal(target.as_ref()))
+        DismantleErrorCode::result_from_i8(self.dismantle_internal(target.as_ref()))
     }
 
     /// Drop a resource on the ground from the creep's [`Store`].
@@ -352,8 +365,11 @@ impl Creep {
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.generateSafeMode)
     ///
     /// [`SAFE_MODE_COST`]: crate::constants::SAFE_MODE_COST
-    pub fn generate_safe_mode(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.generate_safe_mode_internal(target))
+    pub fn generate_safe_mode(
+        &self,
+        target: &StructureController,
+    ) -> Result<(), GenerateSafeModeErrorCode> {
+        GenerateSafeModeErrorCode::result_from_i8(self.generate_safe_mode_internal(target))
     }
 
     /// Get the number of parts of the given type the creep has in its body,
@@ -371,11 +387,11 @@ impl Creep {
     /// [`Source`]: crate::objects::Source
     /// [`Mineral`]: crate::objects::Mineral
     /// [`Deposit`]: crate::objects::Deposit
-    pub fn harvest<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn harvest<T>(&self, target: &T) -> Result<(), HarvestErrorCode>
     where
         T: ?Sized + Harvestable,
     {
-        ErrorCode::result_from_i8(self.harvest_internal(target.as_ref()))
+        HarvestErrorCode::result_from_i8(self.harvest_internal(target.as_ref()))
     }
 
     /// Heal a [`Creep`] or [`PowerCreep`] in melee range, including itself.
@@ -383,11 +399,11 @@ impl Creep {
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.heal)
     ///
     /// [`PowerCreep`]: crate::objects::PowerCreep
-    pub fn heal<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn heal<T>(&self, target: &T) -> Result<(), CreepHealErrorCode>
     where
         T: ?Sized + Healable,
     {
-        ErrorCode::result_from_i8(self.heal_internal(target.as_ref()))
+        CreepHealErrorCode::result_from_i8(self.heal_internal(target.as_ref()))
     }
 
     /// Move one square in the specified direction.
@@ -430,55 +446,58 @@ impl Creep {
     /// Help another creep to move by pulling, if the second creep accepts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.pull)
-    pub fn pull(&self, target: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.pull_internal(target))
+    pub fn pull(&self, target: &Creep) -> Result<(), PullErrorCode> {
+        PullErrorCode::result_from_i8(self.pull_internal(target))
     }
 
     /// Attack a target in range 3 using a creep's ranged attack parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedAttack)
-    pub fn ranged_attack<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn ranged_attack<T>(&self, target: &T) -> Result<(), RangedAttackErrorCode>
     where
         T: ?Sized + Attackable,
     {
-        ErrorCode::result_from_i8(self.ranged_attack_internal(target.as_ref()))
+        RangedAttackErrorCode::result_from_i8(self.ranged_attack_internal(target.as_ref()))
     }
 
     /// Heal a target in range 3 using a creep's heal parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedHeal)
-    pub fn ranged_heal<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn ranged_heal<T>(&self, target: &T) -> Result<(), RangedHealErrorCode>
     where
         T: ?Sized + Healable,
     {
-        ErrorCode::result_from_i8(self.ranged_heal_internal(target.as_ref()))
+        RangedHealErrorCode::result_from_i8(self.ranged_heal_internal(target.as_ref()))
     }
 
     /// Attack all enemy targets in range using a creep's ranged attack parts,
     /// with lower damage depending on range.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.rangedMassAttack)
-    pub fn ranged_mass_attack(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.ranged_mass_attack_internal())
+    pub fn ranged_mass_attack(&self) -> Result<(), RangedMassAttackErrorCode> {
+        RangedMassAttackErrorCode::result_from_i8(self.ranged_mass_attack_internal())
     }
 
     /// Repair a target in range 3 using carried energy and the creep's work
     /// parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.repair)
-    pub fn repair<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn repair<T>(&self, target: &T) -> Result<(), CreepRepairErrorCode>
     where
         T: ?Sized + Repairable,
     {
-        ErrorCode::result_from_i8(self.repair_internal(target.as_ref()))
+        CreepRepairErrorCode::result_from_i8(self.repair_internal(target.as_ref()))
     }
 
     /// Reserve an unowned [`StructureController`] in melee range using a
     /// creep's claim parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.reserveController)
-    pub fn reserve_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.reserve_controller_internal(target))
+    pub fn reserve_controller(
+        &self,
+        target: &StructureController,
+    ) -> Result<(), ReserveControllerErrorCode> {
+        ReserveControllerErrorCode::result_from_i8(self.reserve_controller_internal(target))
     }
 
     /// Display a string in a bubble above the creep next tick. 10 character
@@ -497,8 +516,8 @@ impl Creep {
         &self,
         target: &StructureController,
         text: &str,
-    ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.sign_controller_internal(target, text))
+    ) -> Result<(), SignControllerErrorCode> {
+        SignControllerErrorCode::result_from_i8(self.sign_controller_internal(target, text))
     }
 
     /// Immediately kill the creep.
@@ -514,8 +533,11 @@ impl Creep {
     /// the creep's work parts.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Creep.upgradeController)
-    pub fn upgrade_controller(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.upgrade_controller_internal(target))
+    pub fn upgrade_controller(
+        &self,
+        target: &StructureController,
+    ) -> Result<(), UpgradeControllerErrorCode> {
+        UpgradeControllerErrorCode::result_from_i8(self.upgrade_controller_internal(target))
     }
 
     /// Move the creep toward the specified goal, either a [`RoomPosition`] or

--- a/src/objects/impls/flag.rs
+++ b/src/objects/impls/flag.rs
@@ -72,7 +72,11 @@ impl Flag {
     /// Set the color (and optionally, the secondary color) of the flag.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Flag.setColor)
-    pub fn set_color(&self, color: Color, secondary_color: Option<Color>) -> Result<(), SetColorErrorCode> {
+    pub fn set_color(
+        &self,
+        color: Color,
+        secondary_color: Option<Color>,
+    ) -> Result<(), SetColorErrorCode> {
         SetColorErrorCode::result_from_i8(self.set_color_internal(color, secondary_color))
     }
 

--- a/src/objects/impls/flag.rs
+++ b/src/objects/impls/flag.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::Color,
+    enums::action_error_codes::flag::*,
     objects::{RoomObject, RoomPosition},
     prelude::*,
 };
@@ -50,23 +51,37 @@ extern "C" {
     #[wasm_bindgen(method, getter = name)]
     pub fn name_jsstring(this: &Flag) -> JsString;
 
+    #[wasm_bindgen(method, js_name = remove)]
+    fn remove_internal(this: &Flag) -> i8;
+
+    #[wasm_bindgen(method, js_name = setColor)]
+    fn set_color_internal(this: &Flag, color: Color, secondary_color: Option<Color>) -> i8;
+
+    #[wasm_bindgen(method, js_name = setPosition)]
+    fn set_position_internal(this: &Flag, pos: RoomPosition) -> i8;
+}
+
+impl Flag {
     /// Remove the flag.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Flag.remove)
-    #[wasm_bindgen(method)]
-    pub fn remove(this: &Flag);
+    pub fn remove(&self) -> Result<(), FlagRemoveErrorCode> {
+        FlagRemoveErrorCode::result_from_i8(self.remove_internal())
+    }
 
     /// Set the color (and optionally, the secondary color) of the flag.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Flag.setColor)
-    #[wasm_bindgen(method, js_name = setColor)]
-    pub fn set_color(this: &Flag, color: Color, secondary_color: Option<Color>);
+    pub fn set_color(&self, color: Color, secondary_color: Option<Color>) -> Result<(), SetColorErrorCode> {
+        SetColorErrorCode::result_from_i8(self.set_color_internal(color, secondary_color))
+    }
 
     /// Set the position of the flag
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Flag.setPosition)
-    #[wasm_bindgen(method, js_name = setPosition)]
-    pub fn set_position(this: &Flag, pos: RoomPosition);
+    pub fn set_position(&self, pos: RoomPosition) -> Result<(), SetPositionErrorCode> {
+        SetPositionErrorCode::result_from_i8(self.set_position_internal(pos))
+    }
 }
 
 impl JsCollectionFromValue for Flag {

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -4,12 +4,13 @@ use js_sys::{JsString, Object};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{Direction, ErrorCode, PowerCreepClass, PowerType, ResourceType},
+    constants::{Direction, PowerCreepClass, PowerType, ResourceType},
     enums::action_error_codes::{
-        DropErrorCode, NotifyWhenAttackedErrorCode, PickupErrorCode,
-        PowerCreepCancelOrderErrorCode, PowerCreepMoveByPathErrorCode,
-        PowerCreepMoveDirectionErrorCode, PowerCreepMoveToErrorCode, SayErrorCode,
-        SuicideErrorCode, TransferErrorCode, WithdrawErrorCode,
+        DeleteErrorCode, DropErrorCode, EnableRoomErrorCode, NotifyWhenAttackedErrorCode,
+        PickupErrorCode, PowerCreepCancelOrderErrorCode, PowerCreepCreateErrorCode,
+        PowerCreepMoveByPathErrorCode, PowerCreepMoveDirectionErrorCode, PowerCreepMoveToErrorCode,
+        RenameErrorCode, RenewErrorCode, SayErrorCode, SpawnErrorCode, SuicideErrorCode,
+        TransferErrorCode, UpgradeErrorCode, UsePowerErrorCode, WithdrawErrorCode,
     },
     local::RoomName,
     objects::{
@@ -138,8 +139,11 @@ impl PowerCreep {
     /// initially be spawned.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.create)
-    pub fn create(name: &JsString, class: PowerCreepClass) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(Self::create_internal(name, class))
+    pub fn create(
+        name: &JsString,
+        class: PowerCreepClass,
+    ) -> Result<(), PowerCreepCreateErrorCode> {
+        PowerCreepCreateErrorCode::result_from_i8(Self::create_internal(name, class))
     }
 
     /// Retrieve this power creep's [`PowerCreepClass`].
@@ -259,8 +263,8 @@ impl PowerCreep {
     /// melee range. You do not need to own the controller.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.enableRoom)
-    pub fn enable_room(&self, target: &StructureController) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.enable_room_internal(target))
+    pub fn enable_room(&self, target: &StructureController) -> Result<(), EnableRoomErrorCode> {
+        EnableRoomErrorCode::result_from_i8(self.enable_room_internal(target))
     }
 
     /// Move one square in the specified direction.
@@ -302,8 +306,8 @@ impl PowerCreep {
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.renew)
     ///
     /// [`StructurePowerBank`]: crate::objects::StructurePowerBank
-    pub fn renew(&self, target: &RoomObject) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.renew_internal(target))
+    pub fn renew(&self, target: &RoomObject) -> Result<(), RenewErrorCode> {
+        RenewErrorCode::result_from_i8(self.renew_internal(target))
     }
 
     /// Display a string in a bubble above the power creep next tick. 10
@@ -328,8 +332,8 @@ impl PowerCreep {
         &self,
         power: PowerType,
         target: Option<&RoomObject>,
-    ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.use_power_internal(power, target))
+    ) -> Result<(), UsePowerErrorCode> {
+        UsePowerErrorCode::result_from_i8(self.use_power_internal(power, target))
     }
 
     /// Move the power creep toward the specified goal, either a
@@ -602,30 +606,30 @@ impl AccountPowerCreep {
     /// cancelled with `true` for the cancel paramater.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.delete)
-    pub fn delete(&self, cancel: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.delete_internal(cancel))
+    pub fn delete(&self, cancel: bool) -> Result<(), DeleteErrorCode> {
+        DeleteErrorCode::result_from_i8(self.delete_internal(cancel))
     }
 
     /// Change the name of the power creep. Must not be spawned.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.rename)
-    pub fn rename(&self, name: &JsString) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.rename_internal(name))
+    pub fn rename(&self, name: &JsString) -> Result<(), RenameErrorCode> {
+        RenameErrorCode::result_from_i8(self.rename_internal(name))
     }
 
     /// Spawn the power creep at a [`StructurePowerSpawn`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.spawn)
-    pub fn spawn(&self, target: &StructurePowerSpawn) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.spawn_internal(target))
+    pub fn spawn(&self, target: &StructurePowerSpawn) -> Result<(), SpawnErrorCode> {
+        SpawnErrorCode::result_from_i8(self.spawn_internal(target))
     }
 
     /// Upgrade this power creep, consuming one available GPL and adding a new
     /// level to one of its powers.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.upgrade)
-    pub fn upgrade(&self, power: PowerType) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.upgrade_internal(power))
+    pub fn upgrade(&self, power: PowerType) -> Result<(), UpgradeErrorCode> {
+        UpgradeErrorCode::result_from_i8(self.upgrade_internal(power))
     }
 }
 

--- a/src/objects/impls/power_creep.rs
+++ b/src/objects/impls/power_creep.rs
@@ -5,6 +5,10 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{Direction, ErrorCode, PowerCreepClass, PowerType, ResourceType},
+    enums::action_error_codes::{
+        DropErrorCode, NotifyWhenAttackedErrorCode, PickupErrorCode, SayErrorCode,
+        SuicideErrorCode, TransferErrorCode, WithdrawErrorCode,
+    },
     local::RoomName,
     objects::{
         CostMatrix, MoveToOptions, Owner, Resource, RoomObject, RoomPosition, Store,
@@ -245,8 +249,8 @@ impl PowerCreep {
     /// Drop a resource on the ground from the power creep's [`Store`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.drop)
-    pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.drop_internal(ty, amount))
+    pub fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), DropErrorCode> {
+        DropErrorCode::result_from_i8(self.drop_internal(ty, amount))
     }
 
     /// Enable powers to be used in this room on a [`StructureController`] in
@@ -275,16 +279,16 @@ impl PowerCreep {
     /// Whether to send an email notification when this power creep is attacked.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.notifyWhenAttacked)
-    pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
+    pub fn notify_when_attacked(&self, enabled: bool) -> Result<(), NotifyWhenAttackedErrorCode> {
+        NotifyWhenAttackedErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
     }
 
     /// Pick up a [`Resource`] in melee range (or at the same position as the
     /// creep).
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.pickup)
-    pub fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.pickup_internal(target))
+    pub fn pickup(&self, target: &Resource) -> Result<(), PickupErrorCode> {
+        PickupErrorCode::result_from_i8(self.pickup_internal(target))
     }
 
     /// Renew the power creep's TTL using a [`StructurePowerSpawn`] or
@@ -301,15 +305,15 @@ impl PowerCreep {
     /// character limit.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.say)
-    pub fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.say_internal(message, public))
+    pub fn say(&self, message: &str, public: bool) -> Result<(), SayErrorCode> {
+        SayErrorCode::result_from_i8(self.say_internal(message, public))
     }
 
     /// Immediately kill the power creep.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#PowerCreep.suicide)
-    pub fn suicide(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.suicide_internal())
+    pub fn suicide(&self) -> Result<(), SuicideErrorCode> {
+        SuicideErrorCode::result_from_i8(self.suicide_internal())
     }
 
     /// Use one of the power creep's powers.
@@ -387,7 +391,7 @@ impl SharedCreepProperties for PowerCreep {
         self.cancel_order(target)
     }
 
-    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode> {
+    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), DropErrorCode> {
         self.drop(ty, amount)
     }
 
@@ -427,20 +431,20 @@ impl SharedCreepProperties for PowerCreep {
         }
     }
 
-    fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
+    fn notify_when_attacked(&self, enabled: bool) -> Result<(), NotifyWhenAttackedErrorCode> {
+        NotifyWhenAttackedErrorCode::result_from_i8(self.notify_when_attacked_internal(enabled))
     }
 
-    fn pickup(&self, target: &Resource) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.pickup_internal(target))
+    fn pickup(&self, target: &Resource) -> Result<(), PickupErrorCode> {
+        PickupErrorCode::result_from_i8(self.pickup_internal(target))
     }
 
-    fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.say_internal(message, public))
+    fn say(&self, message: &str, public: bool) -> Result<(), SayErrorCode> {
+        SayErrorCode::result_from_i8(self.say_internal(message, public))
     }
 
-    fn suicide(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.suicide_internal())
+    fn suicide(&self) -> Result<(), SuicideErrorCode> {
+        SuicideErrorCode::result_from_i8(self.suicide_internal())
     }
 
     fn transfer<T>(
@@ -448,11 +452,11 @@ impl SharedCreepProperties for PowerCreep {
         target: &T,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    ) -> Result<(), TransferErrorCode>
     where
         T: Transferable + ?Sized,
     {
-        ErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
+        TransferErrorCode::result_from_i8(self.transfer_internal(target.as_ref(), ty, amount))
     }
 
     fn withdraw<T>(
@@ -460,11 +464,11 @@ impl SharedCreepProperties for PowerCreep {
         target: &T,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    ) -> Result<(), WithdrawErrorCode>
     where
         T: Withdrawable + ?Sized,
     {
-        ErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
+        WithdrawErrorCode::result_from_i8(self.withdraw_internal(target.as_ref(), ty, amount))
     }
 }
 

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -11,8 +11,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{
-        find::*, look::*, Color, Direction, ExitDirection, PowerType, ResourceType,
-        StructureType,
+        find::*, look::*, Color, Direction, ExitDirection, PowerType, ResourceType, StructureType,
     },
     enums::action_error_codes::room::*,
     local::{LodashFilter, RoomName},

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -227,7 +227,9 @@ impl Room {
         ty: StructureType,
         name: Option<&JsString>,
     ) -> Result<(), RoomCreateConstructionSiteErrorCode> {
-        RoomCreateConstructionSiteErrorCode::result_from_i8(self.create_construction_site_internal(x, y, ty, name))
+        RoomCreateConstructionSiteErrorCode::result_from_i8(
+            self.create_construction_site_internal(x, y, ty, name),
+        )
     }
 
     /// Creates a [`Flag`] at given coordinates within this room. The name of
@@ -278,7 +280,8 @@ impl Room {
     pub fn find_exit_to(&self, room: RoomName) -> Result<ExitDirection, FindExitToErrorCode> {
         let result = self.find_exit_to_internal(&room.into());
         if result >= 0 {
-            Ok(ExitDirection::from_i8(result).expect("expect find exit return to be a valid exit constant"))
+            Ok(ExitDirection::from_i8(result)
+                .expect("expect find exit return to be a valid exit constant"))
         } else {
             // The exit direction results should have been caught by the other branch,
             // therefore this should always be an error and never actually panic

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -278,9 +278,11 @@ impl Room {
     pub fn find_exit_to(&self, room: RoomName) -> Result<ExitDirection, FindExitToErrorCode> {
         let result = self.find_exit_to_internal(&room.into());
         if result >= 0 {
-            Ok(ExitDirection::from_i8(result))
+            Ok(ExitDirection::from_i8(result).expect("expect find exit return to be a valid exit constant"))
         } else {
-            FindExitToErrorCode::result_from_i8(result)
+            // The exit direction results should have been caught by the other branch,
+            // therefore this should always be an error and never actually panic
+            Err(FindExitToErrorCode::result_from_i8(result).unwrap_err())
         }
     }
 

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{
-        find::*, look::*, Color, Direction, ErrorCode, ExitDirection, PowerType, ResourceType,
+        find::*, look::*, Color, Direction, ExitDirection, PowerType, ResourceType,
         StructureType,
     },
     enums::action_error_codes::room::*,

--- a/src/objects/impls/room.rs
+++ b/src/objects/impls/room.rs
@@ -14,6 +14,7 @@ use crate::{
         find::*, look::*, Color, Direction, ErrorCode, ExitDirection, PowerType, ResourceType,
         StructureType,
     },
+    enums::action_error_codes::room::*,
     local::{LodashFilter, RoomName},
     objects::*,
     pathfinder::RoomCostResult,
@@ -106,7 +107,7 @@ extern "C" {
     fn find_internal(this: &Room, ty: Find, options: Option<&FindOptions>) -> Array;
 
     #[wasm_bindgen(final, method, js_name = findExitTo)]
-    fn find_exit_to_internal(this: &Room, room: &JsString) -> ExitDirection;
+    fn find_exit_to_internal(this: &Room, room: &JsString) -> i8;
 
     #[wasm_bindgen(final, method, js_name = findPath)]
     fn find_path_internal(
@@ -225,8 +226,8 @@ impl Room {
         y: u8,
         ty: StructureType,
         name: Option<&JsString>,
-    ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.create_construction_site_internal(x, y, ty, name))
+    ) -> Result<(), RoomCreateConstructionSiteErrorCode> {
+        RoomCreateConstructionSiteErrorCode::result_from_i8(self.create_construction_site_internal(x, y, ty, name))
     }
 
     /// Creates a [`Flag`] at given coordinates within this room. The name of
@@ -240,12 +241,12 @@ impl Room {
         name: Option<&JsString>,
         color: Option<Color>,
         secondary_color: Option<Color>,
-    ) -> Result<JsString, ErrorCode> {
+    ) -> Result<JsString, RoomCreateFlagErrorCode> {
         let result = self.create_flag_internal(x, y, name, color, secondary_color);
         if result.is_string() {
             Ok(result.unchecked_into())
         } else {
-            Err(ErrorCode::from_f64(
+            Err(RoomCreateFlagErrorCode::from_f64(
                 result
                     .as_f64()
                     .expect("expected non-string flag return to be a number"),
@@ -274,8 +275,13 @@ impl Room {
     /// Find an exit from the current room which leads to a target room.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Room.findExitTo)
-    pub fn find_exit_to(&self, room: RoomName) -> ExitDirection {
-        self.find_exit_to_internal(&room.into())
+    pub fn find_exit_to(&self, room: RoomName) -> Result<ExitDirection, FindExitToErrorCode> {
+        let result = self.find_exit_to_internal(&room.into());
+        if result >= 0 {
+            Ok(ExitDirection::from_i8(result))
+        } else {
+            FindExitToErrorCode::result_from_i8(result)
+        }
     }
 
     /// Find a path within the room from one position to another.

--- a/src/objects/impls/room_position.rs
+++ b/src/objects/impls/room_position.rs
@@ -228,9 +228,7 @@ impl RoomPosition {
         name: Option<&JsString>,
     ) -> Result<(), RoomPositionCreateConstructionSiteErrorCode> {
         match Self::create_construction_site_internal(self, ty, name) {
-            Ok(result) => {
-                RoomPositionCreateConstructionSiteErrorCode::result_from_i8(result)
-            },
+            Ok(result) => RoomPositionCreateConstructionSiteErrorCode::result_from_i8(result),
             Err(_) => {
                 // js code threw an exception; this happens when the room is not visible
                 Err(RoomPositionCreateConstructionSiteErrorCode::NotInRange)

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -80,8 +80,13 @@ impl Structure {
     /// attacked.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure.notifyWhenAttacked)
-    pub fn notify_when_attacked(&self, val: bool) -> Result<(), StructureNotifyWhenAttackedErrorCode> {
-        StructureNotifyWhenAttackedErrorCode::result_from_i8(self.notify_when_attacked_internal(val))
+    pub fn notify_when_attacked(
+        &self,
+        val: bool,
+    ) -> Result<(), StructureNotifyWhenAttackedErrorCode> {
+        StructureNotifyWhenAttackedErrorCode::result_from_i8(
+            self.notify_when_attacked_internal(val),
+        )
     }
 }
 

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -2,9 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::StructureType,
-    enums::action_error_codes::structure::*,
-    objects::RoomObject,
+    constants::StructureType, enums::action_error_codes::structure::*, objects::RoomObject,
     prelude::*,
 };
 

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{ErrorCode, StructureType},
+    enums::action_error_codes::structure::*,
     objects::RoomObject,
     prelude::*,
 };
@@ -45,12 +46,8 @@ extern "C" {
     #[wasm_bindgen(method, js_name = isActive)]
     pub fn is_active(this: &Structure) -> bool;
 
-    /// Set whether a notification email should be sent when the structure is
-    /// attacked.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#Structure.notifyWhenAttacked)
     #[wasm_bindgen(method, js_name = notifyWhenAttacked)]
-    pub fn notify_when_attacked(this: &Structure, val: bool) -> i8;
+    fn notify_when_attacked_internal(this: &Structure, val: bool) -> i8;
 }
 
 impl Structure {
@@ -75,8 +72,16 @@ impl Structure {
     /// Destroy the structure, if possible.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#Structure.destroy)
-    pub fn destroy(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.destroy_internal())
+    pub fn destroy(&self) -> Result<(), DestroyErrorCode> {
+        DestroyErrorCode::result_from_i8(self.destroy_internal())
+    }
+
+    /// Set whether a notification email should be sent when the structure is
+    /// attacked.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#Structure.notifyWhenAttacked)
+    pub fn notify_when_attacked(&self, val: bool) -> Result<(), StructureNotifyWhenAttackedErrorCode> {
+        StructureNotifyWhenAttackedErrorCode::result_from_i8(self.notify_when_attacked_internal(val))
     }
 }
 
@@ -110,7 +115,7 @@ where
         Structure::structure_type(self.as_ref())
     }
 
-    fn destroy(&self) -> Result<(), ErrorCode> {
+    fn destroy(&self) -> Result<(), DestroyErrorCode> {
         Structure::destroy(self.as_ref())
     }
 
@@ -118,7 +123,7 @@ where
         Structure::is_active(self.as_ref())
     }
 
-    fn notify_when_attacked(&self, val: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(Structure::notify_when_attacked(self.as_ref(), val))
+    fn notify_when_attacked(&self, val: bool) -> Result<(), StructureNotifyWhenAttackedErrorCode> {
+        Structure::notify_when_attacked(self.as_ref(), val)
     }
 }

--- a/src/objects/impls/structure.rs
+++ b/src/objects/impls/structure.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ErrorCode, StructureType},
+    constants::StructureType,
     enums::action_error_codes::structure::*,
     objects::RoomObject,
     prelude::*,

--- a/src/objects/impls/structure_controller.rs
+++ b/src/objects/impls/structure_controller.rs
@@ -2,7 +2,7 @@ use js_sys::Date;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ErrorCode,
+    enums::action_error_codes::structure_controller::*,
     objects::{OwnedStructure, RoomObject, Structure},
     prelude::*,
 };
@@ -110,15 +110,15 @@ impl StructureController {
     /// room for 20,000 ticks
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.activateSafeMode)
-    pub fn activate_safe_mode(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.activate_safe_mode_internal())
+    pub fn activate_safe_mode(&self) -> Result<(), ActivateSafeModeErrorCode> {
+        ActivateSafeModeErrorCode::result_from_i8(self.activate_safe_mode_internal())
     }
 
     /// Relinquish ownership of the controller and its room.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureController.unclaim)
-    pub fn unclaim(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.unclaim_internal())
+    pub fn unclaim(&self) -> Result<(), UnclaimErrorCode> {
+        UnclaimErrorCode::result_from_i8(self.unclaim_internal())
     }
 }
 

--- a/src/objects/impls/structure_factory.rs
+++ b/src/objects/impls/structure_factory.rs
@@ -1,7 +1,8 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ErrorCode, ResourceType},
+    constants::ResourceType,
+    enums::action_error_codes::structure_factory::*,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -38,16 +39,16 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     pub fn store(this: &StructureFactory) -> Store;
 
-    /// Produce a commodity in the factory.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#StructureFactory.produce)
     #[wasm_bindgen(method, js_name = produce)]
     fn produce_internal(this: &StructureFactory, ty: ResourceType) -> i8;
 }
 
 impl StructureFactory {
-    pub fn produce(&self, ty: ResourceType) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.produce_internal(ty))
+    /// Produce a commodity in the factory.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureFactory.produce)
+    pub fn produce(&self, ty: ResourceType) -> Result<(), ProduceErrorCode> {
+        ProduceErrorCode::result_from_i8(self.produce_internal(ty))
     }
 }
 

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -89,7 +89,11 @@ impl StructureLab {
     /// into a new compound in this lab.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.runReaction)
-    pub fn run_reaction(&self, lab1: &StructureLab, lab2: &StructureLab) -> Result<(), RunReactionErrorCode> {
+    pub fn run_reaction(
+        &self,
+        lab1: &StructureLab,
+        lab2: &StructureLab,
+    ) -> Result<(), RunReactionErrorCode> {
         RunReactionErrorCode::result_from_i8(self.run_reaction_internal(lab1, lab2))
     }
 

--- a/src/objects/impls/structure_lab.rs
+++ b/src/objects/impls/structure_lab.rs
@@ -1,7 +1,8 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ErrorCode, ResourceType},
+    constants::ResourceType,
+    enums::action_error_codes::structure_lab::*,
     objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -68,8 +69,8 @@ impl StructureLab {
         &self,
         creep: &Creep,
         body_part_count: Option<u32>,
-    ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.boost_creep_internal(creep, body_part_count))
+    ) -> Result<(), BoostCreepErrorCode> {
+        BoostCreepErrorCode::result_from_i8(self.boost_creep_internal(creep, body_part_count))
     }
 
     /// Reverse a reaction, splitting the compound in this [`StructureLab`] into
@@ -80,16 +81,16 @@ impl StructureLab {
         &self,
         lab1: &StructureLab,
         lab2: &StructureLab,
-    ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.reverse_reaction_internal(lab1, lab2))
+    ) -> Result<(), ReverseReactionErrorCode> {
+        ReverseReactionErrorCode::result_from_i8(self.reverse_reaction_internal(lab1, lab2))
     }
 
     /// Run a reaction, combining components from two other [`StructureLab`]s
     /// into a new compound in this lab.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.runReaction)
-    pub fn run_reaction(&self, lab1: &StructureLab, lab2: &StructureLab) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.run_reaction_internal(lab1, lab2))
+    pub fn run_reaction(&self, lab1: &StructureLab, lab2: &StructureLab) -> Result<(), RunReactionErrorCode> {
+        RunReactionErrorCode::result_from_i8(self.run_reaction_internal(lab1, lab2))
     }
 
     /// Unboost a [`Creep`], removing all boosts from its body and dropping
@@ -99,8 +100,8 @@ impl StructureLab {
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureLab.unboostCreep)
     ///
     /// [`LAB_UNBOOST_MINERAL`]: crate::constants::LAB_UNBOOST_MINERAL
-    pub fn unboost_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.unboost_creep_internal(creep))
+    pub fn unboost_creep(&self, creep: &Creep) -> Result<(), UnboostCreepErrorCode> {
+        UnboostCreepErrorCode::result_from_i8(self.unboost_creep_internal(creep))
     }
 }
 

--- a/src/objects/impls/structure_link.rs
+++ b/src/objects/impls/structure_link.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ErrorCode,
+    enums::action_error_codes::structure_link::*,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -51,8 +51,8 @@ impl StructureLink {
         &self,
         target: &StructureLink,
         amount: Option<u32>,
-    ) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.transfer_energy_internal(target, amount))
+    ) -> Result<(), TransferEnergyErrorCode> {
+        TransferEnergyErrorCode::result_from_i8(self.transfer_energy_internal(target, amount))
     }
 }
 

--- a/src/objects/impls/structure_nuker.rs
+++ b/src/objects/impls/structure_nuker.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ErrorCode,
+    enums::action_error_codes::structure_nuker::*,
     objects::{OwnedStructure, RoomObject, RoomPosition, Store, Structure},
     prelude::*,
 };
@@ -40,8 +40,8 @@ impl StructureNuker {
     /// Launch a nuke at a target [`RoomPosition`].
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureNuker.launchNuke)
-    pub fn launch_nuke(&self, target: &RoomPosition) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.launch_nuke_internal(target))
+    pub fn launch_nuke(&self, target: &RoomPosition) -> Result<(), LaunchNukeErrorCode> {
+        LaunchNukeErrorCode::result_from_i8(self.launch_nuke_internal(target))
     }
 }
 

--- a/src/objects/impls/structure_observer.rs
+++ b/src/objects/impls/structure_observer.rs
@@ -2,7 +2,7 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ErrorCode,
+    enums::action_error_codes::structure_observer::*,
     local::RoomName,
     objects::{OwnedStructure, RoomObject, Structure},
     prelude::*,
@@ -18,19 +18,19 @@ extern "C" {
     #[derive(Clone, Debug)]
     pub type StructureObserver;
 
-    /// Set the [`StructureObserver`] to provide vision of a target room next
-    /// tick.
-    ///
-    /// [Screeps documentation](https://docs.screeps.com/api/#StructureObserver.observeRoom)
     #[wasm_bindgen(method, js_name = observeRoom)]
     fn observe_room_internal(this: &StructureObserver, target: &JsString) -> i8;
 }
 
 impl StructureObserver {
-    pub fn observe_room(&self, target: RoomName) -> Result<(), ErrorCode> {
+    /// Set the [`StructureObserver`] to provide vision of a target room next
+    /// tick.
+    ///
+    /// [Screeps documentation](https://docs.screeps.com/api/#StructureObserver.observeRoom)
+    pub fn observe_room(&self, target: RoomName) -> Result<(), ObserveRoomErrorCode> {
         let target = target.into();
 
-        ErrorCode::result_from_i8(self.observe_room_internal(&target))
+        ObserveRoomErrorCode::result_from_i8(self.observe_room_internal(&target))
     }
 }
 

--- a/src/objects/impls/structure_power_spawn.rs
+++ b/src/objects/impls/structure_power_spawn.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ErrorCode,
+    enums::action_error_codes::structure_powerspawn::*,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -40,8 +40,8 @@ impl StructurePowerSpawn {
     /// [Screeps documentation](https://docs.screeps.com/api/#StructurePowerSpawn.processPower)
     ///
     /// [`POWER_SPAWN_ENERGY_RATIO`]: crate::constants::POWER_SPAWN_ENERGY_RATIO
-    pub fn process_power(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.process_power_internal())
+    pub fn process_power(&self) -> Result<(), ProcessPowerErrorCode> {
+        ProcessPowerErrorCode::result_from_i8(self.process_power_internal())
     }
 }
 

--- a/src/objects/impls/structure_rampart.rs
+++ b/src/objects/impls/structure_rampart.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ErrorCode,
+    enums::action_error_codes::structure_rampart::*,
     objects::{OwnedStructure, RoomObject, Structure},
     prelude::*,
 };
@@ -42,8 +42,8 @@ impl StructureRampart {
     /// walk on it.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureRampart.setPublic)
-    pub fn set_public(&self, public: bool) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.set_public_internal(public))
+    pub fn set_public(&self, public: bool) -> Result<(), SetPublicErrorCode> {
+        SetPublicErrorCode::result_from_i8(self.set_public_internal(public))
     }
 }
 

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -3,10 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{Direction, Part},
-    enums::action_error_codes::{
-        spawning::*,
-        structure_spawn::*,
-    },
+    enums::action_error_codes::{spawning::*, structure_spawn::*},
     objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -2,8 +2,11 @@ use js_sys::{Array, JsString, Object};
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{Direction, ErrorCode, Part},
-    enums::action_error_codes::spawning::*,
+    constants::{Direction, Part},
+    enums::action_error_codes::{
+        spawning::*,
+        structure_spawn::*,
+    },
     objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -79,10 +82,10 @@ impl StructureSpawn {
     /// about how to replace Memory and/or delete RawMemory._parsed
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.spawnCreep)
-    pub fn spawn_creep(&self, body: &[Part], name: &str) -> Result<(), ErrorCode> {
+    pub fn spawn_creep(&self, body: &[Part], name: &str) -> Result<(), SpawnCreepErrorCode> {
         let body = body.iter().cloned().map(JsValue::from).collect();
 
-        ErrorCode::result_from_i8(Self::spawn_creep_internal(self, &body, name, None))
+        SpawnCreepErrorCode::result_from_i8(Self::spawn_creep_internal(self, &body, name, None))
     }
 
     /// Create a new creep with the specified body part [`Array`], name
@@ -99,7 +102,7 @@ impl StructureSpawn {
         body: &[Part],
         name: &str,
         opts: &SpawnOptions,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), SpawnCreepErrorCode> {
         let body = body.iter().cloned().map(JsValue::from).collect();
 
         let js_opts = ObjectExt::unchecked_from_js(JsValue::from(Object::new()));
@@ -120,7 +123,7 @@ impl StructureSpawn {
             ObjectExt::set(&js_opts, "directions", array);
         }
 
-        ErrorCode::result_from_i8(Self::spawn_creep_internal(
+        SpawnCreepErrorCode::result_from_i8(Self::spawn_creep_internal(
             self,
             &body,
             name,
@@ -133,16 +136,16 @@ impl StructureSpawn {
     /// while spawning.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.recycleCreep)
-    pub fn recycle_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.recycle_creep_internal(creep))
+    pub fn recycle_creep(&self, creep: &Creep) -> Result<(), RecycleCreepErrorCode> {
+        RecycleCreepErrorCode::result_from_i8(self.recycle_creep_internal(creep))
     }
 
     /// Renew a [`Creep`] in melee range, removing all boosts adding to its TTL.
     /// Cannot be used while spawning.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.renewCreep)
-    pub fn renew_creep(&self, creep: &Creep) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.renew_creep_internal(creep))
+    pub fn renew_creep(&self, creep: &Creep) -> Result<(), RenewCreepErrorCode> {
+        RenewCreepErrorCode::result_from_i8(self.renew_creep_internal(creep))
     }
 }
 

--- a/src/objects/impls/structure_spawn.rs
+++ b/src/objects/impls/structure_spawn.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::{Direction, ErrorCode, Part},
+    enums::action_error_codes::spawning::*,
     objects::{Creep, OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -270,15 +271,15 @@ impl Spawning {
     /// Cancel spawning this creep, without refunding any energy.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.Spawning.cancel)
-    pub fn cancel(&self) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.cancel_internal())
+    pub fn cancel(&self) -> Result<(), CancelErrorCode> {
+        CancelErrorCode::result_from_i8(self.cancel_internal())
     }
 
     /// Change allowed directions for the creep to leave the spawn once it's
     /// ready.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureSpawn.Spawning.setDirections)
-    pub fn set_directions(&self, directions: &Array) -> Result<(), ErrorCode> {
-        ErrorCode::result_from_i8(self.set_directions_internal(directions))
+    pub fn set_directions(&self, directions: &Array) -> Result<(), SetDirectionsErrorCode> {
+        SetDirectionsErrorCode::result_from_i8(self.set_directions_internal(directions))
     }
 }

--- a/src/objects/impls/structure_terminal.rs
+++ b/src/objects/impls/structure_terminal.rs
@@ -2,7 +2,8 @@ use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::{ErrorCode, ResourceType},
+    constants::ResourceType,
+    enums::action_error_codes::structure_terminal::*,
     local::RoomName,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
@@ -52,11 +53,11 @@ impl StructureTerminal {
         amount: u32,
         destination: RoomName,
         description: Option<&str>,
-    ) -> Result<(), ErrorCode> {
+    ) -> Result<(), SendErrorCode> {
         let desination = destination.into();
         let description = description.map(JsString::from);
 
-        ErrorCode::result_from_i8(self.send_internal(
+        SendErrorCode::result_from_i8(self.send_internal(
             resource_type,
             amount,
             &desination,

--- a/src/objects/impls/structure_tower.rs
+++ b/src/objects/impls/structure_tower.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    constants::ErrorCode,
+    enums::action_error_codes::structure_tower::*,
     objects::{OwnedStructure, RoomObject, Store, Structure},
     prelude::*,
 };
@@ -41,11 +41,11 @@ impl StructureTower {
     ///
     /// [`Creep`]: crate::objects::Creep
     /// [`PowerCreep`]: crate::objects::PowerCreep
-    pub fn attack<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn attack<T>(&self, target: &T) -> Result<(), TowerAttackErrorCode>
     where
         T: ?Sized + Attackable,
     {
-        ErrorCode::result_from_i8(self.attack_internal(target.as_ref()))
+        TowerAttackErrorCode::result_from_i8(self.attack_internal(target.as_ref()))
     }
 
     /// Heal a [`Creep`] or [`PowerCreep`] in the room, adding hit points
@@ -55,22 +55,22 @@ impl StructureTower {
     ///
     /// [`Creep`]: crate::objects::Creep
     /// [`PowerCreep`]: crate::objects::PowerCreep
-    pub fn heal<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn heal<T>(&self, target: &T) -> Result<(), TowerHealErrorCode>
     where
         T: ?Sized + Healable,
     {
-        ErrorCode::result_from_i8(self.heal_internal(target.as_ref()))
+        TowerHealErrorCode::result_from_i8(self.heal_internal(target.as_ref()))
     }
 
     /// Repair a [`Structure`] in the room, adding hit points depending on
     /// range.
     ///
     /// [Screeps documentation](https://docs.screeps.com/api/#StructureTower.repair)
-    pub fn repair<T>(&self, target: &T) -> Result<(), ErrorCode>
+    pub fn repair<T>(&self, target: &T) -> Result<(), TowerRepairErrorCode>
     where
         T: ?Sized + Repairable,
     {
-        ErrorCode::result_from_i8(self.repair_internal(target.as_ref()))
+        TowerRepairErrorCode::result_from_i8(self.repair_internal(target.as_ref()))
     }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,11 @@ use wasm_bindgen::prelude::*;
 use crate::{
     constants::*,
     enums::{
-        action_error_codes::{DestroyErrorCode, StructureNotifyWhenAttackedErrorCode},
+        action_error_codes::{
+            DestroyErrorCode, DropErrorCode, NotifyWhenAttackedErrorCode, PickupErrorCode,
+            SayErrorCode, StructureNotifyWhenAttackedErrorCode, SuicideErrorCode,
+            TransferErrorCode, WithdrawErrorCode,
+        },
         *,
     },
     local::{ObjectId, Position, RawObjectId, RoomName, RoomXY},
@@ -233,7 +237,7 @@ pub trait SharedCreepProperties {
     fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode>;
 
     /// Drop a resource on the ground from the creep's [`Store`].
-    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), ErrorCode>;
+    fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), DropErrorCode>;
 
     /// Move one square in the specified direction.
     fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode>;
@@ -266,18 +270,18 @@ pub trait SharedCreepProperties {
         F: FnMut(RoomName, CostMatrix) -> SingleRoomCostResult;
 
     /// Whether to send an email notification when this creep is attacked.
-    fn notify_when_attacked(&self, enabled: bool) -> Result<(), ErrorCode>;
+    fn notify_when_attacked(&self, enabled: bool) -> Result<(), NotifyWhenAttackedErrorCode>;
 
     /// Pick up a [`Resource`] in melee range (or at the same position as the
     /// creep).
-    fn pickup(&self, target: &Resource) -> Result<(), ErrorCode>;
+    fn pickup(&self, target: &Resource) -> Result<(), PickupErrorCode>;
 
     /// Display a string in a bubble above the creep next tick. 10 character
     /// limit.
-    fn say(&self, message: &str, public: bool) -> Result<(), ErrorCode>;
+    fn say(&self, message: &str, public: bool) -> Result<(), SayErrorCode>;
 
     /// Immediately kill the creep.
-    fn suicide(&self) -> Result<(), ErrorCode>;
+    fn suicide(&self) -> Result<(), SuicideErrorCode>;
 
     /// Transfer a resource from the creep's store to [`Structure`],
     /// [`PowerCreep`], or another [`Creep`].
@@ -286,7 +290,7 @@ pub trait SharedCreepProperties {
         target: &T,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    ) -> Result<(), TransferErrorCode>
     where
         T: Transferable + ?Sized;
 
@@ -296,7 +300,7 @@ pub trait SharedCreepProperties {
         target: &T,
         ty: ResourceType,
         amount: Option<u32>,
-    ) -> Result<(), ErrorCode>
+    ) -> Result<(), WithdrawErrorCode>
     where
         T: Withdrawable + ?Sized;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -231,43 +231,8 @@ pub trait SharedCreepProperties {
     /// The number of ticks the creep has left to live.
     fn ticks_to_live(&self) -> Option<u32>;
 
-    /// Cancel an a successfully called creep function from earlier in the tick,
-    /// with a [`JsString`] that must contain the JS version of the function
-    /// name.
-    fn cancel_order(&self, target: &JsString) -> Result<(), ErrorCode>;
-
     /// Drop a resource on the ground from the creep's [`Store`].
     fn drop(&self, ty: ResourceType, amount: Option<u32>) -> Result<(), DropErrorCode>;
-
-    /// Move one square in the specified direction.
-    fn move_direction(&self, direction: Direction) -> Result<(), ErrorCode>;
-
-    /// Move the creep along a previously determined path returned from a
-    /// pathfinding function, in array or serialized string form.
-    fn move_by_path(&self, path: &JsValue) -> Result<(), ErrorCode>;
-
-    /// Move the creep toward the specified goal, either a [`RoomPosition`] or
-    /// [`RoomObject`]. Note that using this function will store data in
-    /// `Memory.creeps[creep_name]` and enable the default serialization
-    /// behavior of the `Memory` object, which may hamper attempts to directly
-    /// use `RawMemory`.
-    fn move_to<T>(&self, target: T) -> Result<(), ErrorCode>
-    where
-        T: HasPosition;
-
-    /// Move the creep toward the specified goal, either a [`RoomPosition`] or
-    /// [`RoomObject`]. Note that using this function will store data in
-    /// `Memory.creeps[creep_name]` and enable the default serialization
-    /// behavior of the `Memory` object, which may hamper attempts to directly
-    /// use `RawMemory`.
-    fn move_to_with_options<T, F>(
-        &self,
-        target: T,
-        options: Option<MoveToOptions<F>>,
-    ) -> Result<(), ErrorCode>
-    where
-        T: HasPosition,
-        F: FnMut(RoomName, CostMatrix) -> SingleRoomCostResult;
 
     /// Whether to send an email notification when this creep is attacked.
     fn notify_when_attacked(&self, enabled: bool) -> Result<(), NotifyWhenAttackedErrorCode>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,8 +9,10 @@ use wasm_bindgen::prelude::*;
 
 use crate::{
     constants::*,
-    enums::*,
-    enums::action_error_codes::{DestroyErrorCode, StructureNotifyWhenAttackedErrorCode},
+    enums::{
+        action_error_codes::{DestroyErrorCode, StructureNotifyWhenAttackedErrorCode},
+        *,
+    },
     local::{ObjectId, Position, RawObjectId, RoomName, RoomXY},
     objects::*,
     pathfinder::SingleRoomCostResult,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::prelude::*;
 use crate::{
     constants::*,
     enums::*,
+    enums::action_error_codes::{DestroyErrorCode, StructureNotifyWhenAttackedErrorCode},
     local::{ObjectId, Position, RawObjectId, RoomName, RoomXY},
     objects::*,
     pathfinder::SingleRoomCostResult,
@@ -302,11 +303,11 @@ pub trait SharedCreepProperties {
 pub trait StructureProperties {
     fn structure_type(&self) -> StructureType;
 
-    fn destroy(&self) -> Result<(), ErrorCode>;
+    fn destroy(&self) -> Result<(), DestroyErrorCode>;
 
     fn is_active(&self) -> bool;
 
-    fn notify_when_attacked(&self, val: bool) -> Result<(), ErrorCode>;
+    fn notify_when_attacked(&self, val: bool) -> Result<(), StructureNotifyWhenAttackedErrorCode>;
 }
 
 /// Trait for all wrappers over Screeps JavaScript objects which can be the

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -17,9 +17,8 @@ use crate::{
         },
         *,
     },
-    local::{ObjectId, Position, RawObjectId, RoomName, RoomXY},
+    local::{ObjectId, Position, RawObjectId, RoomXY},
     objects::*,
-    pathfinder::SingleRoomCostResult,
     prelude::*,
 };
 


### PR DESCRIPTION
This PR adds dedicated action return types for most of the official API methods, replacing the generic `ErrorCode` error type that most actions return.

This allows for cleaner code, because we can actually have exhaustive matches on return types that don't include values that will never be returned by the official API.

This update also includes a few linter and formatter updates, as suggested by CI.